### PR TITLE
Pitch shift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,21 @@ pip3 install pybind11
 pip3 install .
 ```
 
+To compile a debug build of `pedalboard` that allows using a debugger (like gdb or lldb), use the following command to build the package locally and install a symbolic link for debugging:
+```shell
+python3 setup.py build develop
+```
+
+Then, you can `import pedalboard` from Python (or run the tests with `tox`) to test out your local changes.
+
+To compile a debug build _faster_ by using [Ccache](https://ccache.dev/) (`brew install ccache` on macOS, similar elsewhere):
+```shell
+rm -rf build && CC="ccache clang" CXX="ccache clang++" DEBUG=1 python3 setup.py build -j8 develop
+```
+
+By default, [all `.cpp` files in the `pedalboard` directory (or subdirectories)](https://github.com/spotify/pedalboard/blob/master/setup.py#L129)
+will be automatically compiled by `setup.py`.
+
 ## Workflow
 
 We follow the [GitHub Flow Workflow](https://guides.github.com/introduction/flow/):

--- a/examples/pitch_shift.py
+++ b/examples/pitch_shift.py
@@ -62,7 +62,6 @@ def main():
         default=None,
     )
 
-    # Instantiate the Reverb object early so we can read its defaults for the argparser --help:
     plugin = PitchShift()
 
     parser.add_argument("--pitch_scale", type=float, default=plugin.pitch_scale)

--- a/examples/pitch_shift_file.py
+++ b/examples/pitch_shift_file.py
@@ -1,0 +1,126 @@
+"""
+Add reverb to an audio file using Pedalboard.
+
+The audio file is read in chunks, using nearly no memory.
+This should be one of the fastest possible ways to add reverb to a file
+while also using as little memory as possible.
+
+On my laptop, this runs about 58x faster than real-time
+(i.e.: processes a 60-second file in ~1 second.)
+
+Requirements: `pip install PySoundFile tqdm pedalboard`
+Note that PySoundFile requires a working libsndfile installation.
+"""
+
+import argparse
+import os
+import sys
+import warnings
+
+import numpy as np
+import soundfile as sf
+from tqdm import tqdm
+from tqdm.std import TqdmWarning
+
+from pedalboard import PitchShift
+
+BUFFER_SIZE_SAMPLES = 1024 * 16
+NOISE_FLOOR = 1e-4
+
+
+def get_num_frames(f: sf.SoundFile) -> int:
+    # On some platforms and formats, f.frames == -1L.
+    # Check for this bug and work around it:
+    if f.frames > 2 ** 32:
+        f.seek(0)
+        last_position = f.tell()
+        while True:
+            # Seek through the file in chunks, returning
+            # if the file pointer stops advancing.
+            f.seek(1024 * 1024 * 1024, sf.SEEK_CUR)
+            new_position = f.tell()
+            if new_position == last_position:
+                f.seek(0)
+                return new_position
+            else:
+                last_position = new_position
+    else:
+        return f.frames
+
+
+def main():
+    warnings.filterwarnings("ignore", category=TqdmWarning)
+
+    parser = argparse.ArgumentParser(description="Add reverb to an audio file.")
+    parser.add_argument("input_file", help="The input file to add reverb to.")
+    parser.add_argument(
+        "--output-file",
+        help=(
+            "The name of the output file to write to. If not provided, {input_file}.shifted.wav will"
+            " be used."
+        ),
+        default=None,
+    )
+
+    # Instantiate the Reverb object early so we can read its defaults for the argparser --help:
+    plugin = PitchShift()
+
+    parser.add_argument("--pitch_scale", type=float, default=plugin.pitch_scale)
+    parser.add_argument(
+        "-y",
+        "--overwrite",
+        action="store_true",
+        help="If passed, overwrite the output file if it already exists.",
+    )
+
+    args = parser.parse_args()
+
+    for arg in ['pitch_scale']:
+        setattr(plugin, arg, getattr(args, arg))
+
+    if not args.output_file:
+        args.output_file = args.input_file + ".shifted.wav"
+
+    sys.stderr.write(f"Opening {args.input_file}...\n")
+
+    with sf.SoundFile(args.input_file) as input_file:
+        sys.stderr.write(f"Writing to {args.output_file}...\n")
+        if os.path.isfile(args.output_file) and not args.overwrite:
+            raise ValueError(
+                f"Output file {args.output_file} already exists! (Pass -y to overwrite.)"
+            )
+        with sf.SoundFile(
+            args.output_file,
+            'w',
+            samplerate=input_file.samplerate,
+            channels=input_file.channels,
+        ) as output_file:
+            length = get_num_frames(input_file)
+            length_seconds = length / input_file.samplerate
+            sys.stderr.write(f"Adding shift to {length_seconds:.2f} seconds of audio...\n")
+            with tqdm(
+                total=length_seconds,
+                desc="Adding shift...",
+                bar_format=(
+                    "{percentage:.0f}%|{bar}| {n:.2f}/{total:.2f} seconds processed"
+                    " [{elapsed}<{remaining}, {rate:.2f}x]"
+                ),
+                # Avoid a formatting error that occurs if
+                # TQDM tries to print before we've processed a block
+                delay=1000,
+            ) as t:
+                for i, dry_chunk in enumerate(input_file.blocks(BUFFER_SIZE_SAMPLES, frames=length)):
+                    print("Dry chunk", i)
+                    effected_chunk = plugin.process(
+                        dry_chunk, sample_rate=input_file.samplerate, reset=False
+                    )
+                    # print(effected_chunk.shape, np.amax(np.abs(effected_chunk)))
+                    output_file.write(effected_chunk)
+                    t.update(len(dry_chunk) / input_file.samplerate)
+                    t.refresh()
+
+    sys.stderr.write("Done!\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/pedalboard/RubberbandPlugin.h
+++ b/pedalboard/RubberbandPlugin.h
@@ -1,0 +1,61 @@
+#include "./vendors/rubberband/rubberband/RubberBandStretcher.h"
+#include "Plugin.h"
+
+using namespace RubberBand;
+
+namespace Pedalboard
+{
+
+  // TODO: Is this template needed?
+  // template <typename DSPType>
+  class RubberbandPlugin : public Plugin
+  /*
+  Base class for rubberband plugins.
+  */
+  {
+  public:
+    virtual ~RubberbandPlugin(){};
+
+    virtual void prepare(const juce::dsp::ProcessSpec &spec) = 0;
+
+    void process(
+        const juce::dsp::ProcessContextReplacing<float> &context) override final
+    {
+      // This part might be the same across all rubberband plugins?
+      if (rbPtr)
+      {
+        // Is this the right way to get the next input block?
+        // Do I have to shift something?
+        size_t sampleFrames = 0; // How do I compute this? Is there a value somewhere
+        auto inputBlock = context.getInputBlock();
+        // rbPtr->process(, sampleFrames, false); // Impact of not setting final to true?
+        // size_t samplesRetrieved = 0;
+        // size_t samplesAvailable = 0;
+        // while (samplesRetrieved < inputBlock.getNumSamples()) // is this correct to hang here for each block?
+        // {
+        //   samplesAvailable = rbPtr->available();
+        //   if (samplesAvailable)
+        //   {
+        //     samplesRetrieved += rbPtr->retrieve(context.getOutputBlock(), samplesAvailable);
+        //   }
+        // }
+      }
+    }
+
+    void reset() override final
+    {
+      // dspBlock.reset();
+      if (rbPtr)
+      {
+        rbPtr->reset();
+      }
+    }
+
+    // RubberBandStretcher *getRb() { return rbPtr; }
+
+  protected:
+    // TODO: Do I need the DSP block? or are the buffers handled by RB?
+    // DSPType dspBlock;
+    RubberBandStretcher *rbPtr = nullptr;
+  };
+}; // pedalboard

--- a/pedalboard/RubberbandPlugin.h
+++ b/pedalboard/RubberbandPlugin.h
@@ -21,14 +21,12 @@ namespace Pedalboard
         auto inBlock = context.getInputBlock();
         auto outBlock = context.getOutputBlock();
 
-        // TODO: Is num samples the total number of frames or n_samples_per_channel * n_channels?
         auto len = inBlock.getNumSamples();
         auto numChannels = inBlock.getNumChannels();
 
         jassert(len == outBlock.getNumSamples());
         jassert(numChannels == outBlock.getNumChannels());
 
-        // Have to find way to get all channel data?
         const float *inChannels[numChannels];
         float *outChannels[numChannels];
         for (size_t i = 0; i < numChannels; i++)
@@ -38,7 +36,7 @@ namespace Pedalboard
         }
 
         // Rubberband expects all channel data with one float array per channel
-        processSamples(inChannels, outChannels, len, numChannels, false);
+        processSamples(inChannels, outChannels, len, numChannels);
       }
     }
 
@@ -51,10 +49,10 @@ namespace Pedalboard
     }
 
   private:
-    void processSamples(const float *const *inBlock, float **outBlock, size_t samples, size_t numChannels, bool final)
+    void processSamples(const float *const *inBlock, float **outBlock, size_t samples, size_t numChannels)
     {
       // Push all of the input samples into RubberBand:
-      rbPtr->process(inBlock, samples, final);
+      rbPtr->process(inBlock, samples, false);
 
       // Figure out how many samples RubberBand is ready to give to us:
       int availableSamples = rbPtr->available();

--- a/pedalboard/RubberbandPlugin.h
+++ b/pedalboard/RubberbandPlugin.h
@@ -16,7 +16,7 @@ namespace Pedalboard
   public:
     virtual ~RubberbandPlugin(){};
 
-    virtual void prepare(const juce::dsp::ProcessSpec &spec) = 0;
+    // virtual void prepare(const juce::dsp::ProcessSpec &spec) = 0;
 
     void process(
         const juce::dsp::ProcessContextReplacing<float> &context) override final
@@ -26,19 +26,50 @@ namespace Pedalboard
       {
         // Is this the right way to get the next input block?
         // Do I have to shift something?
-        size_t sampleFrames = 0; // How do I compute this? Is there a value somewhere
-        auto inputBlock = context.getInputBlock();
-        // rbPtr->process(, sampleFrames, false); // Impact of not setting final to true?
-        // size_t samplesRetrieved = 0;
-        // size_t samplesAvailable = 0;
-        // while (samplesRetrieved < inputBlock.getNumSamples()) // is this correct to hang here for each block?
-        // {
-        //   samplesAvailable = rbPtr->available();
-        //   if (samplesAvailable)
-        //   {
-        //     samplesRetrieved += rbPtr->retrieve(context.getOutputBlock(), samplesAvailable);
-        //   }
-        // }
+        // size_t sampleFrames = 0; // How do I compute this? Is there a value somewhere
+
+        auto inBlock = context.getInputBlock();
+        auto outBlock = context.getOutputBlock();
+
+        // TODO: Is num samples the total number of frames or n_samples_per_channel * n_channels
+        auto len = inBlock.getNumSamples();
+        auto numChans = inBlock.getNumChannels();
+
+        jassert(len == outBlock.getNumSamples());
+        jassert(numChans == outBlock.getNumChannels());
+
+        // Have to find way to get all channel data?
+        const float *inChannels[numChans];
+        float *outChannels[numChans];
+        for (size_t i = 0; i < numChans; i++)
+        {
+          inChannels[i] = inBlock.getChannelPointer(i);
+          outChannels[i] = outBlock.getChannelPointer(i);
+          std::cout << "input channel " << i << " = " << inChannels[i] << "\n";
+          std::cout << "output channel " << i << " = " << outChannels[i] << "\n";
+        }
+
+        // Rubberband expects all channel data with one float array per channel
+        processSamples(inChannels, outChannels, len, false);
+      }
+    }
+
+    void processSamples(const float *const *inBlock, float *const *outBlock, size_t samples, bool final)
+    {
+      rbPtr->process(inBlock, samples, false); // Impact of not setting final to true?
+      std::cout << rbPtr->getSamplesRequired() << "\n";
+      size_t samplesRetrieved = 0;
+      size_t samplesAvailable = 0;
+      int count = 0;
+      while (count < 10) // is this correct to hang here for each block?
+      {
+        samplesAvailable = rbPtr->available();
+        std::cout << samplesAvailable << "\n";
+        if (samplesAvailable)
+        {
+          samplesRetrieved += rbPtr->retrieve(outBlock, samplesAvailable);
+        }
+        count++;
       }
     }
 
@@ -54,7 +85,7 @@ namespace Pedalboard
     // RubberBandStretcher *getRb() { return rbPtr; }
 
   protected:
-    // TODO: Do I need the DSP block? or are the buffers handled by RB?
+    // TODO: Do I need the DSP block?
     // DSPType dspBlock;
     RubberBandStretcher *rbPtr = nullptr;
   };

--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -56,11 +56,11 @@ namespace Pedalboard
                 auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels, stretcherOptions);
                 rb->setMaxProcessSize(spec.maximumBlockSize);
                 rb->setPitchScale(_pitchScale);
+                rb->reset();
                 delete rbPtr;
                 rbPtr = rb;
                 lastSpec = spec;
             }
-            reset();
         }
     };
 
@@ -71,8 +71,7 @@ namespace Pedalboard
                           {
                               auto plugin = new PitchShift();
                               plugin->setPitchScale(scale);
-                              return plugin;
-                          }),
+                              return plugin; }),
                  py::arg("pitch_scale") = 1.0)
             .def_property("pitch_scale", &PitchShift::getPitchScale, &PitchShift::setPitchScale);
     }

--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -53,38 +53,38 @@ namespace Pedalboard
 
         void prepare(const juce::dsp::ProcessSpec &spec) override final
         {
-
             bool specChanged = lastSpec.sampleRate != spec.sampleRate ||
                                lastSpec.maximumBlockSize < spec.maximumBlockSize ||
                                spec.numChannels != lastSpec.numChannels;
 
+            std::cout << specChanged << " " << !rbPtr << "\n";
             if (!rbPtr || specChanged)
             {
-                // No need to explicitly call reset if constructing new object
-
-                // Is this appropriate to create a new object every time the spec changes?
-
-                // TODO: Need to add streaming mode!
-                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels);
+                auto stretcherOptions = RubberBand::RubberBandStretcher::OptionProcessRealTime;
+                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels, stretcherOptions);
                 rb->setMaxProcessSize(spec.maximumBlockSize);
                 rb->setPitchScale(_pitchScale);
-                // what about deallocating?
+                // rb->setDebugLevel(2);
                 delete rbPtr;
                 rbPtr = rb;
                 // dspBlock.prepare(spec);
                 lastSpec = spec;
             }
+            // When prepare reset Rubberband buffers regardless if a new object was created or not
+            reset();
         }
     };
-    
+
     inline void init_pitch_shift(py::module &m)
     {
         py::class_<PitchShift, Plugin>(m, "PitchShift", "Shift pitch without affecting audio duration")
             .def(py::init([](double scale)
                           {
-                    auto plugin = new PitchShift();
-                    plugin->setPitchScale(scale);
-                    return plugin; }))
+                              auto plugin = new PitchShift();
+                              plugin->setPitchScale(scale);
+                              return plugin;
+                          }),
+                 py::arg("pitch_scale") = 1.0)
             .def_property("pitch_scale", &PitchShift::getPitchScale, &PitchShift::setPitchScale);
     }
 }; // namespace Pedalboard

--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -1,0 +1,90 @@
+/*
+ * pedalboard
+ * Copyright 2021 Spotify AB
+ *
+ * Licensed under the GNU Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+#include "../RubberbandPlugin.h"
+
+namespace Pedalboard
+{
+    class PitchShift : public RubberbandPlugin
+    /*
+    Modifies an audios pitch (without affecting duration [confirm if this is the case in RT mode])
+    */
+    {
+    private:
+        double _pitchScale = 1.0;
+
+    public:
+        void setPitchScale(double scale)
+        // Instead of mirroring pitchScale value would it be better
+        // to check pointer and then throw error if doesn't exist?
+        // Cannot create ptr to rubberband object in constructor because don't
+        // have sample rate / num channels. Could use dummy instead however.
+        {
+            if (scale < 0)
+            {
+                // Throw error
+            }
+            _pitchScale = scale;
+        }
+
+        double getPitchScale()
+        {
+            return _pitchScale;
+        }
+
+        void prepare(const juce::dsp::ProcessSpec &spec) override final
+        {
+
+            bool specChanged = lastSpec.sampleRate != spec.sampleRate ||
+                               lastSpec.maximumBlockSize < spec.maximumBlockSize ||
+                               spec.numChannels != lastSpec.numChannels;
+
+            if (!rbPtr || specChanged)
+            {
+                // No need to explicitly call reset if constructing new object
+
+                // Is this appropriate to create a new object every time the spec changes?
+
+                // TODO: Need to add streaming mode!
+                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels);
+                rb->setMaxProcessSize(spec.maximumBlockSize);
+                rb->setPitchScale(_pitchScale);
+                // what about deallocating?
+                delete rbPtr;
+                rbPtr = rb;
+                // dspBlock.prepare(spec);
+                lastSpec = spec;
+            }
+        }
+    };
+    
+    inline void init_pitch_shift(py::module &m)
+    {
+        py::class_<PitchShift, Plugin>(m, "PitchShift", "Shift pitch without affecting audio duration")
+            .def(py::init([](double scale)
+                          {
+                    auto plugin = new PitchShift();
+                    plugin->setPitchScale(scale);
+                    return plugin; }))
+            .def_property("pitch_scale", &PitchShift::getPitchScale, &PitchShift::setPitchScale);
+    }
+}; // namespace Pedalboard

--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -35,9 +35,9 @@ namespace Pedalboard
     public:
         void setPitchScale(double scale)
         {
-            if (scale < 0)
+            if (scale <= 0)
             {
-                // Throw error
+                throw std::range_error("Pitch scale be a value > 0");
             }
             _pitchScale = scale;
         }

--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -63,9 +63,7 @@ namespace Pedalboard
                 // No need to explicitly call reset if constructing new object
 
                 // Is this appropriate to create a new object every time the spec changes?
-
-                // TODO: Need to add streaming mode!
-                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels);
+                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels, RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionThreadingNever);
                 rb->setMaxProcessSize(spec.maximumBlockSize);
                 rb->setPitchScale(_pitchScale);
                 // what about deallocating?

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -166,7 +166,6 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
     spec.sampleRate = sampleRate;
     spec.maximumBlockSize = static_cast<juce::uint32>(bufferSize);
     spec.numChannels = static_cast<juce::uint32>(numChannels);
-    std::cout << "sampleRate " << spec.sampleRate << " max Size " << spec.maximumBlockSize << " channels " << spec.numChannels << "\n";
 
     for (auto *plugin : plugins) {
       if (plugin == nullptr)
@@ -183,13 +182,11 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
     juce::AudioBuffer<float> ioBuffer(ioBufferChannelPointers.data(),
                                       numChannels, numSamples);
 
-    for (unsigned int blockStart = 0; blockStart < numSamples; blockStart += bufferSize)
-    {
+    for (unsigned int blockStart = 0; blockStart < numSamples;
+         blockStart += bufferSize) {
       unsigned int blockEnd = std::min(blockStart + bufferSize,
                                        static_cast<unsigned int>(numSamples));
       unsigned int blockSize = blockEnd - blockStart;
-      std::cout << "Block start " << blockStart << " " << " block end " << blockEnd << "\n";
-      std::cout << "Entering buffer loop " << numSamples << " " << bufferSize << " " << blockSize << "\n";
 
       // Copy the input audio into the ioBuffer, which will be used for
       // processing and will be returned.

--- a/pedalboard/process.h
+++ b/pedalboard/process.h
@@ -166,6 +166,7 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
     spec.sampleRate = sampleRate;
     spec.maximumBlockSize = static_cast<juce::uint32>(bufferSize);
     spec.numChannels = static_cast<juce::uint32>(numChannels);
+    std::cout << "sampleRate " << spec.sampleRate << " max Size " << spec.maximumBlockSize << " channels " << spec.numChannels << "\n";
 
     for (auto *plugin : plugins) {
       if (plugin == nullptr)
@@ -182,11 +183,13 @@ process<float>(const py::array_t<float, py::array::c_style> inputArray,
     juce::AudioBuffer<float> ioBuffer(ioBufferChannelPointers.data(),
                                       numChannels, numSamples);
 
-    for (unsigned int blockStart = 0; blockStart < numSamples;
-         blockStart += bufferSize) {
+    for (unsigned int blockStart = 0; blockStart < numSamples; blockStart += bufferSize)
+    {
       unsigned int blockEnd = std::min(blockStart + bufferSize,
                                        static_cast<unsigned int>(numSamples));
       unsigned int blockSize = blockEnd - blockStart;
+      std::cout << "Block start " << blockStart << " " << " block end " << blockEnd << "\n";
+      std::cout << "Entering buffer loop " << numSamples << " " << bufferSize << " " << blockSize << "\n";
 
       // Copy the input audio into the ioBuffer, which will be used for
       // processing and will be returned.

--- a/pedalboard/python_bindings.cpp
+++ b/pedalboard/python_bindings.cpp
@@ -43,6 +43,7 @@ namespace py = pybind11;
 #include "plugins/LowpassFilter.h"
 #include "plugins/NoiseGate.h"
 #include "plugins/Phaser.h"
+#include "plugins/PitchShift.h"
 #include "plugins/Reverb.h"
 
 using namespace Pedalboard;
@@ -132,7 +133,6 @@ PYBIND11_MODULE(pedalboard_native, m) {
   plugin.attr("__call__") = plugin.attr("process");
 
   init_chorus(m);
-
   init_compressor(m);
   init_convolution(m);
   init_distortion(m);
@@ -143,6 +143,7 @@ PYBIND11_MODULE(pedalboard_native, m) {
   init_lowpass(m);
   init_noisegate(m);
   init_phaser(m);
+  init_pitch_shift(m);
   init_reverb(m);
 
   init_external_plugins(m);

--- a/pedalboard/vendors/rubberband/rubberband/RubberBandStretcher.h
+++ b/pedalboard/vendors/rubberband/rubberband/RubberBandStretcher.h
@@ -1,0 +1,778 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCHER_H
+#define RUBBERBAND_STRETCHER_H
+    
+#define RUBBERBAND_VERSION "2.0.0"
+#define RUBBERBAND_API_MAJOR_VERSION 2
+#define RUBBERBAND_API_MINOR_VERSION 6
+
+#undef RUBBERBAND_DLLEXPORT
+#ifdef _MSC_VER
+#define RUBBERBAND_DLLEXPORT __declspec(dllexport)
+#else
+#define RUBBERBAND_DLLEXPORT
+#endif
+
+#include <vector>
+#include <map>
+#include <cstddef>
+
+/**
+ * @mainpage RubberBand
+ * 
+ * The Rubber Band API is contained in the single class
+ * RubberBand::RubberBandStretcher.
+ *
+ * The Rubber Band stretcher supports two processing modes, offline
+ * and real-time. The choice of mode is fixed on construction. In
+ * offline mode, you must provide the audio block-by-block in two
+ * passes: in the first pass calling study(), in the second pass
+ * calling process() and receiving the output via retrieve(). In
+ * real-time mode, there is no study pass, just a single streaming
+ * pass in which the audio is passed to process() and output received
+ * via retrieve().
+ *
+ * In real-time mode you can change the time and pitch ratios at any
+ * time, but in offline mode they are fixed and cannot be changed
+ * after the study pass has begun. (However, see setKeyFrameMap() for
+ * a way to do pre-planned variable time stretching in offline mode.)
+ * Offline mode typically produces slightly more precise results.
+ *
+ * Threading notes for real-time applications:
+ * 
+ * Multiple instances of RubberBandStretcher may be created and used
+ * in separate threads concurrently.  However, for any single instance
+ * of RubberBandStretcher, you may not call process() more than once
+ * concurrently, and you may not change the time or pitch ratio while
+ * a process() call is being executed (if the stretcher was created in
+ * "real-time mode"; in "offline mode" you can't change the ratios
+ * during use anyway).
+ * 
+ * So you can run process() in its own thread if you like, but if you
+ * want to change ratios dynamically from a different thread, you will
+ * need some form of mutex in your code.  Changing the time or pitch
+ * ratio is real-time safe except in extreme circumstances, so for
+ * most applications that may change these dynamically it probably
+ * makes most sense to do so from the same thread as calls process(),
+ * even if that is a real-time thread.
+ */
+
+namespace RubberBand
+{
+
+class RUBBERBAND_DLLEXPORT
+RubberBandStretcher
+{
+public:
+    /**
+     * Processing options for the timestretcher.  The preferred
+     * options should normally be set in the constructor, as a bitwise
+     * OR of the option flags.  The default value (DefaultOptions) is
+     * intended to give good results in most situations.
+     *
+     * 1. Flags prefixed \c OptionProcess determine how the timestretcher
+     * will be invoked.  These options may not be changed after
+     * construction.
+     * 
+     *   \li \c OptionProcessOffline - Run the stretcher in offline
+     *   mode.  In this mode the input data needs to be provided
+     *   twice, once to study(), which calculates a stretch profile
+     *   for the audio, and once to process(), which stretches it.
+     *
+     *   \li \c OptionProcessRealTime - Run the stretcher in real-time
+     *   mode.  In this mode only process() should be called, and the
+     *   stretcher adjusts dynamically in response to the input audio.
+     * 
+     * The Process setting is likely to depend on your architecture:
+     * non-real-time operation on seekable files: Offline; real-time
+     * or streaming operation: RealTime.
+     *
+     * 2. Flags prefixed \c OptionStretch control the profile used for
+     * variable timestretching.  Rubber Band always adjusts the
+     * stretch profile to minimise stretching of busy broadband
+     * transient sounds, but the degree to which it does so is
+     * adjustable.  These options may not be changed after
+     * construction.
+     *
+     *   \li \c OptionStretchElastic - Only meaningful in offline
+     *   mode, and the default in that mode.  The audio will be
+     *   stretched at a variable rate, aimed at preserving the quality
+     *   of transient sounds as much as possible.  The timings of low
+     *   activity regions between transients may be less exact than
+     *   when the precise flag is set.
+     * 
+     *   \li \c OptionStretchPrecise - Although still using a variable
+     *   stretch rate, the audio will be stretched so as to maintain
+     *   as close as possible to a linear stretch ratio throughout.
+     *   Timing may be better than when using \c OptionStretchElastic, at
+     *   slight cost to the sound quality of transients.  This setting
+     *   is always used when running in real-time mode.
+     *
+     * 3. Flags prefixed \c OptionTransients control the component
+     * frequency phase-reset mechanism that may be used at transient
+     * points to provide clarity and realism to percussion and other
+     * significant transient sounds.  These options may be changed
+     * after construction when running in real-time mode, but not when
+     * running in offline mode.
+     * 
+     *   \li \c OptionTransientsCrisp - Reset component phases at the
+     *   peak of each transient (the start of a significant note or
+     *   percussive event).  This, the default setting, usually
+     *   results in a clear-sounding output; but it is not always
+     *   consistent, and may cause interruptions in stable sounds
+     *   present at the same time as transient events.  The
+     *   OptionDetector flags (below) can be used to tune this to some
+     *   extent.
+     *
+     *   \li \c OptionTransientsMixed - Reset component phases at the
+     *   peak of each transient, outside a frequency range typical of
+     *   musical fundamental frequencies.  The results may be more
+     *   regular for mixed stable and percussive notes than
+     *   \c OptionTransientsCrisp, but with a "phasier" sound.  The
+     *   balance may sound very good for certain types of music and
+     *   fairly bad for others.
+     *
+     *   \li \c OptionTransientsSmooth - Do not reset component phases
+     *   at any point.  The results will be smoother and more regular
+     *   but may be less clear than with either of the other
+     *   transients flags.
+     *
+     * 4. Flags prefixed \c OptionDetector control the type of
+     * transient detector used.  These options may be changed
+     * after construction when running in real-time mode, but not when
+     * running in offline mode.
+     *
+     *   \li \c OptionDetectorCompound - Use a general-purpose
+     *   transient detector which is likely to be good for most
+     *   situations.  This is the default.
+     *
+     *   \li \c OptionDetectorPercussive - Detect percussive
+     *   transients.  Note that this was the default and only option
+     *   in Rubber Band versions prior to 1.5.
+     *
+     *   \li \c OptionDetectorSoft - Use an onset detector with less
+     *   of a bias toward percussive transients.  This may give better
+     *   results with certain material (e.g. relatively monophonic
+     *   piano music).
+     *
+     * 5. Flags prefixed \c OptionPhase control the adjustment of
+     * component frequency phases from one analysis window to the next
+     * during non-transient segments.  These options may be changed at
+     * any time.
+     *
+     *   \li \c OptionPhaseLaminar - Adjust phases when stretching in
+     *   such a way as to try to retain the continuity of phase
+     *   relationships between adjacent frequency bins whose phases
+     *   are behaving in similar ways.  This, the default setting,
+     *   should give good results in most situations.
+     *
+     *   \li \c OptionPhaseIndependent - Adjust the phase in each
+     *   frequency bin independently from its neighbours.  This
+     *   usually results in a slightly softer, phasier sound.
+     *
+     * 6. Flags prefixed \c OptionThreading control the threading
+     * model of the stretcher.  These options may not be changed after
+     * construction.
+     *
+     *   \li \c OptionThreadingAuto - Permit the stretcher to
+     *   determine its own threading model.  Usually this means using
+     *   one processing thread per audio channel in offline mode if
+     *   the stretcher is able to determine that more than one CPU is
+     *   available, and one thread only in realtime mode.  This is the
+     *   default.
+     *
+     *   \li \c OptionThreadingNever - Never use more than one thread.
+     *  
+     *   \li \c OptionThreadingAlways - Use multiple threads in any
+     *   situation where \c OptionThreadingAuto would do so, except omit
+     *   the check for multiple CPUs and instead assume it to be true.
+     *
+     * 7. Flags prefixed \c OptionWindow control the window size for
+     * FFT processing.  The window size actually used will depend on
+     * many factors, but it can be influenced.  These options may not
+     * be changed after construction.
+     *
+     *   \li \c OptionWindowStandard - Use the default window size.
+     *   The actual size will vary depending on other parameters.
+     *   This option is expected to produce better results than the
+     *   other window options in most situations.
+     *
+     *   \li \c OptionWindowShort - Use a shorter window.  This may
+     *   result in crisper sound for audio that depends strongly on
+     *   its timing qualities.
+     *
+     *   \li \c OptionWindowLong - Use a longer window.  This is
+     *   likely to result in a smoother sound at the expense of
+     *   clarity and timing.
+     *
+     * 8. Flags prefixed \c OptionSmoothing control the use of
+     * window-presum FFT and time-domain smoothing.  These options may
+     * not be changed after construction.
+     *
+     *   \li \c OptionSmoothingOff - Do not use time-domain smoothing.
+     *   This is the default.
+     *
+     *   \li \c OptionSmoothingOn - Use time-domain smoothing.  This
+     *   will result in a softer sound with some audible artifacts
+     *   around sharp transients, but it may be appropriate for longer
+     *   stretches of some instruments and can mix well with
+     *   OptionWindowShort.
+     *
+     * 9. Flags prefixed \c OptionFormant control the handling of
+     * formant shape (spectral envelope) when pitch-shifting.  These
+     * options may be changed at any time.
+     *
+     *   \li \c OptionFormantShifted - Apply no special formant
+     *   processing.  The spectral envelope will be pitch shifted as
+     *   normal.  This is the default.
+     *
+     *   \li \c OptionFormantPreserved - Preserve the spectral
+     *   envelope of the unshifted signal.  This permits shifting the
+     *   note frequency without so substantially affecting the
+     *   perceived pitch profile of the voice or instrument.
+     *
+     * 10. Flags prefixed \c OptionPitch control the method used for
+     * pitch shifting.  These options may be changed at any time.
+     * They are only effective in realtime mode; in offline mode, the
+     * pitch-shift method is fixed.
+     *
+     *   \li \c OptionPitchHighSpeed - Use a method with a CPU cost
+     *   that is relatively moderate and predictable.  This may
+     *   sound less clear than OptionPitchHighQuality, especially
+     *   for large pitch shifts.  This is the default.
+
+     *   \li \c OptionPitchHighQuality - Use the highest quality
+     *   method for pitch shifting.  This method has a CPU cost
+     *   approximately proportional to the required frequency shift.
+
+     *   \li \c OptionPitchHighConsistency - Use the method that gives
+     *   greatest consistency when used to create small variations in
+     *   pitch around the 1.0-ratio level.  Unlike the previous two
+     *   options, this avoids discontinuities when moving across the
+     *   1.0 pitch scale in real-time; it also consumes more CPU than
+     *   the others in the case where the pitch scale is exactly 1.0.
+     *
+     * 11. Flags prefixed \c OptionChannels control the method used for
+     * processing two-channel audio.  These options may not be changed
+     * after construction.
+     *
+     *   \li \c OptionChannelsApart - Each channel is processed
+     *   individually, though timing is synchronised and phases are
+     *   synchronised at transients (depending on the OptionTransients
+     *   setting).  This gives the highest quality for the individual
+     *   channels but a relative lack of stereo focus and unrealistic
+     *   increase in "width".  This is the default.
+     *
+     *   \li \c OptionChannelsTogether - The first two channels (where
+     *   two or more are present) are considered to be a stereo pair
+     *   and are processed in mid-side format; mid and side are
+     *   processed individually, with timing synchronised and phases
+     *   synchronised at transients (depending on the OptionTransients
+     *   setting).  This usually leads to better focus in the centre
+     *   but a loss of stereo space and width.  Any channels beyond
+     *   the first two are processed individually.
+     */
+    
+    enum Option {
+
+        OptionProcessOffline       = 0x00000000,
+        OptionProcessRealTime      = 0x00000001,
+
+        OptionStretchElastic       = 0x00000000,
+        OptionStretchPrecise       = 0x00000010,
+    
+        OptionTransientsCrisp      = 0x00000000,
+        OptionTransientsMixed      = 0x00000100,
+        OptionTransientsSmooth     = 0x00000200,
+
+        OptionDetectorCompound     = 0x00000000,
+        OptionDetectorPercussive   = 0x00000400,
+        OptionDetectorSoft         = 0x00000800,
+
+        OptionPhaseLaminar         = 0x00000000,
+        OptionPhaseIndependent     = 0x00002000,
+    
+        OptionThreadingAuto        = 0x00000000,
+        OptionThreadingNever       = 0x00010000,
+        OptionThreadingAlways      = 0x00020000,
+
+        OptionWindowStandard       = 0x00000000,
+        OptionWindowShort          = 0x00100000,
+        OptionWindowLong           = 0x00200000,
+
+        OptionSmoothingOff         = 0x00000000,
+        OptionSmoothingOn          = 0x00800000,
+
+        OptionFormantShifted       = 0x00000000,
+        OptionFormantPreserved     = 0x01000000,
+
+        OptionPitchHighSpeed       = 0x00000000,
+        OptionPitchHighQuality     = 0x02000000,
+        OptionPitchHighConsistency = 0x04000000,
+
+        OptionChannelsApart        = 0x00000000,
+        OptionChannelsTogether     = 0x10000000
+
+        // n.b. Options is int, so we must stop before 0x80000000
+    };
+
+    typedef int Options;
+
+    enum PresetOption {
+        DefaultOptions             = 0x00000000,
+        PercussiveOptions          = 0x00102000
+    };
+
+    /**
+     * Construct a time and pitch stretcher object to run at the given
+     * sample rate, with the given number of channels.
+     *
+     * Initial time and pitch scaling ratios and other processing
+     * options may be provided. In particular, the behaviour of the
+     * stretcher depends strongly on whether offline or real-time mode
+     * is selected on construction (via OptionProcessOffline or
+     * OptionProcessRealTime option - offline is the default).
+     * 
+     * In offline mode, you must provide the audio block-by-block in
+     * two passes: in the first pass calling study(), in the second
+     * pass calling process() and receiving the output via
+     * retrieve(). In real-time mode, there is no study pass, just a
+     * single streaming pass in which the audio is passed to process()
+     * and output received via retrieve().
+     *
+     * In real-time mode you can change the time and pitch ratios at
+     * any time, but in offline mode they are fixed and cannot be
+     * changed after the study pass has begun. (However, see
+     * setKeyFrameMap() for a way to do pre-planned variable time
+     * stretching in offline mode.)
+     *
+     * See the option documentation above for more details.
+     */
+    RubberBandStretcher(size_t sampleRate,
+                        size_t channels,
+                        Options options = DefaultOptions,
+                        double initialTimeRatio = 1.0,
+                        double initialPitchScale = 1.0);
+    ~RubberBandStretcher();
+
+    /**
+     * Reset the stretcher's internal buffers.  The stretcher should
+     * subsequently behave as if it had just been constructed
+     * (although retaining the current time and pitch ratio).
+     */
+    void reset();
+
+    /**
+     * Set the time ratio for the stretcher.  This is the ratio of
+     * stretched to unstretched duration -- not tempo.  For example, a
+     * ratio of 2.0 would make the audio twice as long (i.e. halve the
+     * tempo); 0.5 would make it half as long (i.e. double the tempo);
+     * 1.0 would leave the duration unaffected.
+     *
+     * If the stretcher was constructed in Offline mode, the time
+     * ratio is fixed throughout operation; this function may be
+     * called any number of times between construction (or a call to
+     * reset()) and the first call to study() or process(), but may
+     * not be called after study() or process() has been called.
+     *
+     * If the stretcher was constructed in RealTime mode, the time
+     * ratio may be varied during operation; this function may be
+     * called at any time, so long as it is not called concurrently
+     * with process().  You should either call this function from the
+     * same thread as process(), or provide your own mutex or similar
+     * mechanism to ensure that setTimeRatio and process() cannot be
+     * run at once (there is no internal mutex for this purpose).
+     */
+    void setTimeRatio(double ratio);
+
+    /**
+     * Set the pitch scaling ratio for the stretcher.  This is the
+     * ratio of target frequency to source frequency.  For example, a
+     * ratio of 2.0 would shift up by one octave; 0.5 down by one
+     * octave; or 1.0 leave the pitch unaffected.
+     *
+     * To put this in musical terms, a pitch scaling ratio
+     * corresponding to a shift of S equal-tempered semitones (where S
+     * is positive for an upwards shift and negative for downwards) is
+     * pow(2.0, S / 12.0).
+     *
+     * If the stretcher was constructed in Offline mode, the pitch
+     * scaling ratio is fixed throughout operation; this function may
+     * be called any number of times between construction (or a call
+     * to reset()) and the first call to study() or process(), but may
+     * not be called after study() or process() has been called.
+     *
+     * If the stretcher was constructed in RealTime mode, the pitch
+     * scaling ratio may be varied during operation; this function may
+     * be called at any time, so long as it is not called concurrently
+     * with process().  You should either call this function from the
+     * same thread as process(), or provide your own mutex or similar
+     * mechanism to ensure that setPitchScale and process() cannot be
+     * run at once (there is no internal mutex for this purpose).
+     */
+    void setPitchScale(double scale);
+
+    /**
+     * Return the last time ratio value that was set (either on
+     * construction or with setTimeRatio()).
+     */
+    double getTimeRatio() const;
+
+    /**
+     * Return the last pitch scaling ratio value that was set (either
+     * on construction or with setPitchScale()).
+     */
+    double getPitchScale() const;
+
+    /**
+     * Return the processing latency of the stretcher.  This is the
+     * number of audio samples that one would have to discard at the
+     * start of the output in order to ensure that the resulting audio
+     * aligned with the input audio at the start.  In Offline mode,
+     * latency is automatically adjusted for and the result is zero.
+     * In RealTime mode, the latency may depend on the time and pitch
+     * ratio and other options.
+     */
+    size_t getLatency() const;
+
+    /**
+     * Change an OptionTransients configuration setting.  This may be
+     * called at any time in RealTime mode.  It may not be called in
+     * Offline mode (for which the transients option is fixed on
+     * construction).
+     */
+    void setTransientsOption(Options options);
+
+    /**
+     * Change an OptionDetector configuration setting.  This may be
+     * called at any time in RealTime mode.  It may not be called in
+     * Offline mode (for which the detector option is fixed on
+     * construction).
+     */
+    void setDetectorOption(Options options);
+
+    /**
+     * Change an OptionPhase configuration setting.  This may be
+     * called at any time in any mode.
+     *
+     * Note that if running multi-threaded in Offline mode, the change
+     * may not take effect immediately if processing is already under
+     * way when this function is called.
+     */
+    void setPhaseOption(Options options);
+
+    /**
+     * Change an OptionFormant configuration setting.  This may be
+     * called at any time in any mode.
+     *
+     * Note that if running multi-threaded in Offline mode, the change
+     * may not take effect immediately if processing is already under
+     * way when this function is called.
+     */
+    void setFormantOption(Options options);
+
+    /**
+     * Change an OptionPitch configuration setting.  This may be
+     * called at any time in RealTime mode.  It may not be called in
+     * Offline mode (for which the pitch option is fixed on
+     * construction).
+     */
+    void setPitchOption(Options options);
+
+    /**
+     * Tell the stretcher exactly how many input sample frames it will
+     * receive.  This is only useful in Offline mode, when it allows
+     * the stretcher to ensure that the number of output samples is
+     * exactly correct.  In RealTime mode no such guarantee is
+     * possible and this value is ignored.
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     */
+    void setExpectedInputDuration(size_t samples);
+
+    /**
+     * Tell the stretcher the maximum number of sample frames that you
+     * will ever be passing in to a single process() call.  If you
+     * don't call this, the stretcher will assume that you are calling
+     * getSamplesRequired() at each cycle and are never passing more
+     * samples than are suggested by that function.
+     *
+     * If your application has some external constraint that means you
+     * prefer a fixed block size, then your normal mode of operation
+     * would be to provide that block size to this function; to loop
+     * calling process() with that size of block; after each call to
+     * process(), test whether output has been generated by calling
+     * available(); and, if so, call retrieve() to obtain it.  See
+     * getSamplesRequired() for a more suitable operating mode for
+     * applications without such external constraints.
+     *
+     * This function may not be called after the first call to study()
+     * or process().
+     *
+     * Note that this value is only relevant to process(), not to
+     * study() (to which you may pass any number of samples at a time,
+     * and from which there is no output).
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     */
+    void setMaxProcessSize(size_t samples);
+
+    /**
+     * Ask the stretcher how many audio sample frames should be
+     * provided as input in order to ensure that some more output
+     * becomes available.
+     * 
+     * If your application has no particular constraint on processing
+     * block size and you are able to provide any block size as input
+     * for each cycle, then your normal mode of operation would be to
+     * loop querying this function; providing that number of samples
+     * to process(); and reading the output using available() and
+     * retrieve().  See setMaxProcessSize() for a more suitable
+     * operating mode for applications that do have external block
+     * size constraints.
+     *
+     * Note that this value is only relevant to process(), not to
+     * study() (to which you may pass any number of samples at a time,
+     * and from which there is no output).
+     *
+     * Note that the return value refers to the number of audio sample
+     * frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     */
+     size_t getSamplesRequired() const;
+
+    /**
+     * Provide a set of mappings from "before" to "after" sample
+     * numbers so as to enforce a particular stretch profile.  The
+     * argument is a map from audio sample frame number in the source
+     * material, to the corresponding sample frame number in the
+     * stretched output.  The mapping should be for key frames only,
+     * with a "reasonable" gap between mapped samples.
+     *
+     * This function cannot be used in RealTime mode.
+     *
+     * This function may not be called after the first call to
+     * process().  It should be called after the time and pitch ratios
+     * have been set; the results of changing the time and pitch
+     * ratios after calling this function are undefined.  Calling
+     * reset() will clear this mapping.
+     *
+     * The key frame map only affects points within the material; it
+     * does not determine the overall stretch ratio (that is, the
+     * ratio between the output material's duration and the source
+     * material's duration).  You need to provide this ratio
+     * separately to setTimeRatio(), otherwise the results may be
+     * truncated or extended in unexpected ways regardless of the
+     * extent of the frame numbers found in the key frame map.
+     */
+    void setKeyFrameMap(const std::map<size_t, size_t> &);
+    
+    /**
+     * Provide a block of "samples" sample frames for the stretcher to
+     * study and calculate a stretch profile from.
+     *
+     * This is only meaningful in Offline mode, and is required if
+     * running in that mode.  You should pass the entire input through
+     * study() before any process() calls are made, as a sequence of
+     * blocks in individual study() calls, or as a single large block.
+     *
+     * "input" should point to de-interleaved audio data with one
+     * float array per channel. Sample values are conventionally
+     * expected to be in the range -1.0f to +1.0f.  "samples" supplies
+     * the number of audio sample frames available in "input". If
+     * "samples" is zero, "input" may be NULL.
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     * 
+     * Set "final" to true if this is the last block of data that will
+     * be provided to study() before the first process() call.
+     */
+    void study(const float *const *input, size_t samples, bool final);
+
+    /**
+     * Provide a block of "samples" sample frames for processing.
+     * See also getSamplesRequired() and setMaxProcessSize().
+     *
+     * "input" should point to de-interleaved audio data with one
+     * float array per channel. Sample values are conventionally
+     * expected to be in the range -1.0f to +1.0f.  "samples" supplies
+     * the number of audio sample frames available in "input".
+     *
+     * Note that the value of "samples" refers to the number of audio
+     * sample frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     *
+     * Set "final" to true if this is the last block of input data.
+     */
+    void process(const float *const *input, size_t samples, bool final);
+
+    /**
+     * Ask the stretcher how many audio sample frames of output data
+     * are available for reading (via retrieve()).
+     * 
+     * This function returns 0 if no frames are available: this
+     * usually means more input data needs to be provided, but if the
+     * stretcher is running in threaded mode it may just mean that not
+     * enough data has yet been processed.  Call getSamplesRequired()
+     * to discover whether more input is needed.
+     *
+     * Note that the return value refers to the number of audio sample
+     * frames, which may be multi-channel, not the number of
+     * individual samples. (For example, one second of stereo audio
+     * sampled at 44100Hz yields a value of 44100 sample frames, not
+     * 88200.)  This rule applies throughout the Rubber Band API.
+     *
+     * This function returns -1 if all data has been fully processed
+     * and all output read, and the stretch process is now finished.
+     */
+    int available() const;
+
+    /**
+     * Obtain some processed output data from the stretcher.  Up to
+     * "samples" samples will be stored in each of the output arrays
+     * (one per channel for de-interleaved audio data) pointed to by
+     * "output".  The number of sample frames available to be
+     * retrieved can be queried beforehand with a call to available().
+     * The return value is the actual number of sample frames
+     * retrieved.
+     *
+     * Note that the value of "samples" and the return value refer to
+     * the number of audio sample frames, which may be multi-channel,
+     * not the number of individual samples. (For example, one second
+     * of stereo audio sampled at 44100Hz yields a value of 44100
+     * sample frames, not 88200.)  This rule applies throughout the
+     * Rubber Band API.
+     */
+    size_t retrieve(float *const *output, size_t samples) const;
+
+    /**
+     * Return the value of internal frequency cutoff value n.
+     *
+     * This function is not for general use.
+     */
+    float getFrequencyCutoff(int n) const;
+
+    /** 
+     * Set the value of internal frequency cutoff n to f Hz.
+     *
+     * This function is not for general use.
+     */
+    void setFrequencyCutoff(int n, float f);
+    
+    /**
+     * Retrieve the value of the internal input block increment value.
+     *
+     * This function is provided for diagnostic purposes only.
+     */
+    size_t getInputIncrement() const;
+
+    /**
+     * In offline mode, retrieve the sequence of internal block
+     * increments for output, for the entire audio data, provided the
+     * stretch profile has been calculated.  In realtime mode,
+     * retrieve any output increments that have accumulated since the
+     * last call to getOutputIncrements, to a limit of 16.
+     *
+     * This function is provided for diagnostic purposes only.
+     */
+    std::vector<int> getOutputIncrements() const;
+
+    /**
+     * In offline mode, retrieve the sequence of internal phase reset
+     * detection function values, for the entire audio data, provided
+     * the stretch profile has been calculated.  In realtime mode,
+     * retrieve any phase reset points that have accumulated since the
+     * last call to getPhaseResetCurve, to a limit of 16.
+     *
+     * This function is provided for diagnostic purposes only.
+     */
+    std::vector<float> getPhaseResetCurve() const;
+
+    /**
+     * In offline mode, retrieve the sequence of internal frames for
+     * which exact timing has been sought, for the entire audio data,
+     * provided the stretch profile has been calculated.  In realtime
+     * mode, return an empty sequence.
+     *
+     * This function is provided for diagnostic purposes only.
+     */
+    std::vector<int> getExactTimePoints() const;
+
+    /**
+     * Return the number of channels this stretcher was constructed
+     * with.
+     */
+    size_t getChannelCount() const;
+
+    /**
+     * Force the stretcher to calculate a stretch profile.  Normally
+     * this happens automatically for the first process() call in
+     * offline mode.
+     *
+     * This function is provided for diagnostic purposes only.
+     */
+    void calculateStretch();
+
+    /**
+     * Set the level of debug output.  The value may be from 0 (errors
+     * only) to 3 (very verbose, with audible ticks in the output at
+     * phase reset points).  The default is whatever has been set
+     * using setDefaultDebugLevel, or 0 if that function has not been
+     * called.
+     */
+    void setDebugLevel(int level);
+
+    /**
+     * Set the default level of debug output for subsequently
+     * constructed stretchers.
+     *
+     * @see setDebugLevel
+     */
+    static void setDefaultDebugLevel(int level);
+
+protected:
+    class Impl;
+    Impl *m_d;
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/rubberband/rubberband-c.h
+++ b/pedalboard/vendors/rubberband/rubberband/rubberband-c.h
@@ -1,0 +1,151 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_C_API_H
+#define RUBBERBAND_C_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RUBBERBAND_VERSION "2.0.0"
+#define RUBBERBAND_API_MAJOR_VERSION 2
+#define RUBBERBAND_API_MINOR_VERSION 6
+
+#undef RB_EXTERN
+#ifdef _MSC_VER
+#define RB_EXTERN extern __declspec(dllexport)
+#else
+#define RB_EXTERN extern
+#endif
+
+/**
+ * This is a C-linkage interface to the Rubber Band time stretcher.
+ * 
+ * This is a wrapper interface: the primary interface is in C++ and is
+ * defined and documented in RubberBandStretcher.h.  The library
+ * itself is implemented in C++, and requires C++ standard library
+ * support even when using the C-linkage API.
+ *
+ * Please see RubberBandStretcher.h for documentation.
+ *
+ * If you are writing to the C++ API, do not include this header.
+ */
+
+enum RubberBandOption {
+
+    RubberBandOptionProcessOffline       = 0x00000000,
+    RubberBandOptionProcessRealTime      = 0x00000001,
+
+    RubberBandOptionStretchElastic       = 0x00000000,
+    RubberBandOptionStretchPrecise       = 0x00000010,
+    
+    RubberBandOptionTransientsCrisp      = 0x00000000,
+    RubberBandOptionTransientsMixed      = 0x00000100,
+    RubberBandOptionTransientsSmooth     = 0x00000200,
+
+    RubberBandOptionDetectorCompound     = 0x00000000,
+    RubberBandOptionDetectorPercussive   = 0x00000400,
+    RubberBandOptionDetectorSoft         = 0x00000800,
+
+    RubberBandOptionPhaseLaminar         = 0x00000000,
+    RubberBandOptionPhaseIndependent     = 0x00002000,
+    
+    RubberBandOptionThreadingAuto        = 0x00000000,
+    RubberBandOptionThreadingNever       = 0x00010000,
+    RubberBandOptionThreadingAlways      = 0x00020000,
+
+    RubberBandOptionWindowStandard       = 0x00000000,
+    RubberBandOptionWindowShort          = 0x00100000,
+    RubberBandOptionWindowLong           = 0x00200000,
+
+    RubberBandOptionSmoothingOff         = 0x00000000,
+    RubberBandOptionSmoothingOn          = 0x00800000,
+
+    RubberBandOptionFormantShifted       = 0x00000000,
+    RubberBandOptionFormantPreserved     = 0x01000000,
+
+    RubberBandOptionPitchHighSpeed       = 0x00000000,
+    RubberBandOptionPitchHighQuality     = 0x02000000,
+    RubberBandOptionPitchHighConsistency = 0x04000000,
+
+    RubberBandOptionChannelsApart        = 0x00000000,
+    RubberBandOptionChannelsTogether     = 0x10000000
+};
+
+typedef int RubberBandOptions;
+
+struct RubberBandState_;
+typedef struct RubberBandState_ *RubberBandState;
+
+RB_EXTERN RubberBandState rubberband_new(unsigned int sampleRate,
+                                      unsigned int channels,
+                                      RubberBandOptions options,
+                                      double initialTimeRatio,
+                                      double initialPitchScale);
+
+RB_EXTERN void rubberband_delete(RubberBandState);
+
+RB_EXTERN void rubberband_reset(RubberBandState);
+
+RB_EXTERN void rubberband_set_time_ratio(RubberBandState, double ratio);
+RB_EXTERN void rubberband_set_pitch_scale(RubberBandState, double scale);
+
+RB_EXTERN double rubberband_get_time_ratio(const RubberBandState);
+RB_EXTERN double rubberband_get_pitch_scale(const RubberBandState);
+
+RB_EXTERN unsigned int rubberband_get_latency(const RubberBandState);
+
+RB_EXTERN void rubberband_set_transients_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_detector_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_phase_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_formant_option(RubberBandState, RubberBandOptions options);
+RB_EXTERN void rubberband_set_pitch_option(RubberBandState, RubberBandOptions options);
+
+RB_EXTERN void rubberband_set_expected_input_duration(RubberBandState, unsigned int samples);
+
+RB_EXTERN unsigned int rubberband_get_samples_required(const RubberBandState);
+
+RB_EXTERN void rubberband_set_max_process_size(RubberBandState, unsigned int samples);
+RB_EXTERN void rubberband_set_key_frame_map(RubberBandState, unsigned int keyframecount, unsigned int *from, unsigned int *to);
+
+RB_EXTERN void rubberband_study(RubberBandState, const float *const *input, unsigned int samples, int final);
+RB_EXTERN void rubberband_process(RubberBandState, const float *const *input, unsigned int samples, int final);
+
+RB_EXTERN int rubberband_available(const RubberBandState);
+RB_EXTERN unsigned int rubberband_retrieve(const RubberBandState, float *const *output, unsigned int samples);
+
+RB_EXTERN unsigned int rubberband_get_channel_count(const RubberBandState);
+
+RB_EXTERN void rubberband_calculate_stretch(RubberBandState);
+
+RB_EXTERN void rubberband_set_debug_level(RubberBandState, int level);
+RB_EXTERN void rubberband_set_default_debug_level(int level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#undef RB_EXTERN
+
+#endif

--- a/pedalboard/vendors/rubberband/single/RubberBandSingle.cpp
+++ b/pedalboard/vendors/rubberband/single/RubberBandSingle.cpp
@@ -1,0 +1,80 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+/*
+    RubberBandSingle.cpp
+ 
+    This is a single-file compilation unit for Rubber Band Library.
+  
+    To use the library in your project without building it separately,
+    include in your code either rubberband/RubberBandStretcher.h for
+    use in C++ or rubberband/rubberband-c.h if you need the C
+    interface, then add this single C++ source file to your build.
+ 
+    Don't move this file into your source tree - keep it in the same
+    place relative to the other Rubber Band code, so that the relative
+    include paths work, and just add it to your list of build files.
+  
+    This produces a build using the built-in FFT and resampler
+    implementations, except on Apple platforms, where the vDSP FFT is
+    used (and where you will need the Accelerate framework when
+    linking). It should work correctly on any supported platform, but
+    may not be the fastest configuration available. For further
+    customisation, consider using the full build system to make a
+    standalone library.
+*/
+
+#define USE_BQRESAMPLER 1
+
+#define NO_TIMING 1
+#define NO_THREADING 1
+#define NO_THREAD_CHECKS 1
+
+#if defined(__APPLE__)
+#define HAVE_VDSP 1
+#else
+#define USE_BUILTIN_FFT 1
+#endif
+
+#include "../src/audiocurves/CompoundAudioCurve.cpp"
+#include "../src/audiocurves/SpectralDifferenceAudioCurve.cpp"
+#include "../src/audiocurves/HighFrequencyAudioCurve.cpp"
+#include "../src/audiocurves/SilentAudioCurve.cpp"
+#include "../src/audiocurves/ConstantAudioCurve.cpp"
+#include "../src/audiocurves/PercussiveAudioCurve.cpp"
+#include "../src/base/Profiler.cpp"
+#include "../src/dsp/AudioCurveCalculator.cpp"
+#include "../src/dsp/FFT.cpp"
+#include "../src/dsp/Resampler.cpp"
+#include "../src/dsp/BQResampler.cpp"
+#include "../src/system/Allocators.cpp"
+#include "../src/system/sysutils.cpp"
+#include "../src/system/Thread.cpp"
+#include "../src/RubberBandStretcher.cpp"
+#include "../src/StretchCalculator.cpp"
+#include "../src/StretcherChannelData.cpp"
+#include "../src/StretcherImpl.cpp"
+#include "../src/StretcherProcess.cpp"
+
+#include "../src/rubberband-c.cpp"
+

--- a/pedalboard/vendors/rubberband/src/RubberBandStretcher.cpp
+++ b/pedalboard/vendors/rubberband/src/RubberBandStretcher.cpp
@@ -1,0 +1,222 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretcherImpl.h"
+
+
+namespace RubberBand {
+
+
+RubberBandStretcher::RubberBandStretcher(size_t sampleRate,
+                                         size_t channels,
+                                         Options options,
+                                         double initialTimeRatio,
+                                         double initialPitchScale) :
+    m_d(new Impl(sampleRate, channels, options,
+                 initialTimeRatio, initialPitchScale))
+{
+}
+
+RubberBandStretcher::~RubberBandStretcher()
+{
+    delete m_d;
+}
+
+void
+RubberBandStretcher::reset()
+{
+    m_d->reset();
+}
+
+void
+RubberBandStretcher::setTimeRatio(double ratio)
+{
+    m_d->setTimeRatio(ratio);
+}
+
+void
+RubberBandStretcher::setPitchScale(double scale)
+{
+    m_d->setPitchScale(scale);
+}
+
+double
+RubberBandStretcher::getTimeRatio() const
+{
+    return m_d->getTimeRatio();
+}
+
+double
+RubberBandStretcher::getPitchScale() const
+{
+    return m_d->getPitchScale();
+}
+
+size_t
+RubberBandStretcher::getLatency() const
+{
+    return m_d->getLatency();
+}
+
+void
+RubberBandStretcher::setTransientsOption(Options options) 
+{
+    m_d->setTransientsOption(options);
+}
+
+void
+RubberBandStretcher::setDetectorOption(Options options) 
+{
+    m_d->setDetectorOption(options);
+}
+
+void
+RubberBandStretcher::setPhaseOption(Options options) 
+{
+    m_d->setPhaseOption(options);
+}
+
+void
+RubberBandStretcher::setFormantOption(Options options)
+{
+    m_d->setFormantOption(options);
+}
+
+void
+RubberBandStretcher::setPitchOption(Options options)
+{
+    m_d->setPitchOption(options);
+}
+
+void
+RubberBandStretcher::setExpectedInputDuration(size_t samples) 
+{
+    m_d->setExpectedInputDuration(samples);
+}
+
+void
+RubberBandStretcher::setMaxProcessSize(size_t samples)
+{
+    m_d->setMaxProcessSize(samples);
+}
+
+void
+RubberBandStretcher::setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+{
+    m_d->setKeyFrameMap(mapping);
+}
+
+size_t
+RubberBandStretcher::getSamplesRequired() const
+{
+    return m_d->getSamplesRequired();
+}
+
+void
+RubberBandStretcher::study(const float *const *input, size_t samples,
+                           bool final)
+{
+    m_d->study(input, samples, final);
+}
+
+void
+RubberBandStretcher::process(const float *const *input, size_t samples,
+                             bool final)
+{
+    m_d->process(input, samples, final);
+}
+
+int
+RubberBandStretcher::available() const
+{
+    return m_d->available();
+}
+
+size_t
+RubberBandStretcher::retrieve(float *const *output, size_t samples) const
+{
+    return m_d->retrieve(output, samples);
+}
+
+float
+RubberBandStretcher::getFrequencyCutoff(int n) const
+{
+    return m_d->getFrequencyCutoff(n);
+}
+
+void
+RubberBandStretcher::setFrequencyCutoff(int n, float f) 
+{
+    m_d->setFrequencyCutoff(n, f);
+}
+
+size_t
+RubberBandStretcher::getInputIncrement() const
+{
+    return m_d->getInputIncrement();
+}
+
+std::vector<int>
+RubberBandStretcher::getOutputIncrements() const
+{
+    return m_d->getOutputIncrements();
+}
+
+std::vector<float>
+RubberBandStretcher::getPhaseResetCurve() const
+{
+    return m_d->getPhaseResetCurve();
+}
+
+std::vector<int>
+RubberBandStretcher::getExactTimePoints() const
+{
+    return m_d->getExactTimePoints();
+}
+
+size_t
+RubberBandStretcher::getChannelCount() const
+{
+    return m_d->getChannelCount();
+}
+
+void
+RubberBandStretcher::calculateStretch()
+{
+    m_d->calculateStretch();
+}
+
+void
+RubberBandStretcher::setDebugLevel(int level)
+{
+    m_d->setDebugLevel(level);
+}
+
+void
+RubberBandStretcher::setDefaultDebugLevel(int level)
+{
+    Impl::setDefaultDebugLevel(level);
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/StretchCalculator.cpp
+++ b/pedalboard/vendors/rubberband/src/StretchCalculator.cpp
@@ -1,0 +1,1145 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretchCalculator.h"
+
+#include <math.h>
+#include <iostream>
+#include <deque>
+#include <set>
+#include <cassert>
+#include <algorithm>
+
+#include "system/sysutils.h"
+
+namespace RubberBand
+{
+	
+StretchCalculator::StretchCalculator(size_t sampleRate,
+                                     size_t inputIncrement,
+                                     bool useHardPeaks) :
+    m_sampleRate(sampleRate),
+    m_increment(inputIncrement),
+    m_prevDf(0),
+    m_prevRatio(1.0),
+    m_prevTimeRatio(1.0),
+    m_transientAmnesty(0),
+    m_debugLevel(0),
+    m_useHardPeaks(useHardPeaks),
+    m_inFrameCounter(0),
+    m_frameCheckpoint(0, 0),
+    m_outFrameCounter(0)
+{
+//    std::cerr << "StretchCalculator::StretchCalculator: useHardPeaks = " << useHardPeaks << std::endl;
+}    
+
+StretchCalculator::~StretchCalculator()
+{
+}
+
+void
+StretchCalculator::setKeyFrameMap(const std::map<size_t, size_t> &mapping)
+{
+    m_keyFrameMap = mapping;
+
+    // Ensure we always have a 0 -> 0 mapping. If there's nothing in
+    // the map at all, don't need to worry about this (empty map is
+    // handled separately anyway)
+    if (!m_keyFrameMap.empty()) {
+        if (m_keyFrameMap.find(0) == m_keyFrameMap.end()) {
+            m_keyFrameMap[0] = 0;
+        }
+    }
+}
+
+std::vector<int>
+StretchCalculator::calculate(double ratio, size_t inputDuration,
+                             const std::vector<float> &phaseResetDf,
+                             const std::vector<float> &stretchDf)
+{
+    assert(phaseResetDf.size() == stretchDf.size());
+    
+    m_peaks = findPeaks(phaseResetDf);
+
+    size_t totalCount = phaseResetDf.size();
+
+    size_t outputDuration = lrint(inputDuration * ratio);
+
+    if (m_debugLevel > 0) {
+        std::cerr << "StretchCalculator::calculate(): inputDuration " << inputDuration << ", ratio " << ratio << ", outputDuration " << outputDuration;
+    }
+
+    outputDuration = lrint((phaseResetDf.size() * m_increment) * ratio);
+
+    if (m_debugLevel > 0) {
+        std::cerr << " (rounded up to " << outputDuration << ")";
+        std::cerr << ", df size " << phaseResetDf.size() << ", increment "
+                  << m_increment << std::endl;
+    }
+
+    std::vector<Peak> peaks; // peak position (in chunks) and hardness
+    std::vector<size_t> targets; // targets for mapping peaks (in samples)
+    mapPeaks(peaks, targets, outputDuration, totalCount);
+
+    if (m_debugLevel > 1) {
+        std::cerr << "have " << peaks.size() << " fixed positions" << std::endl;
+    }
+
+    size_t totalInput = 0, totalOutput = 0;
+
+    // For each region between two consecutive time sync points, we
+    // want to take the number of output chunks to be allocated and
+    // the detection function values within the range, and produce a
+    // series of increments that sum to the number of output chunks,
+    // such that each increment is displaced from the input increment
+    // by an amount inversely proportional to the magnitude of the
+    // stretch detection function at that input step.
+
+    size_t regionTotalChunks = 0;
+
+    std::vector<int> increments;
+
+    for (size_t i = 0; i <= peaks.size(); ++i) {
+        
+        size_t regionStart, regionStartChunk, regionEnd, regionEndChunk;
+        bool phaseReset = false;
+
+        if (i == 0) {
+            regionStartChunk = 0;
+            regionStart = 0;
+        } else {
+            regionStartChunk = peaks[i-1].chunk;
+            regionStart = targets[i-1];
+            phaseReset = peaks[i-1].hard;
+        }
+
+        if (i == peaks.size()) {
+//            std::cerr << "note: i (=" << i << ") == peaks.size(); regionEndChunk " << regionEndChunk << " -> " << totalCount << ", regionEnd " << regionEnd << " -> " << outputDuration << std::endl;
+            regionEndChunk = totalCount;
+            regionEnd = outputDuration;
+        } else {
+            regionEndChunk = peaks[i].chunk;
+            regionEnd = targets[i];
+        }
+
+        if (regionStartChunk > totalCount) regionStartChunk = totalCount;
+        if (regionStart > outputDuration) regionStart = outputDuration;
+        if (regionEndChunk > totalCount) regionEndChunk = totalCount;
+        if (regionEnd > outputDuration) regionEnd = outputDuration;
+        
+        size_t regionDuration = regionEnd - regionStart;
+        regionTotalChunks += regionDuration;
+
+        std::vector<float> dfRegion;
+
+        for (size_t j = regionStartChunk; j != regionEndChunk; ++j) {
+            dfRegion.push_back(stretchDf[j]);
+        }
+
+        if (m_debugLevel > 1) {
+            std::cerr << "distributeRegion from " << regionStartChunk << " to " << regionEndChunk << " (samples " << regionStart << " to " << regionEnd << ")" << std::endl;
+        }
+
+        dfRegion = smoothDF(dfRegion);
+        
+        std::vector<int> regionIncrements = distributeRegion
+            (dfRegion, regionDuration, ratio, phaseReset);
+
+        size_t totalForRegion = 0;
+
+        for (size_t j = 0; j < regionIncrements.size(); ++j) {
+
+            int incr = regionIncrements[j];
+
+            if (j == 0 && phaseReset) increments.push_back(-incr);
+            else increments.push_back(incr);
+
+            if (incr > 0) totalForRegion += incr;
+            else totalForRegion += -incr;
+
+            totalInput += m_increment;
+        }
+
+        if (totalForRegion != regionDuration) {
+            std::cerr << "*** ERROR: distributeRegion returned wrong duration " << totalForRegion << ", expected " << regionDuration << std::endl;
+        }
+
+        totalOutput += totalForRegion;
+    }
+
+    if (m_debugLevel > 0) {
+        std::cerr << "total input increment = " << totalInput << " (= " << totalInput / m_increment << " chunks), output = " << totalOutput << ", ratio = " << double(totalOutput)/double(totalInput) << ", ideal output " << size_t(ceil(totalInput * ratio)) << std::endl;
+        std::cerr << "(region total = " << regionTotalChunks << ")" << std::endl;
+    }
+
+    return increments;
+}
+
+void
+StretchCalculator::mapPeaks(std::vector<Peak> &peaks,
+                            std::vector<size_t> &targets,
+                            size_t outputDuration,
+                            size_t totalCount)
+{
+    // outputDuration is in audio samples; totalCount is in chunks
+
+    if (m_keyFrameMap.empty()) {
+        // "normal" behaviour -- fixed points are strictly in
+        // proportion
+        peaks = m_peaks;
+        for (size_t i = 0; i < peaks.size(); ++i) {
+            targets.push_back
+                (lrint((double(peaks[i].chunk) * outputDuration) / totalCount));
+        }
+        return;
+    }
+
+    // We have been given a set of source -> target sample frames in
+    // m_keyFrameMap.  We want to ensure that (to the nearest chunk) these
+    // are followed exactly, and any fixed points that we calculated
+    // ourselves are interpolated in linear proportion in between.
+
+    size_t peakidx = 0;
+    std::map<size_t, size_t>::const_iterator mi = m_keyFrameMap.begin();
+
+    // NB we know for certain we have a mapping from 0 -> 0 (or at
+    // least, some mapping for source sample 0) because that is
+    // enforced in setKeyFrameMap above.  However, we aren't guaranteed
+    // to have a mapping for the total duration -- we will usually
+    // need to assume it maps to the normal duration * ratio sample
+
+    while (mi != m_keyFrameMap.end()) {
+
+//        std::cerr << "mi->first is " << mi->first << ", second is " << mi->second <<std::endl;
+
+        // The map we've been given is from sample to sample, but
+        // we can only map from chunk to sample.  We should perhaps
+        // adjust the target sample to compensate for the discrepancy
+        // between the chunk position and the exact requested source
+        // sample.  But we aren't doing that yet.
+
+        size_t sourceStartChunk = mi->first / m_increment;
+        size_t sourceEndChunk = totalCount;
+
+        size_t targetStartSample = mi->second;
+        size_t targetEndSample = outputDuration;
+
+        ++mi;
+        if (mi != m_keyFrameMap.end()) {
+            sourceEndChunk = mi->first / m_increment;
+            targetEndSample = mi->second;
+        }
+
+        if (sourceStartChunk >= totalCount ||
+            sourceStartChunk >= sourceEndChunk ||
+            targetStartSample >= outputDuration ||
+            targetStartSample >= targetEndSample) {
+            std::cerr << "NOTE: ignoring mapping from chunk " << sourceStartChunk << " to sample " << targetStartSample << "\n(source or target chunk exceeds total count, or end is not later than start)" << std::endl;
+            continue;
+        }
+        
+        // one peak and target for the mapping, then one for each of
+        // the computed peaks that appear before the following mapping
+
+        Peak p;
+        p.chunk = sourceStartChunk;
+        p.hard = false; // mappings are in time only, not phase reset points
+        peaks.push_back(p);
+        targets.push_back(targetStartSample);
+
+        if (m_debugLevel > 1) {
+            std::cerr << "mapped chunk " << sourceStartChunk << " (frame " << sourceStartChunk * m_increment << ") -> " << targetStartSample << std::endl;
+        }
+
+        while (peakidx < m_peaks.size()) {
+
+            size_t pchunk = m_peaks[peakidx].chunk;
+
+            if (pchunk < sourceStartChunk) {
+                // shouldn't happen, should have been dealt with
+                // already -- but no harm in ignoring it explicitly
+                ++peakidx;
+                continue;
+            }
+            if (pchunk == sourceStartChunk) {
+                // convert that last peak to a hard one, after all
+                peaks[peaks.size()-1].hard = true;
+                ++peakidx;
+                continue;
+            }
+            if (pchunk >= sourceEndChunk) {
+                // leave the rest for after the next mapping
+                break;
+            }
+            p.chunk = pchunk;
+            p.hard = m_peaks[peakidx].hard;
+
+            double proportion =
+                double(pchunk - sourceStartChunk) /
+                double(sourceEndChunk - sourceStartChunk);
+            
+            size_t target =
+                targetStartSample +
+                lrint(proportion *
+                      (targetEndSample - targetStartSample));
+
+            if (target <= targets[targets.size()-1] + m_increment) {
+                // peaks will become too close together afterwards, ignore
+                ++peakidx;
+                continue;
+            }
+
+            if (m_debugLevel > 1) {
+                std::cerr << "  peak chunk " << pchunk << " (frame " << pchunk * m_increment << ") -> " << target << std::endl;
+            }
+
+            peaks.push_back(p);
+            targets.push_back(target);
+            ++peakidx;
+        }
+    }
+}    
+
+int64_t
+StretchCalculator::expectedOutFrame(int64_t inFrame, double timeRatio)
+{
+    int64_t checkpointedAt = m_frameCheckpoint.first;
+    int64_t checkpointed = m_frameCheckpoint.second;
+    return int64_t(round(checkpointed + (inFrame - checkpointedAt) * timeRatio));
+}
+
+int
+StretchCalculator::calculateSingle(double timeRatio,
+                                   double effectivePitchRatio,
+                                   float df,
+                                   size_t inIncrement,
+                                   size_t analysisWindowSize,
+                                   size_t synthesisWindowSize)
+{
+    double ratio = timeRatio / effectivePitchRatio;
+    
+    int increment = int(inIncrement);
+    if (increment == 0) increment = m_increment;
+
+    int outIncrement = lrint(increment * ratio); // the normal case
+    bool isTransient = false;
+    
+    // We want to ensure, as close as possible, that the phase reset
+    // points appear at the right audio frame numbers. To this end we
+    // track the incoming frame number, its corresponding expected
+    // output frame number, and the actual output frame number
+    // projected based on the ratios provided.
+    //
+    // There are two subtleties:
+    // 
+    // (1) on a ratio change, we need to checkpoint the expected
+    // output frame number reached so far and start counting again
+    // with the new ratio. We could do this with a reset to zero, but
+    // it's easier to reason about absolute input/output frame
+    // matches, so for the moment at least we're doing this by
+    // explicitly checkpointing the current numbers (hence the use of
+    // the above expectedOutFrame() function which refers to the
+    // last checkpointed values).
+    //
+    // (2) in the case of a pitch shift in a configuration where
+    // resampling occurs after stretching, all of our output
+    // increments will be effectively modified by resampling after we
+    // return. This is why we separate out timeRatio and
+    // effectivePitchRatio arguments - the former is the ratio that
+    // has already been applied and the latter is the ratio that will
+    // be applied by any subsequent resampling step (which will be 1.0
+    // / pitchScale if resampling is happening after stretching). So
+    // the overall ratio is timeRatio / effectivePitchRatio.
+
+    bool ratioChanged = (ratio != m_prevRatio);
+    if (ratioChanged) {
+        // Reset our frame counters from the ratio change.
+
+        // m_outFrameCounter tracks the frames counted at output from
+        // this function, which normally precedes resampling - hence
+        // the use of timeRatio rather than ratio here
+
+        if (m_debugLevel > 1) {
+            std::cerr << "StretchCalculator: ratio changed from " << m_prevRatio << " to " << ratio << std::endl;
+        }
+
+        int64_t toCheckpoint = expectedOutFrame
+            (m_inFrameCounter, m_prevTimeRatio);
+        m_frameCheckpoint =
+            std::pair<int64_t, int64_t>(m_inFrameCounter, toCheckpoint);
+    }
+    
+    m_prevRatio = ratio;
+    m_prevTimeRatio = timeRatio;
+
+    if (m_debugLevel > 2) {
+        std::cerr << "StretchCalculator::calculateSingle: timeRatio = "
+                  << timeRatio << ", effectivePitchRatio = "
+                  << effectivePitchRatio << " (that's 1.0 / "
+                  << (1.0 / effectivePitchRatio)
+                  << "), ratio = " << ratio << ", df = " << df
+                  << ", inIncrement = " << inIncrement
+                  << ", default outIncrement = " << outIncrement
+                  << ", analysisWindowSize = " << analysisWindowSize
+                  << ", synthesisWindowSize = " << synthesisWindowSize
+                  << std::endl;
+
+        std::cerr << "inFrameCounter = " << m_inFrameCounter
+                  << ", outFrameCounter = " << m_outFrameCounter
+                  << std::endl;
+
+        std::cerr << "The next sample out is input sample " << m_inFrameCounter << std::endl;
+    }
+    
+    int64_t intended = expectedOutFrame
+        (m_inFrameCounter + analysisWindowSize/4, timeRatio);
+    int64_t projected = int64_t
+        (round(m_outFrameCounter + (synthesisWindowSize/4 * effectivePitchRatio)));
+
+    int64_t divergence = projected - intended;
+
+    if (m_debugLevel > 2) {
+        std::cerr << "for current frame + quarter frame: intended " << intended << ", projected " << projected << ", divergence " << divergence << std::endl;
+    }
+    
+    // In principle, the threshold depends on chunk size: larger chunk
+    // sizes need higher thresholds.  Since chunk size depends on
+    // ratio, I suppose we could in theory calculate the threshold
+    // from the ratio directly.  For the moment we're happy if it
+    // works well in common situations.
+
+    float transientThreshold = 0.35f;
+//    if (ratio > 1) transientThreshold = 0.25f;
+
+    if (m_useHardPeaks && df > m_prevDf * 1.1f && df > transientThreshold) {
+        if (divergence > 1000 || divergence < -1000) {
+            if (m_debugLevel > 1) {
+                std::cerr << "StretchCalculator::calculateSingle: transient, but we're not permitting it because the divergence (" << divergence << ") is too great" << std::endl;
+            }
+        } else {
+            isTransient = true;
+        }
+    }
+
+    if (m_debugLevel > 2) {
+        std::cerr << "df = " << df << ", prevDf = " << m_prevDf
+                  << ", thresh = " << transientThreshold << std::endl;
+    }
+
+    m_prevDf = df;
+
+    if (m_transientAmnesty > 0) {
+        if (isTransient) {
+            if (m_debugLevel > 1) {
+                std::cerr << "StretchCalculator::calculateSingle: transient, but we have an amnesty (df " << df << ", threshold " << transientThreshold << ")" << std::endl;
+            }
+            isTransient = false;
+        }
+        --m_transientAmnesty;
+    }
+            
+    if (isTransient) {
+        if (m_debugLevel > 1) {
+            std::cerr << "StretchCalculator::calculateSingle: transient at (df " << df << ", threshold " << transientThreshold << ")" << std::endl;
+        }
+
+        // as in offline mode, 0.05 sec approx min between transients
+        m_transientAmnesty =
+            lrint(ceil(double(m_sampleRate) / (20 * double(increment))));
+
+        outIncrement = increment;
+
+    } else {
+
+        double recovery = 0.0;
+        if (divergence > 1000 || divergence < -1000) {
+            recovery = divergence / ((m_sampleRate / 10.0) / increment);
+        } else if (divergence > 100 || divergence < -100) {
+            recovery = divergence / ((m_sampleRate / 20.0) / increment);
+        } else {
+            recovery = divergence / 4.0;
+        }
+
+        int incr = lrint(outIncrement - recovery);
+        if (m_debugLevel > 2 || (m_debugLevel > 1 && divergence != 0)) {
+            std::cerr << "divergence = " << divergence << ", recovery = " << recovery << ", incr = " << incr << ", ";
+        }
+
+        int minIncr = lrint(increment * ratio * 0.3);
+        int maxIncr = lrint(increment * ratio * 2);
+        
+        if (incr < minIncr) {
+            incr = minIncr;
+        } else if (incr > maxIncr) {
+            incr = maxIncr;
+        }
+
+        if (m_debugLevel > 2 || (m_debugLevel > 1 && divergence != 0)) {
+            std::cerr << "clamped into [" << minIncr << ", " << maxIncr
+                      << "] becomes " << incr << std::endl;
+        }
+
+        if (incr < 0) {
+            std::cerr << "WARNING: internal error: incr < 0 in calculateSingle"
+                      << std::endl;
+            outIncrement = 0;
+        } else {
+            outIncrement = incr;
+        }
+    }
+
+    if (m_debugLevel > 1) {
+        std::cerr << "StretchCalculator::calculateSingle: returning isTransient = "
+                  << isTransient << ", outIncrement = " << outIncrement
+                  << std::endl;
+    }
+
+    m_inFrameCounter += inIncrement;
+    m_outFrameCounter += outIncrement * effectivePitchRatio;
+    
+    if (isTransient) {
+        return -outIncrement;
+    } else {
+        return outIncrement;
+    }
+}
+
+void
+StretchCalculator::reset()
+{
+    m_prevDf = 0;
+    m_prevRatio = 1.0;
+    m_prevTimeRatio = 1.0;
+    m_inFrameCounter = 0;
+    m_frameCheckpoint = std::pair<int64_t, int64_t>(0, 0);
+    m_outFrameCounter = 0.0;
+    m_transientAmnesty = 0;
+    m_keyFrameMap.clear();
+}
+
+std::vector<StretchCalculator::Peak>
+StretchCalculator::findPeaks(const std::vector<float> &rawDf)
+{
+    std::vector<float> df = smoothDF(rawDf);
+
+    // We distinguish between "soft" and "hard" peaks.  A soft peak is
+    // simply the result of peak-picking on the smoothed onset
+    // detection function, and it represents any (strong-ish) onset.
+    // We aim to ensure always that soft peaks are placed at the
+    // correct position in time.  A hard peak is where there is a very
+    // rapid rise in detection function, and it presumably represents
+    // a more broadband, noisy transient.  For these we perform a
+    // phase reset (if in the appropriate mode), and we locate the
+    // reset at the first point where we notice enough of a rapid
+    // rise, rather than necessarily at the peak itself, in order to
+    // preserve the shape of the transient.
+            
+    std::set<size_t> hardPeakCandidates;
+    std::set<size_t> softPeakCandidates;
+
+    if (m_useHardPeaks) {
+
+        // 0.05 sec approx min between hard peaks
+        size_t hardPeakAmnesty = lrint(ceil(double(m_sampleRate) /
+                                            (20 * double(m_increment))));
+        size_t prevHardPeak = 0;
+
+        if (m_debugLevel > 1) {
+            std::cerr << "hardPeakAmnesty = " << hardPeakAmnesty << std::endl;
+        }
+
+        for (size_t i = 1; i + 1 < df.size(); ++i) {
+
+            if (df[i] < 0.1) continue;
+            if (df[i] <= df[i-1] * 1.1) continue;
+            if (df[i] < 0.22) continue;
+
+            if (!hardPeakCandidates.empty() &&
+                i < prevHardPeak + hardPeakAmnesty) {
+                continue;
+            }
+
+            bool hard = (df[i] > 0.4);
+            
+            if (hard && (m_debugLevel > 1)) {
+                std::cerr << "hard peak at " << i << ": " << df[i] 
+                          << " > absolute " << 0.4
+                          << std::endl;
+            }
+
+            if (!hard) {
+                hard = (df[i] > df[i-1] * 1.4);
+
+                if (hard && (m_debugLevel > 1)) {
+                    std::cerr << "hard peak at " << i << ": " << df[i] 
+                              << " > prev " << df[i-1] << " * 1.4"
+                              << std::endl;
+                }
+            }
+
+            if (!hard && i > 1) {
+                hard = (df[i]   > df[i-1] * 1.2 &&
+                        df[i-1] > df[i-2] * 1.2);
+
+                if (hard && (m_debugLevel > 1)) {
+                    std::cerr << "hard peak at " << i << ": " << df[i] 
+                              << " > prev " << df[i-1] << " * 1.2 and "
+                              << df[i-1] << " > prev " << df[i-2] << " * 1.2"
+                              << std::endl;
+                }
+            }
+
+            if (!hard && i > 2) {
+                // have already established that df[i] > df[i-1] * 1.1
+                hard = (df[i] > 0.3 &&
+                        df[i-1] > df[i-2] * 1.1 &&
+                        df[i-2] > df[i-3] * 1.1);
+
+                if (hard && (m_debugLevel > 1)) {
+                    std::cerr << "hard peak at " << i << ": " << df[i] 
+                              << " > prev " << df[i-1] << " * 1.1 and "
+                              << df[i-1] << " > prev " << df[i-2] << " * 1.1 and "
+                              << df[i-2] << " > prev " << df[i-3] << " * 1.1"
+                              << std::endl;
+                }
+            }
+
+            if (!hard) continue;
+
+//            (df[i+1] > df[i] && df[i+1] > df[i-1] * 1.8) ||
+//                df[i] > 0.4) {
+
+            size_t peakLocation = i;
+
+            if (i + 1 < rawDf.size() &&
+                rawDf[i + 1] > rawDf[i] * 1.4) {
+
+                ++peakLocation;
+
+                if (m_debugLevel > 1) {
+                    std::cerr << "pushing hard peak forward to " << peakLocation << ": " << df[peakLocation] << " > " << df[peakLocation-1] << " * " << 1.4 << std::endl;
+                }
+            }
+
+            hardPeakCandidates.insert(peakLocation);
+            prevHardPeak = peakLocation;
+        }
+    }
+
+    size_t medianmaxsize = lrint(ceil(double(m_sampleRate) /
+                                 double(m_increment))); // 1 sec ish
+
+    if (m_debugLevel > 1) {
+        std::cerr << "mediansize = " << medianmaxsize << std::endl;
+    }
+    if (medianmaxsize < 7) {
+        medianmaxsize = 7;
+        if (m_debugLevel > 1) {
+            std::cerr << "adjusted mediansize = " << medianmaxsize << std::endl;
+        }
+    }
+
+    int minspacing = lrint(ceil(double(m_sampleRate) /
+                                (20 * double(m_increment)))); // 0.05 sec ish
+    
+    std::deque<float> medianwin;
+    std::vector<float> sorted;
+    int softPeakAmnesty = 0;
+
+    for (size_t i = 0; i < medianmaxsize/2; ++i) {
+        medianwin.push_back(0);
+    }
+    for (size_t i = 0; i < medianmaxsize/2 && i < df.size(); ++i) {
+        medianwin.push_back(df[i]);
+    }
+
+    size_t lastSoftPeak = 0;
+
+    for (size_t i = 0; i < df.size(); ++i) {
+        
+        size_t mediansize = medianmaxsize;
+
+        if (medianwin.size() < mediansize) {
+            mediansize = medianwin.size();
+        }
+
+        size_t middle = medianmaxsize / 2;
+        if (middle >= mediansize) middle = mediansize-1;
+
+        size_t nextDf = i + mediansize - middle;
+
+        if (mediansize < 2) {
+            if (mediansize > medianmaxsize) { // absurd, but never mind that
+                medianwin.pop_front();
+            }
+            if (nextDf < df.size()) {
+                medianwin.push_back(df[nextDf]);
+            } else {
+                medianwin.push_back(0);
+            }
+            continue;
+        }
+
+        if (m_debugLevel > 2) {
+//            std::cerr << "have " << mediansize << " in median buffer" << std::endl;
+        }
+
+        sorted.clear();
+        for (size_t j = 0; j < mediansize; ++j) {
+            sorted.push_back(medianwin[j]);
+        }
+        std::sort(sorted.begin(), sorted.end());
+
+        size_t n = 90; // percentile above which we pick peaks
+        size_t index = (sorted.size() * n) / 100;
+        if (index >= sorted.size()) index = sorted.size()-1;
+        if (index == sorted.size()-1 && index > 0) --index;
+        float thresh = sorted[index];
+
+//        if (m_debugLevel > 2) {
+//            std::cerr << "medianwin[" << middle << "] = " << medianwin[middle] << ", thresh = " << thresh << std::endl;
+//            if (medianwin[middle] == 0.f) {
+//                std::cerr << "contents: ";
+//                for (size_t j = 0; j < medianwin.size(); ++j) {
+//                    std::cerr << medianwin[j] << " ";
+//                }
+//                std::cerr << std::endl;
+//            }
+//        }
+
+        if (medianwin[middle] > thresh &&
+            medianwin[middle] > medianwin[middle-1] &&
+            medianwin[middle] > medianwin[middle+1] &&
+            softPeakAmnesty == 0) {
+
+            size_t maxindex = middle;
+            float maxval = medianwin[middle];
+
+            for (size_t j = middle+1; j < mediansize; ++j) {
+                if (medianwin[j] > maxval) {
+                    maxval = medianwin[j];
+                    maxindex = j;
+                } else if (medianwin[j] < medianwin[middle]) {
+                    break;
+                }
+            }
+
+            size_t peak = i + maxindex - middle;
+
+//            std::cerr << "i = " << i << ", maxindex = " << maxindex << ", middle = " << middle << ", so peak at " << peak << std::endl;
+
+            if (softPeakCandidates.empty() || lastSoftPeak != peak) {
+
+                if (m_debugLevel > 1) {
+                    std::cerr << "soft peak at " << peak << " ("
+                              << peak * m_increment << "): "
+                              << medianwin[middle] << " > "
+                              << thresh << " and "
+                              << medianwin[middle]
+                              << " > " << medianwin[middle-1] << " and "
+                              << medianwin[middle]
+                              << " > " << medianwin[middle+1]
+                              << std::endl;
+                }
+
+                if (peak >= df.size()) {
+                    if (m_debugLevel > 2) {
+                        std::cerr << "peak is beyond end"  << std::endl;
+                    }
+                } else {
+                    softPeakCandidates.insert(peak);
+                    lastSoftPeak = peak;
+                }
+            }
+
+            softPeakAmnesty = minspacing + maxindex - middle;
+            if (m_debugLevel > 2) {
+                std::cerr << "amnesty = " << softPeakAmnesty << std::endl;
+            }
+
+        } else if (softPeakAmnesty > 0) --softPeakAmnesty;
+
+        if (mediansize >= medianmaxsize) {
+            medianwin.pop_front();
+        }
+        if (nextDf < df.size()) {
+            medianwin.push_back(df[nextDf]);
+        } else {
+            medianwin.push_back(0);
+        }
+    }
+
+    std::vector<Peak> peaks;
+
+    while (!hardPeakCandidates.empty() || !softPeakCandidates.empty()) {
+
+        bool haveHardPeak = !hardPeakCandidates.empty();
+        bool haveSoftPeak = !softPeakCandidates.empty();
+
+        size_t hardPeak = (haveHardPeak ? *hardPeakCandidates.begin() : 0);
+        size_t softPeak = (haveSoftPeak ? *softPeakCandidates.begin() : 0);
+
+        Peak peak;
+        peak.hard = false;
+        peak.chunk = softPeak;
+
+        bool ignore = false;
+
+        if (haveHardPeak &&
+            (!haveSoftPeak || hardPeak <= softPeak)) {
+
+            if (m_debugLevel > 2) {
+                std::cerr << "Hard peak: " << hardPeak << std::endl;
+            }
+
+            peak.hard = true;
+            peak.chunk = hardPeak;
+            hardPeakCandidates.erase(hardPeakCandidates.begin());
+
+        } else {
+            if (m_debugLevel > 2) {
+                std::cerr << "Soft peak: " << softPeak << std::endl;
+            }
+            if (!peaks.empty() &&
+                peaks[peaks.size()-1].hard &&
+                peaks[peaks.size()-1].chunk + 3 >= softPeak) {
+                if (m_debugLevel > 2) {
+                    std::cerr << "(ignoring, as we just had a hard peak)"
+                              << std::endl;
+                }
+                ignore = true;
+            }
+        }            
+
+        if (haveSoftPeak && peak.chunk == softPeak) {
+            softPeakCandidates.erase(softPeakCandidates.begin());
+        }
+
+        if (!ignore) {
+            peaks.push_back(peak);
+        }
+    }                
+
+    return peaks;
+}
+
+std::vector<float>
+StretchCalculator::smoothDF(const std::vector<float> &df)
+{
+    std::vector<float> smoothedDF;
+    
+    for (size_t i = 0; i < df.size(); ++i) {
+        // three-value moving mean window for simple smoothing
+        float total = 0.f, count = 0;
+        if (i > 0) { total += df[i-1]; ++count; }
+        total += df[i]; ++count;
+        if (i+1 < df.size()) { total += df[i+1]; ++count; }
+        float mean = total / count;
+        smoothedDF.push_back(mean);
+    }
+
+    return smoothedDF;
+}
+
+std::vector<int>
+StretchCalculator::distributeRegion(const std::vector<float> &dfIn,
+                                    size_t duration, float ratio, bool phaseReset)
+{
+    std::vector<float> df(dfIn);
+    std::vector<int> increments;
+
+    // The peak for the stretch detection function may appear after
+    // the peak that we're using to calculate the start of the region.
+    // We don't want that.  If we find a peak in the first half of
+    // the region, we should set all the values up to that point to
+    // the same value as the peak.
+
+    // (This might not be subtle enough, especially if the region is
+    // long -- we want a bound that corresponds to acoustic perception
+    // of the audible bounce.)
+
+    for (size_t i = 1; i < df.size()/2; ++i) {
+        if (df[i] < df[i-1]) {
+            if (m_debugLevel > 1) {
+                std::cerr << "stretch peak offset: " << i-1 << " (peak " << df[i-1] << ")" << std::endl;
+            }
+            for (size_t j = 0; j < i-1; ++j) {
+                df[j] = df[i-1];
+            }
+            break;
+        }
+    }
+
+    float maxDf = 0;
+
+    for (size_t i = 0; i < df.size(); ++i) {
+        if (i == 0 || df[i] > maxDf) maxDf = df[i];
+    }
+
+    // We want to try to ensure the last 100ms or so (if possible) are
+    // tending back towards the maximum df, so that the stretchiness
+    // reduces at the end of the stretched region.
+    
+    int reducedRegion = lrint((0.1 * m_sampleRate) / m_increment);
+    if (reducedRegion > int(df.size()/5)) reducedRegion = df.size()/5;
+
+    for (int i = 0; i < reducedRegion; ++i) {
+        size_t index = df.size() - reducedRegion + i;
+        df[index] = df[index] + ((maxDf - df[index]) * i) / reducedRegion;
+    }
+
+    long toAllot = long(duration) - long(m_increment * df.size());
+    
+    if (m_debugLevel > 1) {
+        std::cerr << "region of " << df.size() << " chunks, output duration " << duration << ", increment " << m_increment << ", toAllot " << toAllot << std::endl;
+    }
+
+    size_t totalIncrement = 0;
+
+    // We place limits on the amount of displacement per chunk.  if
+    // ratio < 0, no increment should be larger than increment*ratio
+    // or smaller than increment*ratio/2; if ratio > 0, none should be
+    // smaller than increment*ratio or larger than increment*ratio*2.
+    // We need to enforce this in the assignment of displacements to
+    // allotments, not by trying to respond if something turns out
+    // wrong.
+
+    // Note that the ratio is only provided to this function for the
+    // purposes of establishing this bound to the displacement.
+    
+    // so if
+    // maxDisplacement / totalDisplacement > increment * ratio*2 - increment
+    // (for ratio > 1)
+    // or
+    // maxDisplacement / totalDisplacement < increment * ratio/2
+    // (for ratio < 1)
+
+    // then we need to adjust and accommodate
+    
+    double totalDisplacement = 0;
+    double maxDisplacement = 0; // min displacement will be 0 by definition
+
+    maxDf = 0;
+    float adj = 0;
+
+    bool tooShort = true, tooLong = true;
+    const int acceptableIterations = 10;
+    int iteration = 0;
+    int prevExtreme = 0;
+    bool better = false;
+
+    while ((tooLong || tooShort) && iteration < acceptableIterations) {
+
+        ++iteration;
+
+        tooLong = false;
+        tooShort = false;
+        calculateDisplacements(df, maxDf, totalDisplacement, maxDisplacement,
+                               adj);
+
+        if (m_debugLevel > 1) {
+            std::cerr << "totalDisplacement " << totalDisplacement << ", max " << maxDisplacement << " (maxDf " << maxDf << ", df count " << df.size() << ")" << std::endl;
+        }
+
+        if (totalDisplacement == 0) {
+// Not usually a problem, in fact
+//            std::cerr << "WARNING: totalDisplacement == 0 (duration " << duration << ", " << df.size() << " values in df)" << std::endl;
+            if (!df.empty() && adj == 0) {
+                tooLong = true; tooShort = true;
+                adj = 1;
+            }
+            continue;
+        }
+
+        int extremeIncrement = m_increment +
+            lrint((toAllot * maxDisplacement) / totalDisplacement);
+
+        if (extremeIncrement < 0) {
+            if (m_debugLevel > 0) {
+                std::cerr << "NOTE: extreme increment " << extremeIncrement << " < 0, adjusting" << std::endl;
+            }
+            tooShort = true;
+        } else {
+            if (ratio < 1.0) {
+                if (extremeIncrement > lrint(ceil(m_increment * ratio))) {
+                    std::cerr << "WARNING: extreme increment "
+                              << extremeIncrement << " > "
+                              << m_increment * ratio << std::endl;
+                } else if (extremeIncrement < (m_increment * ratio) / 2) {
+                    if (m_debugLevel > 0) {
+                        std::cerr << "NOTE: extreme increment "
+                                  << extremeIncrement << " < " 
+                                  << (m_increment * ratio) / 2
+                                  << ", adjusting" << std::endl;
+                    }
+                    tooShort = true;
+                    if (iteration > 0) {
+                        better = (extremeIncrement > prevExtreme);
+                    }
+                    prevExtreme = extremeIncrement;
+                }
+            } else {
+                if (extremeIncrement > m_increment * ratio * 2) {
+                    if (m_debugLevel > 0) {
+                        std::cerr << "NOTE: extreme increment "
+                                  << extremeIncrement << " > "
+                                  << m_increment * ratio * 2
+                                  << ", adjusting" << std::endl;
+                    }
+                    tooLong = true;
+                    if (iteration > 0) {
+                        better = (extremeIncrement < prevExtreme);
+                    }
+                    prevExtreme = extremeIncrement;
+                } else if (extremeIncrement < lrint(floor(m_increment * ratio))) {
+                    std::cerr << "WARNING: extreme increment "
+                              << extremeIncrement << " < "
+                              << m_increment * ratio << std::endl;
+                }
+            }
+        }
+
+        if (tooLong || tooShort) {
+            // Need to make maxDisplacement smaller as a proportion of
+            // the total displacement, yet ensure that the
+            // displacements still sum to the total.
+            adj += maxDf/10;
+        }
+    }
+
+    if (tooLong) {
+        if (better) {
+            // we were iterating in the right direction, so
+            // leave things as they are (and undo that last tweak)
+            std::cerr << "WARNING: No acceptable displacement adjustment found, using latest values:\nthis region could sound bad" << std::endl;
+            adj -= maxDf/10;
+        } else {
+            std::cerr << "WARNING: No acceptable displacement adjustment found, using defaults:\nthis region could sound bad" << std::endl;
+            adj = 1;
+            calculateDisplacements(df, maxDf, totalDisplacement, maxDisplacement,
+                                   adj);
+        }
+    } else if (tooShort) {
+        std::cerr << "WARNING: No acceptable displacement adjustment found, using flat distribution:\nthis region could sound bad" << std::endl;
+        adj = 1;
+        for (size_t i = 0; i < df.size(); ++i) {
+            df[i] = 1.f;
+        }
+        calculateDisplacements(df, maxDf, totalDisplacement, maxDisplacement,
+                               adj);
+    }
+
+    for (size_t i = 0; i < df.size(); ++i) {
+
+        double displacement = maxDf - df[i];
+        if (displacement < 0) displacement -= adj;
+        else displacement += adj;
+
+        if (i == 0 && phaseReset) {
+            if (m_debugLevel > 2) {
+                std::cerr << "Phase reset at first chunk" << std::endl;
+            }
+            if (df.size() == 1) {
+                increments.push_back(duration);
+                totalIncrement += duration;
+            } else {
+                increments.push_back(m_increment);
+                totalIncrement += m_increment;
+            }
+            totalDisplacement -= displacement;
+            continue;
+        }
+
+        double theoreticalAllotment = 0;
+
+        if (totalDisplacement != 0) {
+            theoreticalAllotment = (toAllot * displacement) / totalDisplacement;
+        }
+        int allotment = lrint(theoreticalAllotment);
+        if (i + 1 == df.size()) allotment = toAllot;
+
+        int increment = m_increment + allotment;
+
+        if (increment < 0) {
+            // this is a serious problem, the allocation is quite
+            // wrong if it allows increment to diverge so far from the
+            // input increment (though it can happen legitimately if
+            // asked to squash very violently)
+            std::cerr << "*** WARNING: increment " << increment << " <= 0, rounding to zero" << std::endl;
+
+            toAllot += m_increment;
+            increment = 0;
+
+        } else {
+            toAllot -= allotment;
+        }
+
+        increments.push_back(increment);
+        totalIncrement += increment;
+
+        totalDisplacement -= displacement;
+
+        if (m_debugLevel > 2) {
+            std::cerr << "df " << df[i] << ", smoothed " << df[i] << ", disp " << displacement << ", allot " << theoreticalAllotment << ", incr " << increment << ", remain " << toAllot << std::endl;
+        }
+    }
+    
+    if (m_debugLevel > 2) {
+        std::cerr << "total increment: " << totalIncrement << ", left over: " << toAllot << " to allot, displacement " << totalDisplacement << std::endl;
+    }
+
+    if (totalIncrement != duration) {
+        std::cerr << "*** WARNING: calculated output duration " << totalIncrement << " != expected " << duration << std::endl;
+    }
+
+    return increments;
+}
+
+void
+StretchCalculator::calculateDisplacements(const std::vector<float> &df,
+                                          float &maxDf,
+                                          double &totalDisplacement,
+                                          double &maxDisplacement,
+                                          float adj) const
+{
+    totalDisplacement = maxDisplacement = 0;
+
+    maxDf = 0;
+
+    for (size_t i = 0; i < df.size(); ++i) {
+        if (i == 0 || df[i] > maxDf) maxDf = df[i];
+    }
+
+    for (size_t i = 0; i < df.size(); ++i) {
+        double displacement = maxDf - df[i];
+        if (displacement < 0) displacement -= adj;
+        else displacement += adj;
+        totalDisplacement += displacement;
+        if (i == 0 || displacement > maxDisplacement) {
+            maxDisplacement = displacement;
+        }
+    }
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/StretchCalculator.h
+++ b/pedalboard/vendors/rubberband/src/StretchCalculator.h
@@ -1,0 +1,127 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCH_CALCULATOR_H
+#define RUBBERBAND_STRETCH_CALCULATOR_H
+
+#include <sys/types.h>
+
+#include <vector>
+#include <map>
+
+namespace RubberBand
+{
+
+class StretchCalculator
+{
+public:
+    StretchCalculator(size_t sampleRate, size_t inputIncrement, bool useHardPeaks);
+    virtual ~StretchCalculator();
+
+    /**
+     * Provide a set of mappings from "before" to "after" sample
+     * numbers so as to enforce a particular stretch profile.  This
+     * must be called before calculate().  The argument is a map from
+     * audio sample frame number in the source material to the
+     * corresponding sample frame number in the stretched output.
+     */
+    void setKeyFrameMap(const std::map<size_t, size_t> &mapping);
+    
+    /**
+     * Calculate phase increments for a region of audio, given the
+     * overall target stretch ratio, input duration in audio samples,
+     * and the audio curves to use for identifying phase lock points
+     * (lockAudioCurve) and for allocating stretches to relatively
+     * less prominent points (stretchAudioCurve).
+     */
+    std::vector<int> calculate(double ratio, size_t inputDuration,
+                               const std::vector<float> &lockAudioCurve,
+                               const std::vector<float> &stretchAudioCurve);
+
+    /**
+     * Calculate the phase increment for a single audio block, given
+     * the overall target stretch ratio and the block's value on the
+     * phase-lock audio curve.  State is retained between calls in the
+     * StretchCalculator object; call reset() to reset it.  This uses
+     * a less sophisticated method than the offline calculate().
+     *
+     * If increment is non-zero, use it for the input increment for
+     * this block in preference to m_increment.
+     */
+    int calculateSingle(double timeRatio,
+                        double effectivePitchRatio,
+                        float curveValue,
+                        size_t increment,
+                        size_t analysisWindowSize,
+                        size_t synthesisWindowSize);
+
+    void setUseHardPeaks(bool use) { m_useHardPeaks = use; }
+
+    void reset();
+  
+    void setDebugLevel(int level) { m_debugLevel = level; }
+
+    struct Peak {
+        size_t chunk;
+        bool hard;
+    };
+    std::vector<Peak> getLastCalculatedPeaks() const { return m_peaks; }
+
+    std::vector<float> smoothDF(const std::vector<float> &df);
+
+protected:
+    std::vector<Peak> findPeaks(const std::vector<float> &audioCurve);
+
+    void mapPeaks(std::vector<Peak> &peaks, std::vector<size_t> &targets,
+                  size_t outputDuration, size_t totalCount);
+
+    std::vector<int> distributeRegion(const std::vector<float> &regionCurve,
+                                      size_t outputDuration, float ratio,
+                                      bool phaseReset);
+
+    void calculateDisplacements(const std::vector<float> &df,
+                                float &maxDf,
+                                double &totalDisplacement,
+                                double &maxDisplacement,
+                                float adj) const;
+
+    size_t m_sampleRate;
+    size_t m_increment;
+    float m_prevDf;
+    double m_prevRatio;
+    double m_prevTimeRatio;
+    int m_transientAmnesty; // only in RT mode; handled differently offline
+    int m_debugLevel;
+    bool m_useHardPeaks;
+    int64_t m_inFrameCounter;
+    std::pair<int64_t, int64_t> m_frameCheckpoint;
+    int64_t expectedOutFrame(int64_t inFrame, double timeRatio);
+    double m_outFrameCounter;
+
+    std::map<size_t, size_t> m_keyFrameMap;
+    std::vector<Peak> m_peaks;
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/StretcherChannelData.cpp
+++ b/pedalboard/vendors/rubberband/src/StretcherChannelData.cpp
@@ -1,0 +1,292 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretcherChannelData.h"
+
+#include "dsp/Resampler.h"
+
+#include "system/Allocators.h"
+
+#include <algorithm>
+
+namespace RubberBand 
+{
+      
+RubberBandStretcher::Impl::ChannelData::ChannelData(size_t windowSize,
+                                                    size_t fftSize,
+                                                    size_t outbufSize)
+{
+    std::set<size_t> s;
+    construct(s, windowSize, fftSize, outbufSize);
+}
+
+RubberBandStretcher::Impl::ChannelData::ChannelData(const std::set<size_t> &sizes,
+                                                    size_t initialWindowSize,
+                                                    size_t initialFftSize,
+                                                    size_t outbufSize)
+{
+    construct(sizes, initialWindowSize, initialFftSize, outbufSize);
+}
+
+void
+RubberBandStretcher::Impl::ChannelData::construct(const std::set<size_t> &sizes,
+                                                  size_t initialWindowSize,
+                                                  size_t initialFftSize,
+                                                  size_t outbufSize)
+{
+    size_t maxSize = initialWindowSize * 2;
+    if (initialFftSize > maxSize) maxSize = initialFftSize;
+
+//    std::cerr << "ChannelData::construct: initialWindowSize = " << initialWindowSize << ", initialFftSize = " << initialFftSize << ", outbufSize = " << outbufSize << std::endl;
+
+    // std::set is ordered by value
+    std::set<size_t>::const_iterator i = sizes.end();
+    if (i != sizes.begin()) {
+        --i;
+        if (*i > maxSize) maxSize = *i;
+    }
+
+    // max possible size of the real "half" of freq data
+    size_t realSize = maxSize / 2 + 1;
+
+//    std::cerr << "ChannelData::construct([" << sizes.size() << "], " << maxSize << ", " << realSize << ", " << outbufSize << ")" << std::endl;
+    
+    if (outbufSize < maxSize) outbufSize = maxSize;
+
+    inbuf = new RingBuffer<float>(maxSize);
+    outbuf = new RingBuffer<float>(outbufSize);
+
+    mag = allocate_and_zero<process_t>(realSize);
+    phase = allocate_and_zero<process_t>(realSize);
+    prevPhase = allocate_and_zero<process_t>(realSize);
+    prevError = allocate_and_zero<process_t>(realSize);
+    unwrappedPhase = allocate_and_zero<process_t>(realSize);
+    envelope = allocate_and_zero<process_t>(realSize);
+
+    fltbuf = allocate_and_zero<float>(maxSize);
+    dblbuf = allocate_and_zero<process_t>(maxSize);
+
+    accumulator = allocate_and_zero<float>(maxSize);
+    windowAccumulator = allocate_and_zero<float>(maxSize);
+    ms = allocate_and_zero<float>(maxSize);
+    interpolator = allocate_and_zero<float>(maxSize);
+    interpolatorScale = 0;
+
+    for (std::set<size_t>::const_iterator i = sizes.begin();
+         i != sizes.end(); ++i) {
+        ffts[*i] = new FFT(*i);
+        if (sizeof(process_t) == sizeof(double)) {
+            ffts[*i]->initDouble();
+        } else {
+            ffts[*i]->initFloat();
+        }
+    }
+    fft = ffts[initialFftSize];
+
+    resampler = 0;
+    resamplebuf = 0;
+    resamplebufSize = 0;
+
+    reset();
+
+    // Avoid dividing opening sample (which will be discarded anyway) by zero
+    windowAccumulator[0] = 1.f;
+}
+
+
+void
+RubberBandStretcher::Impl::ChannelData::setSizes(size_t windowSize,
+                                                 size_t fftSize)
+{
+//    std::cerr << "ChannelData::setSizes: windowSize = " << windowSize << ", fftSize = " << fftSize << std::endl;
+
+    size_t maxSize = 2 * std::max(windowSize, fftSize);
+    size_t realSize = maxSize / 2 + 1;
+    size_t oldMax = inbuf->getSize();
+    size_t oldReal = oldMax / 2 + 1;
+
+    if (oldMax >= maxSize) {
+
+        // no need to reallocate buffers, just reselect fft
+
+        //!!! we can't actually do this without locking against the
+        //process thread, can we?  we need to zero the mag/phase
+        //buffers without interference
+
+        if (ffts.find(fftSize) == ffts.end()) {
+            //!!! this also requires a lock, but it shouldn't occur in
+            //RT mode with proper initialisation
+            ffts[fftSize] = new FFT(fftSize);
+            if (sizeof(process_t) == sizeof(double)) {
+                ffts[fftSize]->initDouble();
+            } else {
+                ffts[fftSize]->initFloat();
+            }
+        }
+        
+        fft = ffts[fftSize];
+
+        v_zero(fltbuf, maxSize);
+        v_zero(dblbuf, maxSize);
+
+        v_zero(mag, realSize);
+        v_zero(phase, realSize);
+        v_zero(prevPhase, realSize);
+        v_zero(prevError, realSize);
+        v_zero(unwrappedPhase, realSize);
+
+        return;
+    }
+
+    //!!! at this point we need a lock in case a different client
+    //thread is calling process() -- we need this lock even if we
+    //aren't running in threaded mode ourselves -- if we're in RT
+    //mode, then the process call should trylock and fail if the lock
+    //is unavailable (since this should never normally be the case in
+    //general use in RT mode)
+
+    RingBuffer<float> *newbuf = inbuf->resized(maxSize);
+    delete inbuf;
+    inbuf = newbuf;
+
+    // We don't want to preserve data in these arrays
+
+    mag = reallocate_and_zero(mag, oldReal, realSize);
+    phase = reallocate_and_zero(phase, oldReal, realSize);
+    prevPhase = reallocate_and_zero(prevPhase, oldReal, realSize);
+    prevError = reallocate_and_zero(prevError, oldReal, realSize);
+    unwrappedPhase = reallocate_and_zero(unwrappedPhase, oldReal, realSize);
+    envelope = reallocate_and_zero(envelope, oldReal, realSize);
+    fltbuf = reallocate_and_zero(fltbuf, oldMax, maxSize);
+    dblbuf = reallocate_and_zero(dblbuf, oldMax, maxSize);
+    ms = reallocate_and_zero(ms, oldMax, maxSize);
+    interpolator = reallocate_and_zero(interpolator, oldMax, maxSize);
+
+    // But we do want to preserve data in these
+
+    accumulator = reallocate_and_zero_extension
+        (accumulator, oldMax, maxSize);
+
+    windowAccumulator = reallocate_and_zero_extension
+        (windowAccumulator, oldMax, maxSize);
+
+    interpolatorScale = 0;
+    
+    //!!! and resampler?
+
+    if (ffts.find(fftSize) == ffts.end()) {
+        ffts[fftSize] = new FFT(fftSize);
+        if (sizeof(process_t) == sizeof(double)) {
+            ffts[fftSize]->initDouble();
+        } else {
+            ffts[fftSize]->initFloat();
+        }
+    }
+    
+    fft = ffts[fftSize];
+}
+
+void
+RubberBandStretcher::Impl::ChannelData::setOutbufSize(size_t outbufSize)
+{
+    size_t oldSize = outbuf->getSize();
+
+//    std::cerr << "ChannelData::setOutbufSize(" << outbufSize << ") [from " << oldSize << "]" << std::endl;
+
+    if (oldSize < outbufSize) {
+
+        //!!! at this point we need a lock in case a different client
+        //thread is calling process()
+
+        RingBuffer<float> *newbuf = outbuf->resized(outbufSize);
+        delete outbuf;
+        outbuf = newbuf;
+    }
+}
+
+void
+RubberBandStretcher::Impl::ChannelData::setResampleBufSize(size_t sz)
+{
+    resamplebuf = reallocate_and_zero<float>(resamplebuf, resamplebufSize, sz);
+    resamplebufSize = sz;
+}
+
+RubberBandStretcher::Impl::ChannelData::~ChannelData()
+{
+    delete resampler;
+
+    deallocate(resamplebuf);
+
+    delete inbuf;
+    delete outbuf;
+
+    deallocate(mag);
+    deallocate(phase);
+    deallocate(prevPhase);
+    deallocate(prevError);
+    deallocate(unwrappedPhase);
+    deallocate(envelope);
+    deallocate(interpolator);
+    deallocate(ms);
+    deallocate(accumulator);
+    deallocate(windowAccumulator);
+    deallocate(fltbuf);
+    deallocate(dblbuf);
+
+    for (std::map<size_t, FFT *>::iterator i = ffts.begin();
+         i != ffts.end(); ++i) {
+        delete i->second;
+    }
+}
+
+void
+RubberBandStretcher::Impl::ChannelData::reset()
+{
+    inbuf->reset();
+    outbuf->reset();
+
+    if (resampler) resampler->reset();
+
+    size_t size = inbuf->getSize();
+
+    for (size_t i = 0; i < size; ++i) {
+        accumulator[i] = 0.f;
+        windowAccumulator[i] = 0.f;
+    }
+
+    // Avoid dividing opening sample (which will be discarded anyway) by zero
+    windowAccumulator[0] = 1.f;
+    
+    accumulatorFill = 0;
+    prevIncrement = 0;
+    chunkCount = 0;
+    inCount = 0;
+    inputSize = -1;
+    outCount = 0;
+    interpolatorScale = 0;
+    unchanged = true;
+    draining = false;
+    outputComplete = false;
+}
+
+}

--- a/pedalboard/vendors/rubberband/src/StretcherChannelData.h
+++ b/pedalboard/vendors/rubberband/src/StretcherChannelData.h
@@ -1,0 +1,147 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCHERCHANNELDATA_H
+#define RUBBERBAND_STRETCHERCHANNELDATA_H
+
+#include "StretcherImpl.h"
+
+#include <set>
+#include <atomic>
+
+namespace RubberBand
+{
+
+class Resampler;
+
+class RubberBandStretcher::Impl::ChannelData
+{
+public:        
+    /**
+     * Construct a ChannelData structure.
+     *
+     * The sizes passed in here are for the time-domain analysis
+     * window and FFT calculation, and most of the buffer sizes also
+     * depend on them.  In practice they are always powers of two, the
+     * window and FFT sizes are either equal or generally in a 2:1
+     * relationship either way, and except for very extreme stretches
+     * the FFT size is either 1024, 2048 or 4096.
+     *
+     * The outbuf size depends on other factors as well, including
+     * the pitch scale factor and any maximum processing block
+     * size specified by the user of the code.
+     */
+    ChannelData(size_t windowSize,
+                size_t fftSize,
+                size_t outbufSize);
+
+    /**
+     * Construct a ChannelData structure that can process at different
+     * FFT sizes without requiring reallocation when the size changes.
+     * The sizes can subsequently be changed with a call to setSizes.
+     * Reallocation will only be necessary if setSizes is called with
+     * values not equal to any of those passed in to the constructor.
+     *
+     * The outbufSize should be the maximum possible outbufSize to
+     * avoid reallocation, which will happen if setOutbufSize is
+     * called subsequently.
+     */
+    ChannelData(const std::set<size_t> &sizes,
+                size_t initialWindowSize,
+                size_t initialFftSize,
+                size_t outbufSize);
+    ~ChannelData();
+
+    /**
+     * Reset buffers
+     */
+    void reset();
+
+    /**
+     * Set the FFT, analysis window, and buffer sizes.  If this
+     * ChannelData was constructed with a set of sizes and the given
+     * window and FFT sizes here were among them, no reallocation will
+     * be required.
+     */
+    void setSizes(size_t windowSize, size_t fftSizes);
+
+    /**
+     * Set the outbufSize for the channel data.  Reallocation will
+     * occur.
+     */
+    void setOutbufSize(size_t outbufSize);
+
+    /**
+     * Set the resampler buffer size.  Default if not called is no
+     * buffer allocated at all.
+     */
+    void setResampleBufSize(size_t resamplebufSize);
+    
+    RingBuffer<float> *inbuf;
+    RingBuffer<float> *outbuf;
+
+    process_t *mag;
+    process_t *phase;
+
+    process_t *prevPhase;
+    process_t *prevError;
+    process_t *unwrappedPhase;
+
+    float *accumulator;
+    size_t accumulatorFill;
+    float *windowAccumulator;
+    float *ms; // only used when mid-side processing
+    float *interpolator; // only used when time-domain smoothing is on
+    int interpolatorScale;
+
+    float *fltbuf;
+    process_t *dblbuf; // owned by FFT object, only used for time domain FFT i/o
+    process_t *envelope; // for cepstral formant shift
+    bool unchanged;
+
+    size_t prevIncrement; // only used in RT mode
+
+    size_t chunkCount;
+    size_t inCount;
+    std::atomic<int64_t> inputSize; // set only after known (when data ended); -1 previously
+    size_t outCount;
+
+    std::atomic<bool> draining;
+    std::atomic<bool> outputComplete;
+
+    FFT *fft;
+    std::map<size_t, FFT *> ffts;
+
+    Resampler *resampler;
+    float *resamplebuf;
+    size_t resamplebufSize;
+
+private:
+    void construct(const std::set<size_t> &sizes,
+                   size_t initialWindowSize, size_t initialFftSize,
+                   size_t outbufSize);
+};        
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/StretcherImpl.cpp
+++ b/pedalboard/vendors/rubberband/src/StretcherImpl.cpp
@@ -1,0 +1,1394 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretcherImpl.h"
+
+#include "audiocurves/PercussiveAudioCurve.h"
+#include "audiocurves/HighFrequencyAudioCurve.h"
+#include "audiocurves/SpectralDifferenceAudioCurve.h"
+#include "audiocurves/SilentAudioCurve.h"
+#include "audiocurves/ConstantAudioCurve.h"
+#include "audiocurves/CompoundAudioCurve.h"
+
+#include "dsp/Resampler.h"
+
+#include "StretchCalculator.h"
+#include "StretcherChannelData.h"
+
+#include "base/Profiler.h"
+
+#include "system/sysutils.h"
+
+#include <cassert>
+#include <cmath>
+#include <set>
+#include <map>
+#include <algorithm>
+
+using namespace RubberBand;
+
+using std::cerr;
+using std::endl;
+using std::vector;
+using std::map;
+using std::set;
+using std::max;
+using std::min;
+
+namespace RubberBand {
+
+const size_t
+RubberBandStretcher::Impl::m_defaultIncrement = 256;
+
+const size_t
+RubberBandStretcher::Impl::m_defaultFftSize = 2048;
+
+int
+RubberBandStretcher::Impl::m_defaultDebugLevel = 0;
+
+static bool _initialised = false;
+
+RubberBandStretcher::Impl::Impl(size_t sampleRate,
+                                size_t channels,
+                                Options options,
+                                double initialTimeRatio,
+                                double initialPitchScale) :
+    m_sampleRate(sampleRate),
+    m_channels(channels),
+    m_timeRatio(initialTimeRatio),
+    m_pitchScale(initialPitchScale),
+    m_fftSize(m_defaultFftSize),
+    m_aWindowSize(m_defaultFftSize),
+    m_sWindowSize(m_defaultFftSize),
+    m_increment(m_defaultIncrement),
+    m_outbufSize(m_defaultFftSize * 2),
+    m_maxProcessSize(m_defaultFftSize),
+    m_expectedInputDuration(0),
+#ifndef NO_THREADING
+    m_threaded(false),
+#endif
+    m_realtime(false),
+    m_options(options),
+    m_debugLevel(m_defaultDebugLevel),
+    m_mode(JustCreated),
+    m_awindow(0),
+    m_afilter(0),
+    m_swindow(0),
+    m_studyFFT(0),
+#ifndef NO_THREADING
+    m_spaceAvailable("space"),
+#endif
+    m_inputDuration(0),
+    m_detectorType(CompoundAudioCurve::CompoundDetector),
+    m_silentHistory(0),
+    m_lastProcessOutputIncrements(16),
+    m_lastProcessPhaseResetDf(16),
+    m_emergencyScavenger(10, 4),
+    m_phaseResetAudioCurve(0),
+    m_stretchAudioCurve(0),
+    m_silentAudioCurve(0),
+    m_stretchCalculator(0),
+    m_freq0(600),
+    m_freq1(1200),
+    m_freq2(12000),
+    m_baseFftSize(m_defaultFftSize)
+{
+    if (!_initialised) {
+        system_specific_initialise();
+        _initialised = true;
+    }
+
+    if (m_debugLevel > 0) {
+        cerr << "RubberBandStretcher::Impl::Impl: rate = " << m_sampleRate << ", options = " << options << endl;
+    }
+
+    // Window size will vary according to the audio sample rate, but
+    // we don't let it drop below the 48k default
+    m_rateMultiple = float(m_sampleRate) / 48000.f;
+//    if (m_rateMultiple < 1.f) m_rateMultiple = 1.f;
+    m_baseFftSize = roundUp(int(m_defaultFftSize * m_rateMultiple));
+
+    if ((options & OptionWindowShort) || (options & OptionWindowLong)) {
+        if ((options & OptionWindowShort) && (options & OptionWindowLong)) {
+            cerr << "RubberBandStretcher::Impl::Impl: Cannot specify OptionWindowLong and OptionWindowShort together; falling back to OptionWindowStandard" << endl;
+        } else if (options & OptionWindowShort) {
+            m_baseFftSize = m_baseFftSize / 2;
+            if (m_debugLevel > 0) {
+                cerr << "setting baseFftSize to " << m_baseFftSize << endl;
+            }
+        } else if (options & OptionWindowLong) {
+            m_baseFftSize = m_baseFftSize * 2;
+            if (m_debugLevel > 0) {
+                cerr << "setting baseFftSize to " << m_baseFftSize << endl;
+            }
+        }
+        m_fftSize = m_baseFftSize;
+        m_aWindowSize = m_baseFftSize;
+        m_sWindowSize = m_baseFftSize;
+        m_outbufSize = m_sWindowSize * 2;
+        m_maxProcessSize = m_aWindowSize;
+    }
+
+    if (m_options & OptionProcessRealTime) {
+
+        m_realtime = true;
+
+        if (!(m_options & OptionStretchPrecise)) {
+            m_options |= OptionStretchPrecise;
+        }
+    }
+
+#ifndef NO_THREADING
+    if (m_channels > 1) {
+
+        m_threaded = true;
+
+        if (m_realtime) {
+            m_threaded = false;
+        } else if (m_options & OptionThreadingNever) {
+            m_threaded = false;
+        } else if (!(m_options & OptionThreadingAlways) &&
+                   !system_is_multiprocessor()) {
+            m_threaded = false;
+        }
+
+        if (m_threaded && m_debugLevel > 0) {
+            cerr << "Going multithreaded..." << endl;
+        }
+    }
+#endif
+
+    configure();
+}
+
+RubberBandStretcher::Impl::~Impl()
+{
+#ifndef NO_THREADING
+    if (m_threaded) {
+        MutexLocker locker(&m_threadSetMutex);
+        for (set<ProcessThread *>::iterator i = m_threadSet.begin();
+             i != m_threadSet.end(); ++i) {
+            if (m_debugLevel > 0) {
+                cerr << "RubberBandStretcher::~RubberBandStretcher: joining (channel " << *i << ")" << endl;
+            }
+            (*i)->abandon();
+            (*i)->wait();
+            delete *i;
+        }
+    }
+#endif
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        delete m_channelData[c];
+    }
+
+    delete m_phaseResetAudioCurve;
+    delete m_stretchAudioCurve;
+    delete m_silentAudioCurve;
+    delete m_stretchCalculator;
+    delete m_studyFFT;
+
+    for (map<size_t, Window<float> *>::iterator i = m_windows.begin();
+         i != m_windows.end(); ++i) {
+        delete i->second;
+    }
+    for (map<size_t, SincWindow<float> *>::iterator i = m_sincs.begin();
+         i != m_sincs.end(); ++i) {
+        delete i->second;
+    }
+}
+
+void
+RubberBandStretcher::Impl::reset()
+{
+#ifndef NO_THREADING
+    if (m_threaded) {
+        m_threadSetMutex.lock();
+        for (set<ProcessThread *>::iterator i = m_threadSet.begin();
+             i != m_threadSet.end(); ++i) {
+            if (m_debugLevel > 0) {
+                cerr << "RubberBandStretcher::~RubberBandStretcher: joining (channel " << *i << ")" << endl;
+            }
+            (*i)->abandon();
+            (*i)->wait();
+            delete *i;
+        }
+        m_threadSet.clear();
+    }
+#endif
+
+    m_emergencyScavenger.scavenge();
+
+    if (m_stretchCalculator) {
+        m_stretchCalculator->reset();
+    }
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        m_channelData[c]->reset();
+    }
+
+    m_mode = JustCreated;
+    if (m_phaseResetAudioCurve) m_phaseResetAudioCurve->reset();
+    if (m_stretchAudioCurve) m_stretchAudioCurve->reset();
+    if (m_silentAudioCurve) m_silentAudioCurve->reset();
+    m_inputDuration = 0;
+    m_silentHistory = 0;
+
+#ifndef NO_THREADING
+    if (m_threaded) m_threadSetMutex.unlock();
+#endif
+
+    reconfigure();
+}
+
+void
+RubberBandStretcher::Impl::setTimeRatio(double ratio)
+{
+    if (!m_realtime) {
+        if (m_mode == Studying || m_mode == Processing) {
+            cerr << "RubberBandStretcher::Impl::setTimeRatio: Cannot set ratio while studying or processing in non-RT mode" << endl;
+            return;
+        }
+    }
+
+    if (ratio == m_timeRatio) return;
+    m_timeRatio = ratio;
+
+    reconfigure();
+}
+
+void
+RubberBandStretcher::Impl::setPitchScale(double fs)
+{
+    if (!m_realtime) {
+        if (m_mode == Studying || m_mode == Processing) {
+            cerr << "RubberBandStretcher::Impl::setPitchScale: Cannot set ratio while studying or processing in non-RT mode" << endl;
+            return;
+        }
+    }
+
+    if (fs == m_pitchScale) return;
+    
+    bool was1 = (m_pitchScale == 1.f);
+    bool rbs = resampleBeforeStretching();
+
+    m_pitchScale = fs;
+
+    reconfigure();
+
+    if (!(m_options & OptionPitchHighConsistency) &&
+        (was1 || resampleBeforeStretching() != rbs) &&
+        m_pitchScale != 1.f) {
+        
+        // resampling mode has changed
+        for (int c = 0; c < int(m_channels); ++c) {
+            if (m_channelData[c]->resampler) {
+                m_channelData[c]->resampler->reset();
+            }
+        }
+    }
+}
+
+double
+RubberBandStretcher::Impl::getTimeRatio() const
+{
+    return m_timeRatio;
+}
+
+double
+RubberBandStretcher::Impl::getPitchScale() const
+{
+    return m_pitchScale;
+}
+
+void
+RubberBandStretcher::Impl::setExpectedInputDuration(size_t samples)
+{
+    if (samples == m_expectedInputDuration) return;
+    m_expectedInputDuration = samples;
+
+    reconfigure();
+}
+
+void
+RubberBandStretcher::Impl::setMaxProcessSize(size_t samples)
+{
+    if (samples <= m_maxProcessSize) return;
+    m_maxProcessSize = samples;
+
+    reconfigure();
+}
+
+void
+RubberBandStretcher::Impl::setKeyFrameMap(const std::map<size_t, size_t> &
+                                          mapping)
+{
+    if (m_realtime) {
+        cerr << "RubberBandStretcher::Impl::setKeyFrameMap: Cannot specify key frame map in RT mode" << endl;
+        return;
+    }
+    if (m_mode == Processing) {
+        cerr << "RubberBandStretcher::Impl::setKeyFrameMap: Cannot specify key frame map after process() has begun" << endl;
+        return;
+    }
+
+    if (m_stretchCalculator) {
+        m_stretchCalculator->setKeyFrameMap(mapping);
+    }
+}
+
+float
+RubberBandStretcher::Impl::getFrequencyCutoff(int n) const
+{
+    switch (n) {
+    case 0: return m_freq0;
+    case 1: return m_freq1;
+    case 2: return m_freq2;
+    }
+    return 0.f;
+}
+
+void
+RubberBandStretcher::Impl::setFrequencyCutoff(int n, float f)
+{
+    switch (n) {
+    case 0: m_freq0 = f; break;
+    case 1: m_freq1 = f; break;
+    case 2: m_freq2 = f; break;
+    }
+}
+
+double
+RubberBandStretcher::Impl::getEffectiveRatio() const
+{
+    // Returns the ratio that the internal time stretcher needs to
+    // achieve, not the resulting duration ratio of the output (which
+    // is simply m_timeRatio).
+
+    // A frequency shift is achieved using an additional time shift,
+    // followed by resampling back to the original time shift to
+    // change the pitch.  Note that the resulting frequency change is
+    // fixed, as it is effected by the resampler -- in contrast to
+    // time shifting, which is variable aiming to place the majority
+    // of the stretch or squash in low-interest regions of audio.
+
+    return m_timeRatio * m_pitchScale;
+}
+
+size_t
+RubberBandStretcher::Impl::roundUp(size_t value)
+{
+    if (!(value & (value - 1))) return value;
+    int bits = 0;
+    while (value) { ++bits; value >>= 1; }
+    value = 1 << bits;
+    return value;
+}
+
+void
+RubberBandStretcher::Impl::calculateSizes()
+{
+    size_t inputIncrement = m_defaultIncrement;
+    size_t windowSize = m_baseFftSize;
+    size_t outputIncrement;
+
+    if (m_pitchScale <= 0.0) {
+        // This special case is likelier than one might hope, because
+        // of naive initialisations in programs that set it from a
+        // variable
+        std::cerr << "RubberBandStretcher: WARNING: Pitch scale must be greater than zero!\nResetting it from " << m_pitchScale << " to the default of 1.0: no pitch change will occur" << std::endl;
+        m_pitchScale = 1.0;
+    }
+    if (m_timeRatio <= 0.0) {
+        // Likewise
+        std::cerr << "RubberBandStretcher: WARNING: Time ratio must be greater than zero!\nResetting it from " << m_timeRatio << " to the default of 1.0: no time stretch will occur" << std::endl;
+        m_timeRatio = 1.0;
+    }
+
+    double r = getEffectiveRatio();
+
+    if (m_realtime) {
+
+        if (r < 1) {
+            
+            bool rsb = (m_pitchScale < 1.0 && !resampleBeforeStretching());
+            float windowIncrRatio = 4.5;
+            if (r == 1.0) windowIncrRatio = 4;
+            else if (rsb) windowIncrRatio = 4.5;
+            else windowIncrRatio = 6;
+
+            inputIncrement = int(windowSize / windowIncrRatio);
+            outputIncrement = int(floor(inputIncrement * r));
+
+            // Very long stretch or very low pitch shift
+            if (outputIncrement < m_defaultIncrement / 4) {
+                if (outputIncrement < 1) outputIncrement = 1;
+                while (outputIncrement < m_defaultIncrement / 4 &&
+                       windowSize < m_baseFftSize * 4) {
+                    outputIncrement *= 2;
+                    inputIncrement = lrint(ceil(outputIncrement / r));
+                    windowSize = roundUp(lrint(ceil(inputIncrement * windowIncrRatio)));
+                }
+            }
+
+        } else {
+
+            bool rsb = (m_pitchScale > 1.0 && resampleBeforeStretching());
+            float windowIncrRatio = 4.5;
+            if (r == 1.0) windowIncrRatio = 4;
+            else if (rsb) windowIncrRatio = 4.5;
+            else windowIncrRatio = 8;
+
+            outputIncrement = int(windowSize / windowIncrRatio);
+            inputIncrement = int(outputIncrement / r);
+            while (outputIncrement > 1024 * m_rateMultiple &&
+                   inputIncrement > 1) {
+                outputIncrement /= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            while (inputIncrement < 1) {
+                outputIncrement *= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            size_t minwin = roundUp(lrint(outputIncrement * windowIncrRatio));
+            if (windowSize < minwin) windowSize = minwin;
+
+            if (rsb) {
+//                cerr << "adjusting window size from " << windowSize;
+                size_t newWindowSize = roundUp(lrint(windowSize / m_pitchScale));
+                if (newWindowSize < 512) newWindowSize = 512;
+                size_t div = windowSize / newWindowSize;
+                if (inputIncrement > div && outputIncrement > div) {
+                    inputIncrement /= div;
+                    outputIncrement /= div;
+                    windowSize /= div;
+                }
+//                cerr << " to " << windowSize << " (inputIncrement = " << inputIncrement << ", outputIncrement = " << outputIncrement << ")" << endl;
+            }
+        }
+
+    } else {
+
+        if (r < 1) {
+            inputIncrement = windowSize / 4;
+            while (inputIncrement >= 512) inputIncrement /= 2;
+            outputIncrement = int(floor(inputIncrement * r));
+            if (outputIncrement < 1) {
+                outputIncrement = 1;
+                inputIncrement = roundUp(lrint(ceil(outputIncrement / r)));
+                windowSize = inputIncrement * 4;
+            }
+        } else {
+            outputIncrement = windowSize / 6;
+            inputIncrement = int(outputIncrement / r);
+            while (outputIncrement > 1024 && inputIncrement > 1) {
+                outputIncrement /= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            while (inputIncrement < 1) {
+                outputIncrement *= 2;
+                inputIncrement = int(outputIncrement / r);
+            }
+            windowSize = std::max(windowSize, roundUp(outputIncrement * 6));
+            if (r > 5) while (windowSize < 8192) windowSize *= 2;
+        }
+    }
+
+    if (m_expectedInputDuration > 0) {
+        while (inputIncrement * 4 > m_expectedInputDuration &&
+               inputIncrement > 1) {
+            inputIncrement /= 2;
+        }
+    }
+
+    // m_fftSize can be almost anything, but it can't be greater than
+    // 4 * m_baseFftSize unless ratio is less than 1/1024.
+
+    m_fftSize = windowSize;
+    
+    if (m_options & OptionSmoothingOn) {
+        m_aWindowSize = windowSize * 2;
+        m_sWindowSize = windowSize * 2;
+    } else {
+        m_aWindowSize = windowSize;
+        m_sWindowSize = windowSize;
+    }
+
+    m_increment = inputIncrement;
+
+    // When squashing, the greatest theoretically possible output
+    // increment is the input increment.  When stretching adaptively
+    // the sky's the limit in principle, but we expect
+    // StretchCalculator to restrict itself to using no more than
+    // twice the basic output increment (i.e. input increment times
+    // ratio) for any chunk.
+
+    if (m_debugLevel > 0) {
+        cerr << "calculateSizes: time ratio = " << m_timeRatio << ", pitch scale = " << m_pitchScale << ", effective ratio = " << getEffectiveRatio() << endl;
+        cerr << "calculateSizes: analysis window size = " << m_aWindowSize << ", synthesis window size = " << m_sWindowSize << ", fft size = " << m_fftSize << ", increment = " << m_increment << " (approx output increment = " << int(lrint(m_increment * getEffectiveRatio())) << ")" << endl;
+    }
+
+    if (std::max(m_aWindowSize, m_sWindowSize) > m_maxProcessSize) {
+        m_maxProcessSize = std::max(m_aWindowSize, m_sWindowSize);
+    }
+
+    m_outbufSize =
+        size_t
+        (ceil(max
+              (m_maxProcessSize / m_pitchScale,
+               m_maxProcessSize * 2 * (m_timeRatio > 1.f ? m_timeRatio : 1.f))));
+
+    if (m_realtime) {
+        // This headroom is so as to try to avoid reallocation when
+        // the pitch scale changes
+        m_outbufSize = m_outbufSize * 16;
+    } else {
+#ifndef NO_THREADING
+        if (m_threaded) {
+            // This headroom is to permit the processing threads to
+            // run ahead of the buffer output drainage; the exact
+            // amount of headroom is a question of tuning rather than
+            // results
+            m_outbufSize = m_outbufSize * 16;
+        }
+#endif
+    }
+
+    if (m_debugLevel > 0) {
+        cerr << "calculateSizes: outbuf size = " << m_outbufSize << endl;
+    }
+}
+
+void
+RubberBandStretcher::Impl::configure()
+{
+    if (m_debugLevel > 0) {
+        std::cerr << "configure[" << this << "]: realtime = " << m_realtime << ", pitch scale = "
+                  << m_pitchScale << ", channels = " << m_channels << std::endl;
+    }
+
+    size_t prevFftSize = m_fftSize;
+    size_t prevAWindowSize = m_aWindowSize;
+    size_t prevSWindowSize = m_sWindowSize;
+    size_t prevOutbufSize = m_outbufSize;
+    if (m_windows.empty()) {
+        prevFftSize = 0;
+        prevAWindowSize = 0;
+        prevSWindowSize = 0;
+        prevOutbufSize = 0;
+    }
+
+    calculateSizes();
+
+    bool fftSizeChanged = (prevFftSize != m_fftSize);
+    bool windowSizeChanged = ((prevAWindowSize != m_aWindowSize) ||
+                              (prevSWindowSize != m_sWindowSize));
+    bool outbufSizeChanged = (prevOutbufSize != m_outbufSize);
+
+    // This function may be called at any time in non-RT mode, after a
+    // parameter has changed.  It shouldn't be legal to call it after
+    // processing has already begun.
+
+    // This function is only called once (on construction) in RT
+    // mode.  After that reconfigure() does the work in a hopefully
+    // RT-safe way.
+
+    set<size_t> windowSizes;
+    if (m_realtime) {
+        windowSizes.insert(m_baseFftSize);
+        windowSizes.insert(m_baseFftSize / 2);
+        windowSizes.insert(m_baseFftSize * 2);
+//        windowSizes.insert(m_baseFftSize * 4);
+    }
+    windowSizes.insert(m_fftSize);
+    windowSizes.insert(m_aWindowSize);
+    windowSizes.insert(m_sWindowSize);
+
+    if (windowSizeChanged) {
+
+        for (set<size_t>::const_iterator i = windowSizes.begin();
+             i != windowSizes.end(); ++i) {
+            if (m_windows.find(*i) == m_windows.end()) {
+                m_windows[*i] = new Window<float>(HanningWindow, *i);
+            }
+            if (m_sincs.find(*i) == m_sincs.end()) {
+                m_sincs[*i] = new SincWindow<float>(*i, *i);
+            }
+        }
+        m_awindow = m_windows[m_aWindowSize];
+        m_afilter = m_sincs[m_aWindowSize];
+        m_swindow = m_windows[m_sWindowSize];
+
+        if (m_debugLevel > 0) {
+            cerr << "Window area: " << m_awindow->getArea() << "; synthesis window area: " << m_swindow->getArea() << endl;
+        }
+    }
+
+    if (windowSizeChanged || outbufSizeChanged) {
+        
+        for (size_t c = 0; c < m_channelData.size(); ++c) {
+            delete m_channelData[c];
+        }
+        m_channelData.clear();
+
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData.push_back
+                (new ChannelData(windowSizes,
+                                 std::max(m_aWindowSize, m_sWindowSize),
+                                 m_fftSize,
+                                 m_outbufSize));
+        }
+    }
+
+    if (!m_realtime && fftSizeChanged) {
+        delete m_studyFFT;
+        m_studyFFT = new FFT(m_fftSize, m_debugLevel);
+        m_studyFFT->initFloat();
+    }
+
+    if (m_pitchScale != 1.0 ||
+        (m_options & OptionPitchHighConsistency) ||
+        m_realtime) {
+
+        for (size_t c = 0; c < m_channels; ++c) {
+
+            if (m_channelData[c]->resampler) continue;
+
+            Resampler::Parameters params;
+            params.quality = Resampler::FastestTolerable;
+
+            if (m_realtime) {
+                params.dynamism = Resampler::RatioOftenChanging;
+                params.ratioChange = Resampler::SmoothRatioChange;
+            } else {
+                // ratio can't be changed in offline mode
+                params.dynamism = Resampler::RatioMostlyFixed;
+                params.ratioChange = Resampler::SuddenRatioChange;
+            }
+            
+            params.maxBufferSize = 4096 * 16;
+            params.debugLevel = (m_debugLevel > 0 ? m_debugLevel-1 : 0);
+            
+            m_channelData[c]->resampler = new Resampler(params, 1);
+
+            // rbs is the amount of buffer space we think we'll need
+            // for resampling; but allocate a sensible amount in case
+            // the pitch scale changes during use
+            size_t rbs = 
+                lrintf(ceil((m_increment * m_timeRatio * 2) / m_pitchScale));
+            if (rbs < m_increment * 16) rbs = m_increment * 16;
+            m_channelData[c]->setResampleBufSize(rbs);
+        }
+    }
+    
+    // stretchAudioCurve is unused in RT mode; phaseResetAudioCurve,
+    // silentAudioCurve and stretchCalculator however are used in all
+    // modes
+
+    delete m_phaseResetAudioCurve;
+    m_phaseResetAudioCurve = new CompoundAudioCurve
+        (CompoundAudioCurve::Parameters(m_sampleRate, m_fftSize));
+    m_phaseResetAudioCurve->setType(m_detectorType);
+
+    delete m_silentAudioCurve;
+    m_silentAudioCurve = new SilentAudioCurve
+        (SilentAudioCurve::Parameters(m_sampleRate, m_fftSize));
+
+    if (!m_realtime) {
+        delete m_stretchAudioCurve;
+        if (!(m_options & OptionStretchPrecise)) {
+            m_stretchAudioCurve = new SpectralDifferenceAudioCurve
+                (SpectralDifferenceAudioCurve::Parameters(m_sampleRate, m_fftSize));
+        } else {
+            m_stretchAudioCurve = new ConstantAudioCurve
+                (ConstantAudioCurve::Parameters(m_sampleRate, m_fftSize));
+        }
+    }
+
+    delete m_stretchCalculator;
+    m_stretchCalculator = new StretchCalculator
+        (m_sampleRate, m_increment,
+         !(m_options & OptionTransientsSmooth));
+
+    m_stretchCalculator->setDebugLevel(m_debugLevel);
+    m_inputDuration = 0;
+
+    // Prepare the inbufs with half a chunk of emptiness.  The centre
+    // point of the first processing chunk for the onset detector
+    // should be the first sample of the audio, and we continue until
+    // we can no longer centre a chunk within the input audio.  The
+    // number of onset detector chunks will be the number of audio
+    // samples input, divided by the input increment, plus one.
+
+    // In real-time mode, we don't do this prefill -- it's better to
+    // start with a swoosh than introduce more latency, and we don't
+    // want gaps when the ratio changes.
+
+    if (!m_realtime) {
+        if (m_debugLevel > 1) {
+            cerr << "Not real time mode: prefilling with " << m_aWindowSize/2 << " samples" << endl;
+        }
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData[c]->reset();
+            m_channelData[c]->inbuf->zero(m_aWindowSize/2);
+        }
+    }
+}
+
+
+void
+RubberBandStretcher::Impl::reconfigure()
+{
+    if (!m_realtime) {
+        if (m_mode == Studying) {
+            // stop and calculate the stretch curve so far, then reset
+            // the df vectors
+            calculateStretch();
+            m_phaseResetDf.clear();
+            m_stretchDf.clear();
+            m_silence.clear();
+            m_inputDuration = 0;
+        }
+        configure();
+    }
+
+    size_t prevFftSize = m_fftSize;
+    size_t prevAWindowSize = m_aWindowSize;
+    size_t prevSWindowSize = m_sWindowSize;
+    size_t prevOutbufSize = m_outbufSize;
+
+    calculateSizes();
+
+    bool somethingChanged = false;
+    
+    // There are various allocations in this function, but they should
+    // never happen in normal use -- they just recover from the case
+    // where not all of the things we need were correctly created when
+    // we first configured (for whatever reason).  This is intended to
+    // be "effectively" realtime safe.  The same goes for
+    // ChannelData::setOutbufSize and setSizes.
+
+    if (m_aWindowSize != prevAWindowSize ||
+        m_sWindowSize != prevSWindowSize) {
+
+        if (m_windows.find(m_aWindowSize) == m_windows.end()) {
+            std::cerr << "WARNING: reconfigure(): window allocation (size " << m_aWindowSize << ") required in RT mode" << std::endl;
+            m_windows[m_aWindowSize] = new Window<float>
+                (HanningWindow, m_aWindowSize);
+            m_sincs[m_aWindowSize] = new SincWindow<float>
+                (m_aWindowSize, m_aWindowSize);
+        }
+
+        if (m_windows.find(m_sWindowSize) == m_windows.end()) {
+            std::cerr << "WARNING: reconfigure(): window allocation (size " << m_sWindowSize << ") required in RT mode" << std::endl;
+            m_windows[m_sWindowSize] = new Window<float>
+                (HanningWindow, m_sWindowSize);
+            m_sincs[m_sWindowSize] = new SincWindow<float>
+                (m_sWindowSize, m_sWindowSize);
+        }
+
+        m_awindow = m_windows[m_aWindowSize];
+        m_afilter = m_sincs[m_aWindowSize];
+        m_swindow = m_windows[m_sWindowSize];
+
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData[c]->setSizes(std::max(m_aWindowSize, m_sWindowSize),
+                                       m_fftSize);
+        }
+
+        somethingChanged = true;
+    }
+
+    if (m_outbufSize != prevOutbufSize) {
+        for (size_t c = 0; c < m_channels; ++c) {
+            m_channelData[c]->setOutbufSize(m_outbufSize);
+        }
+        somethingChanged = true;
+    }
+
+    if (m_pitchScale != 1.0) {
+        for (size_t c = 0; c < m_channels; ++c) {
+
+            if (m_channelData[c]->resampler) continue;
+
+            std::cerr << "WARNING: reconfigure(): resampler construction required in RT mode" << std::endl;
+
+            Resampler::Parameters params;
+            params.quality = Resampler::FastestTolerable;
+            params.dynamism = Resampler::RatioOftenChanging;
+            params.ratioChange = Resampler::SmoothRatioChange;
+            params.maxBufferSize = m_sWindowSize;
+            params.debugLevel = (m_debugLevel > 0 ? m_debugLevel-1 : 0);
+            
+            m_channelData[c]->resampler = new Resampler(params, 1);
+
+            size_t rbs = 
+                lrintf(ceil((m_increment * m_timeRatio * 2) / m_pitchScale));
+            if (rbs < m_increment * 16) rbs = m_increment * 16;
+            m_channelData[c]->setResampleBufSize(rbs);
+
+            somethingChanged = true;
+        }
+    }
+
+    if (m_fftSize != prevFftSize) {
+        m_phaseResetAudioCurve->setFftSize(m_fftSize);
+        m_silentAudioCurve->setFftSize(m_fftSize);
+        if (m_stretchAudioCurve) {
+            m_stretchAudioCurve->setFftSize(m_fftSize);
+        }
+        somethingChanged = true;
+    }
+
+    if (m_debugLevel > 0) {
+        if (somethingChanged) {
+            std::cerr << "reconfigure: at least one parameter changed" << std::endl;
+        } else {
+            std::cerr << "reconfigure: nothing changed" << std::endl;
+        }
+    }
+}
+
+size_t
+RubberBandStretcher::Impl::getLatency() const
+{
+    if (!m_realtime) return 0;
+    return lrint((m_aWindowSize/2) / m_pitchScale);
+}
+
+void
+RubberBandStretcher::Impl::setTransientsOption(Options options)
+{
+    if (!m_realtime) {
+        cerr << "RubberBandStretcher::Impl::setTransientsOption: Not permissible in non-realtime mode" << endl;
+        return;
+    }
+    int mask = (OptionTransientsMixed | OptionTransientsSmooth | OptionTransientsCrisp);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+
+    m_stretchCalculator->setUseHardPeaks
+        (!(m_options & OptionTransientsSmooth));
+}
+
+void
+RubberBandStretcher::Impl::setDetectorOption(Options options)
+{
+    if (!m_realtime) {
+        cerr << "RubberBandStretcher::Impl::setDetectorOption: Not permissible in non-realtime mode" << endl;
+        return;
+    }
+    int mask = (OptionDetectorPercussive | OptionDetectorCompound | OptionDetectorSoft);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+
+    CompoundAudioCurve::Type dt = CompoundAudioCurve::CompoundDetector;
+    if (m_options & OptionDetectorPercussive) dt = CompoundAudioCurve::PercussiveDetector;
+    else if (m_options & OptionDetectorSoft) dt = CompoundAudioCurve::SoftDetector;
+    
+    if (dt == m_detectorType) return;
+    m_detectorType = dt;
+
+    if (m_phaseResetAudioCurve) {
+        m_phaseResetAudioCurve->setType(m_detectorType);
+    }
+}
+
+void
+RubberBandStretcher::Impl::setPhaseOption(Options options)
+{
+    int mask = (OptionPhaseLaminar | OptionPhaseIndependent);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+}
+
+void
+RubberBandStretcher::Impl::setFormantOption(Options options)
+{
+    int mask = (OptionFormantShifted | OptionFormantPreserved);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+}
+
+void
+RubberBandStretcher::Impl::setPitchOption(Options options)
+{
+    if (!m_realtime) {
+        cerr << "RubberBandStretcher::Impl::setPitchOption: Pitch option is not used in non-RT mode" << endl;
+        return;
+    }
+
+    Options prior = m_options;
+
+    int mask = (OptionPitchHighQuality |
+                OptionPitchHighSpeed |
+                OptionPitchHighConsistency);
+    m_options &= ~mask;
+    options &= mask;
+    m_options |= options;
+
+    if (prior != m_options) reconfigure();
+}
+
+void
+RubberBandStretcher::Impl::study(const float *const *input, size_t samples, bool final)
+{
+    Profiler profiler("RubberBandStretcher::Impl::study");
+
+    if (m_realtime) {
+        if (m_debugLevel > 1) {
+            cerr << "RubberBandStretcher::Impl::study: Not meaningful in realtime mode" << endl;
+        }
+        return;
+    }
+
+    if (m_mode == Processing || m_mode == Finished) {
+        cerr << "RubberBandStretcher::Impl::study: Cannot study after processing" << endl;
+        return;
+    }
+    m_mode = Studying;
+    
+    size_t consumed = 0;
+
+    ChannelData &cd = *m_channelData[0];
+    RingBuffer<float> &inbuf = *cd.inbuf;
+
+    const float *mixdown;
+    float *mdalloc = 0;
+
+    if (m_channels > 1 || final) {
+        // mix down into a single channel for analysis
+        mdalloc = new float[samples];
+        for (size_t i = 0; i < samples; ++i) {
+            if (i < samples) {
+                mdalloc[i] = input[0][i];
+            } else {
+                mdalloc[i] = 0.f;
+            }
+        }
+        for (size_t c = 1; c < m_channels; ++c) {
+            for (size_t i = 0; i < samples; ++i) {
+                mdalloc[i] += input[c][i];
+            }
+        }
+        for (size_t i = 0; i < samples; ++i) {
+            mdalloc[i] /= m_channels;
+        }
+        mixdown = mdalloc;
+    } else {
+        mixdown = input[0];
+    }
+
+    while (consumed < samples) {
+
+	size_t writable = inbuf.getWriteSpace();
+	writable = min(writable, samples - consumed);
+
+	if (writable == 0) {
+            // warn
+            cerr << "WARNING: writable == 0 (consumed = " << consumed << ", samples = " << samples << ")" << endl;
+	} else {
+            inbuf.write(mixdown + consumed, writable);
+            consumed += writable;
+        }
+
+	while ((inbuf.getReadSpace() >= int(m_aWindowSize)) ||
+               (final && (inbuf.getReadSpace() >= int(m_aWindowSize/2)))) {
+
+	    // We know we have at least m_aWindowSize samples
+	    // available in m_inbuf.  We need to peek m_aWindowSize of
+	    // them for processing, and then skip m_increment to
+	    // advance the read pointer.
+
+            // cd.accumulator is not otherwise used during studying,
+            // so we can use it as a temporary buffer here
+
+            size_t ready = inbuf.getReadSpace();
+            assert(final || ready >= m_aWindowSize);
+            inbuf.peek(cd.accumulator, std::min(ready, m_aWindowSize));
+
+            if (m_aWindowSize == m_fftSize) {
+
+                // We don't need the fftshift for studying, as we're
+                // only interested in magnitude.
+
+                m_awindow->cut(cd.accumulator);
+
+            } else {
+
+                // If we need to fold (i.e. if the window size is
+                // greater than the fft size so we are doing a
+                // time-aliased presum fft) or zero-pad, then we might
+                // as well use our standard function for it.  This
+                // means we retain the m_afilter cut if folding as well,
+                // which is good for consistency with real-time mode.
+                // We get fftshift as well, which we don't want, but
+                // the penalty is nominal.
+
+                // Note that we can't do this in-place.  Pity
+
+                float *tmp = (float *)alloca
+                    (std::max(m_fftSize, m_aWindowSize) * sizeof(float));
+
+                if (m_aWindowSize > m_fftSize) {
+                    m_afilter->cut(cd.accumulator);
+                }
+
+                cutShiftAndFold(tmp, m_fftSize, cd.accumulator, m_awindow);
+                v_copy(cd.accumulator, tmp, m_fftSize);
+            }
+
+            m_studyFFT->forwardMagnitude(cd.accumulator, cd.fltbuf);
+
+            float df = m_phaseResetAudioCurve->processFloat(cd.fltbuf, m_increment);
+            m_phaseResetDf.push_back(df);
+
+//            cout << m_phaseResetDf.size() << " [" << final << "] -> " << df << " \t: ";
+
+            df = m_stretchAudioCurve->processFloat(cd.fltbuf, m_increment);
+            m_stretchDf.push_back(df);
+
+            df = m_silentAudioCurve->processFloat(cd.fltbuf, m_increment);
+            bool silent = (df > 0.f);
+            if (silent && m_debugLevel > 1) {
+                cerr << "silence found at " << m_inputDuration << endl;
+            }
+            m_silence.push_back(silent);
+
+//            cout << df << endl;
+
+            // We have augmented the input by m_aWindowSize/2 so that
+            // the first chunk is centred on the first audio sample.
+            // We want to ensure that m_inputDuration contains the
+            // exact input duration without including this extra bit.
+            // We just add up all the increments here, and deduct the
+            // extra afterwards.
+
+            m_inputDuration += m_increment;
+//                cerr << "incr input duration by increment: " << m_increment << " -> " << m_inputDuration << endl;
+            inbuf.skip(m_increment);
+	}
+    }
+
+    if (final) {
+        int rs = inbuf.getReadSpace();
+        m_inputDuration += rs;
+//        cerr << "incr input duration by read space: " << rs << " -> " << m_inputDuration << endl;
+
+        if (m_inputDuration > m_aWindowSize/2) { // deducting the extra
+            m_inputDuration -= m_aWindowSize/2;
+        }
+    }
+
+    if (m_channels > 1 || final) delete[] mdalloc;
+}
+
+vector<int>
+RubberBandStretcher::Impl::getOutputIncrements() const
+{
+    if (!m_realtime) {
+        return m_outputIncrements;
+    } else {
+        vector<int> increments;
+        while (m_lastProcessOutputIncrements.getReadSpace() > 0) {
+            increments.push_back(m_lastProcessOutputIncrements.readOne());
+        }
+        return increments;
+    }
+}
+
+vector<float>
+RubberBandStretcher::Impl::getPhaseResetCurve() const
+{
+    if (!m_realtime) {
+        return m_phaseResetDf;
+    } else {
+        vector<float> df;
+        while (m_lastProcessPhaseResetDf.getReadSpace() > 0) {
+            df.push_back(m_lastProcessPhaseResetDf.readOne());
+        }
+        return df;
+    }
+}
+
+vector<int>
+RubberBandStretcher::Impl::getExactTimePoints() const
+{
+    std::vector<int> points;
+    if (!m_realtime) {
+        std::vector<StretchCalculator::Peak> peaks =
+            m_stretchCalculator->getLastCalculatedPeaks();
+        for (size_t i = 0; i < peaks.size(); ++i) {
+            points.push_back(peaks[i].chunk);
+        }
+    }
+    return points;
+}
+
+void
+RubberBandStretcher::Impl::calculateStretch()
+{
+    Profiler profiler("RubberBandStretcher::Impl::calculateStretch");
+
+    size_t inputDuration = m_inputDuration;
+
+    if (!m_realtime && m_expectedInputDuration > 0) {
+        if (m_expectedInputDuration != inputDuration) {
+            std::cerr << "RubberBandStretcher: WARNING: Actual study() duration differs from duration set by setExpectedInputDuration (" << m_inputDuration << " vs " << m_expectedInputDuration << ", diff = " << (m_expectedInputDuration - m_inputDuration) << "), using the latter for calculation" << std::endl;
+            inputDuration = m_expectedInputDuration;
+        }
+    }
+
+    double prdm = 0, sdm = 0;
+    if (!m_phaseResetDf.empty()) {
+        for (int i = 0; i < (int)m_phaseResetDf.size(); ++i) {
+            prdm += m_phaseResetDf[i];
+        }
+        prdm /= m_phaseResetDf.size();
+    }
+    if (!m_stretchDf.empty()) {
+        for (int i = 0; i < (int)m_stretchDf.size(); ++i) {
+            sdm += m_stretchDf[i];
+        }
+        sdm /= m_stretchDf.size();
+    }
+//    std::cerr << "phase reset df mean = " << prdm << ", stretch df mean = " << sdm << std::endl;
+
+    std::vector<int> increments = m_stretchCalculator->calculate
+        (getEffectiveRatio(),
+         inputDuration,
+         m_phaseResetDf,
+         m_stretchDf);
+
+    int history = 0;
+    for (size_t i = 0; i < increments.size(); ++i) {
+        if (i >= m_silence.size()) break;
+        if (m_silence[i]) ++history;
+        else history = 0;
+        if (history >= int(m_aWindowSize / m_increment) && increments[i] >= 0) {
+            increments[i] = -increments[i];
+            if (m_debugLevel > 1) {
+                std::cerr << "phase reset on silence (silent history == "
+                          << history << ")" << std::endl;
+            }
+        }
+    }
+
+    if (m_outputIncrements.empty()) m_outputIncrements = increments;
+    else {
+        for (size_t i = 0; i < increments.size(); ++i) {
+            m_outputIncrements.push_back(increments[i]);
+        }
+    }
+    
+    return;
+}
+
+void
+RubberBandStretcher::Impl::setDebugLevel(int level)
+{
+    m_debugLevel = level;
+    if (m_stretchCalculator) m_stretchCalculator->setDebugLevel(level);
+}	
+
+size_t
+RubberBandStretcher::Impl::getSamplesRequired() const
+{
+    Profiler profiler("RubberBandStretcher::Impl::getSamplesRequired");
+
+    size_t reqd = 0;
+
+    for (size_t c = 0; c < m_channels; ++c) {
+
+        size_t reqdHere = 0;
+
+        ChannelData &cd = *m_channelData[c];
+        RingBuffer<float> &inbuf = *cd.inbuf;
+        RingBuffer<float> &outbuf = *cd.outbuf;
+
+        size_t rs = inbuf.getReadSpace();
+        size_t ws = outbuf.getReadSpace();
+
+        if (m_debugLevel > 2) {
+            cerr << "getSamplesRequired: ws = " << ws << ", rs = " << rs << ", m_aWindowSize = " << m_aWindowSize << endl;
+        }
+
+        // We should never return zero in non-threaded modes if
+        // available() would also return zero, i.e. if ws == 0.  If we
+        // do that, nothing will ever happen again!  We need to demand
+        // at least one increment (i.e. a nominal amount) to feed the
+        // engine.
+
+        if (ws == 0 && reqd == 0) reqd = m_increment;
+
+        // See notes in testInbufReadSpace 
+
+        if (rs < m_aWindowSize && !cd.draining) {
+            
+            if (cd.inputSize == -1) {
+                reqdHere = m_aWindowSize - rs;
+                if (reqdHere > reqd) reqd = reqdHere;
+                continue;
+            }
+        
+            if (rs == 0) {
+                reqdHere = m_aWindowSize;
+                if (reqdHere > reqd) reqd = reqdHere;
+                continue;
+            }
+        }
+    }
+    
+    return reqd;
+}    
+
+void
+RubberBandStretcher::Impl::process(const float *const *input, size_t samples, bool final)
+{
+    Profiler profiler("RubberBandStretcher::Impl::process");
+
+    if (m_mode == Finished) {
+        cerr << "RubberBandStretcher::Impl::process: Cannot process again after final chunk" << endl;
+        return;
+    }
+
+    if (m_mode == JustCreated || m_mode == Studying) {
+
+        if (m_mode == Studying) {
+
+            calculateStretch();
+
+            if (!m_realtime) {
+                // See note in configure() above. Of course, we should
+                // never enter Studying unless we are non-RT anyway
+                if (m_debugLevel > 1) {
+                    cerr << "Not real time mode: prefilling" << endl;
+                }
+                for (size_t c = 0; c < m_channels; ++c) {
+                    m_channelData[c]->reset();
+                    m_channelData[c]->inbuf->zero(m_aWindowSize/2);
+                }
+            }
+        }
+
+#ifndef NO_THREADING
+        if (m_threaded) {
+            MutexLocker locker(&m_threadSetMutex);
+
+            for (size_t c = 0; c < m_channels; ++c) {
+                ProcessThread *thread = new ProcessThread(this, c);
+                m_threadSet.insert(thread);
+                thread->start();
+            }
+            
+            if (m_debugLevel > 0) {
+                cerr << m_channels << " threads created" << endl;
+            }
+        }
+#endif
+        
+        m_mode = Processing;
+    }
+
+    bool allConsumed = false;
+
+    size_t *consumed = (size_t *)alloca(m_channels * sizeof(size_t));
+    for (size_t c = 0; c < m_channels; ++c) {
+        consumed[c] = 0;
+    }
+
+    while (!allConsumed) {
+
+        // In a threaded mode, our "consumed" counters only indicate
+        // the number of samples that have been taken into the input
+        // ring buffers waiting to be processed by the process thread.
+        // In non-threaded mode, "consumed" counts the number that
+        // have actually been processed.
+
+        allConsumed = true;
+
+        for (size_t c = 0; c < m_channels; ++c) {
+            consumed[c] += consumeChannel(c,
+                                          input,
+                                          consumed[c],
+                                          samples - consumed[c],
+                                          final);
+            if (consumed[c] < samples) {
+                allConsumed = false;
+//                cerr << "process: waiting on input consumption for channel " << c << endl;
+            } else {
+                if (final) {
+                    m_channelData[c]->inputSize = m_channelData[c]->inCount;
+                }
+//                cerr << "process: happy with channel " << c << endl;
+            }
+            if (
+#ifndef NO_THREADING
+                !m_threaded &&
+#endif
+                !m_realtime) {
+                bool any = false, last = false;
+                processChunks(c, any, last);
+            }
+        }
+
+        if (m_realtime) {
+            // When running in real time, we need to process both
+            // channels in step because we will need to use the sum of
+            // their frequency domain representations as the input to
+            // the realtime onset detector
+            processOneChunk();
+        }
+#ifndef NO_THREADING
+        if (m_threaded) {
+            for (ThreadSet::iterator i = m_threadSet.begin();
+                 i != m_threadSet.end(); ++i) {
+                (*i)->signalDataAvailable();
+            }
+            m_spaceAvailable.lock();
+            if (!allConsumed) {
+                m_spaceAvailable.wait(500);
+            }
+            m_spaceAvailable.unlock();
+        }
+#endif
+
+        if (m_debugLevel > 1) {
+            if (!allConsumed) cerr << "process looping" << endl;
+        }
+    }
+
+    if (m_debugLevel > 1) {
+        cerr << "process returning" << endl;
+    }
+
+    if (final) m_mode = Finished;
+}
+
+
+}
+

--- a/pedalboard/vendors/rubberband/src/StretcherImpl.h
+++ b/pedalboard/vendors/rubberband/src/StretcherImpl.h
@@ -1,0 +1,270 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_STRETCHERIMPL_H
+#define RUBBERBAND_STRETCHERIMPL_H
+
+#include "../rubberband/RubberBandStretcher.h"
+
+#include "dsp/Window.h"
+#include "dsp/SincWindow.h"
+#include "dsp/FFT.h"
+
+#include "audiocurves/CompoundAudioCurve.h"
+
+#include "base/RingBuffer.h"
+#include "base/Scavenger.h"
+#include "system/Thread.h"
+#include "system/sysutils.h"
+
+#include <set>
+#include <algorithm>
+
+using namespace RubberBand;
+
+namespace RubberBand
+{
+
+#ifdef PROCESS_SAMPLE_TYPE
+typedef PROCESS_SAMPLE_TYPE process_t;
+#else
+typedef double process_t;
+#endif
+
+class AudioCurveCalculator;
+class StretchCalculator;
+
+class RubberBandStretcher::Impl
+{
+public:
+    Impl(size_t sampleRate, size_t channels, Options options,
+         double initialTimeRatio, double initialPitchScale);
+    ~Impl();
+    
+    void reset();
+    void setTimeRatio(double ratio);
+    void setPitchScale(double scale);
+
+    double getTimeRatio() const;
+    double getPitchScale() const;
+
+    size_t getLatency() const;
+
+    void setTransientsOption(Options);
+    void setDetectorOption(Options);
+    void setPhaseOption(Options);
+    void setFormantOption(Options);
+    void setPitchOption(Options);
+
+    void setExpectedInputDuration(size_t samples);
+    void setMaxProcessSize(size_t samples);
+    void setKeyFrameMap(const std::map<size_t, size_t> &);
+
+    size_t getSamplesRequired() const;
+
+    void study(const float *const *input, size_t samples, bool final);
+    void process(const float *const *input, size_t samples, bool final);
+
+    int available() const;
+    size_t retrieve(float *const *output, size_t samples) const;
+
+    float getFrequencyCutoff(int n) const;
+    void setFrequencyCutoff(int n, float f);
+
+    size_t getInputIncrement() const {
+        return m_increment;
+    }
+
+    std::vector<int> getOutputIncrements() const;
+    std::vector<float> getPhaseResetCurve() const;
+    std::vector<int> getExactTimePoints() const;
+
+    size_t getChannelCount() const {
+        return m_channels;
+    }
+    
+    void calculateStretch();
+
+    void setDebugLevel(int level);
+    static void setDefaultDebugLevel(int level) { m_defaultDebugLevel = level; }
+
+protected:
+    size_t m_sampleRate;
+    size_t m_channels;
+
+    void prepareChannelMS(size_t channel, const float *const *inputs,
+                          size_t offset, size_t samples, float *prepared);
+    size_t consumeChannel(size_t channel, const float *const *inputs,
+                          size_t offset, size_t samples, bool final);
+    void processChunks(size_t channel, bool &any, bool &last);
+    bool processOneChunk(); // across all channels, for real time use
+    bool processChunkForChannel(size_t channel, size_t phaseIncrement,
+                                size_t shiftIncrement, bool phaseReset);
+    bool testInbufReadSpace(size_t channel);
+    void calculateIncrements(size_t &phaseIncrement,
+                             size_t &shiftIncrement, bool &phaseReset);
+    bool getIncrements(size_t channel, size_t &phaseIncrement,
+                       size_t &shiftIncrement, bool &phaseReset);
+    void analyseChunk(size_t channel);
+    void modifyChunk(size_t channel, size_t outputIncrement, bool phaseReset);
+    void formantShiftChunk(size_t channel);
+    void synthesiseChunk(size_t channel, size_t shiftIncrement);
+    void writeChunk(size_t channel, size_t shiftIncrement, bool last);
+
+    void calculateSizes();
+    void configure();
+    void reconfigure();
+
+    double getEffectiveRatio() const;
+    
+    size_t roundUp(size_t value); // to next power of two
+
+    template <typename T, typename S>
+    void cutShiftAndFold(T *target, int targetSize,
+                         S *src, // destructive to src
+                         Window<float> *window) {
+        window->cut(src);
+        const int windowSize = window->getSize();
+        const int hs = targetSize / 2;
+        if (windowSize == targetSize) {
+            v_convert(target, src + hs, hs);
+            v_convert(target + hs, src, hs);
+        } else {
+            v_zero(target, targetSize);
+            int j = targetSize - windowSize/2;
+            while (j < 0) j += targetSize;
+            for (int i = 0; i < windowSize; ++i) {
+                target[j] += src[i];
+                if (++j == targetSize) j = 0;
+            }
+        }
+    }
+
+    bool resampleBeforeStretching() const;
+    
+    double m_timeRatio;
+    double m_pitchScale;
+
+    // n.b. either m_fftSize is an integer multiple of m_windowSize,
+    // or vice versa
+    size_t m_fftSize;
+    size_t m_aWindowSize; //!!! or use m_awindow->getSize() throughout?
+    size_t m_sWindowSize; //!!! or use m_swindow->getSize() throughout?
+    size_t m_increment;
+    size_t m_outbufSize;
+
+    size_t m_maxProcessSize;
+    size_t m_expectedInputDuration;
+
+#ifndef NO_THREADING    
+    bool m_threaded;
+#endif
+
+    bool m_realtime;
+    Options m_options;
+    int m_debugLevel;
+
+    enum ProcessMode {
+        JustCreated,
+        Studying,
+        Processing,
+        Finished
+    };
+
+    ProcessMode m_mode;
+
+    std::map<size_t, Window<float> *> m_windows;
+    std::map<size_t, SincWindow<float> *> m_sincs;
+    Window<float> *m_awindow;
+    SincWindow<float> *m_afilter;
+    Window<float> *m_swindow;
+    FFT *m_studyFFT;
+
+#ifndef NO_THREADING
+    Condition m_spaceAvailable;
+    
+    class ProcessThread : public Thread
+    {
+    public:
+        ProcessThread(Impl *s, size_t c);
+        void run();
+        void signalDataAvailable();
+        void abandon();
+    private:
+        Impl *m_s;
+        size_t m_channel;
+        Condition m_dataAvailable;
+        bool m_abandoning;
+    };
+
+    mutable Mutex m_threadSetMutex;
+    typedef std::set<ProcessThread *> ThreadSet;
+    ThreadSet m_threadSet;
+    
+#if defined HAVE_IPP && !defined USE_SPEEX
+    // Exasperatingly, the IPP polyphase resampler does not appear to
+    // be thread-safe as advertised -- a good reason to prefer the
+    // Speex alternative
+    Mutex m_resamplerMutex;
+#endif
+#endif
+
+    size_t m_inputDuration;
+    CompoundAudioCurve::Type m_detectorType;
+    std::vector<float> m_phaseResetDf;
+    std::vector<float> m_stretchDf;
+    std::vector<bool> m_silence;
+    int m_silentHistory;
+
+    class ChannelData; 
+    std::vector<ChannelData *> m_channelData;
+
+    std::vector<int> m_outputIncrements;
+
+    mutable RingBuffer<int> m_lastProcessOutputIncrements;
+    mutable RingBuffer<float> m_lastProcessPhaseResetDf;
+    Scavenger<RingBuffer<float> > m_emergencyScavenger;
+
+    CompoundAudioCurve *m_phaseResetAudioCurve;
+    AudioCurveCalculator *m_stretchAudioCurve;
+    AudioCurveCalculator *m_silentAudioCurve;
+    StretchCalculator *m_stretchCalculator;
+
+    float m_freq0;
+    float m_freq1;
+    float m_freq2;
+
+    size_t m_baseFftSize;
+    float m_rateMultiple;
+
+    void writeOutput(RingBuffer<float> &to, float *from,
+                     size_t qty, size_t &outCount, size_t theoreticalOut);
+
+    static int m_defaultDebugLevel;
+    static const size_t m_defaultIncrement;
+    static const size_t m_defaultFftSize;
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/StretcherProcess.cpp
+++ b/pedalboard/vendors/rubberband/src/StretcherProcess.cpp
@@ -1,0 +1,1311 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "StretcherImpl.h"
+
+#include "audiocurves/PercussiveAudioCurve.h"
+#include "audiocurves/HighFrequencyAudioCurve.h"
+#include "audiocurves/ConstantAudioCurve.h"
+
+#include "StretchCalculator.h"
+#include "StretcherChannelData.h"
+
+#include "dsp/Resampler.h"
+#include "base/Profiler.h"
+#include "system/VectorOps.h"
+#include "system/sysutils.h"
+
+#include <cassert>
+#include <cmath>
+#include <set>
+#include <map>
+#include <deque>
+#include <algorithm>
+
+using namespace RubberBand;
+
+using std::cerr;
+using std::endl;
+
+namespace RubberBand {
+
+#ifndef NO_THREADING
+
+RubberBandStretcher::Impl::ProcessThread::ProcessThread(Impl *s, size_t c) :
+    m_s(s),
+    m_channel(c),
+    m_dataAvailable(std::string("data ") + char('A' + c)),
+    m_abandoning(false)
+{ }
+
+void
+RubberBandStretcher::Impl::ProcessThread::run()
+{
+    if (m_s->m_debugLevel > 1) {
+        cerr << "thread " << m_channel << " getting going" << endl;
+    }
+
+    ChannelData &cd = *m_s->m_channelData[m_channel];
+
+    while (cd.inputSize == -1 ||
+           cd.inbuf->getReadSpace() > 0) {
+
+//        if (cd.inputSize != -1) {
+//            cerr << "inputSize == " << cd.inputSize
+//                 << ", readSpace == " << cd.inbuf->getReadSpace() << endl;
+//        }
+        
+        bool any = false, last = false;
+        m_s->processChunks(m_channel, any, last);
+
+        if (last) break;
+
+        if (any) {
+            m_s->m_spaceAvailable.lock();
+            m_s->m_spaceAvailable.signal();
+            m_s->m_spaceAvailable.unlock();
+        }
+
+        m_dataAvailable.lock();
+        if (!m_s->testInbufReadSpace(m_channel) && !m_abandoning) {
+            m_dataAvailable.wait(50000); // bounded in case of abandonment
+        }
+        m_dataAvailable.unlock();
+
+        if (m_abandoning) {
+            if (m_s->m_debugLevel > 1) {
+                cerr << "thread " << m_channel << " abandoning" << endl;
+            }
+            return;
+        }
+    }
+
+    bool any = false, last = false;
+    m_s->processChunks(m_channel, any, last);
+    m_s->m_spaceAvailable.lock();
+    m_s->m_spaceAvailable.signal();
+    m_s->m_spaceAvailable.unlock();
+    
+    if (m_s->m_debugLevel > 1) {
+        cerr << "thread " << m_channel << " done" << endl;
+    }
+}
+
+void
+RubberBandStretcher::Impl::ProcessThread::signalDataAvailable()
+{
+    m_dataAvailable.lock();
+    m_dataAvailable.signal();
+    m_dataAvailable.unlock();
+}
+
+void
+RubberBandStretcher::Impl::ProcessThread::abandon()
+{
+    m_abandoning = true;
+}
+
+#endif
+
+bool
+RubberBandStretcher::Impl::resampleBeforeStretching() const
+{
+    // We can't resample before stretching in offline mode, because
+    // the stretch calculation is based on doing it the other way
+    // around.  It would take more work (and testing) to enable this.
+    if (!m_realtime) return false;
+
+    if (m_options & OptionPitchHighQuality) {
+        return (m_pitchScale < 1.0); // better sound
+    } else if (m_options & OptionPitchHighConsistency) {
+        return false;
+    } else {
+        return (m_pitchScale > 1.0); // better performance
+    }
+}
+
+void
+RubberBandStretcher::Impl::prepareChannelMS(size_t c,
+                                            const float *const *inputs,
+                                            size_t offset,
+                                            size_t samples, 
+                                            float *prepared)
+{
+    for (size_t i = 0; i < samples; ++i) {
+        float left = inputs[0][i + offset];
+        float right = inputs[1][i + offset];
+        float mid = (left + right) / 2;
+        float side = (left - right) / 2;
+        if (c == 0) {
+            prepared[i] = mid;
+        } else {
+            prepared[i] = side;
+        }
+    }
+}
+    
+size_t
+RubberBandStretcher::Impl::consumeChannel(size_t c,
+                                          const float *const *inputs,
+                                          size_t offset,
+                                          size_t samples,
+                                          bool final)
+{
+    Profiler profiler("RubberBandStretcher::Impl::consumeChannel");
+
+    ChannelData &cd = *m_channelData[c];
+    RingBuffer<float> &inbuf = *cd.inbuf;
+
+    size_t toWrite = samples;
+    size_t writable = inbuf.getWriteSpace();
+
+    bool resampling = resampleBeforeStretching();
+
+    const float *input = 0;
+
+    bool useMidSide = ((m_options & OptionChannelsTogether) &&
+                       (m_channels >= 2) &&
+                       (c < 2));
+
+    if (resampling) {
+
+        Profiler profiler2("RubberBandStretcher::Impl::resample");
+        
+        toWrite = int(ceil(samples / m_pitchScale));
+        if (writable < toWrite) {
+            samples = int(floor(writable * m_pitchScale));
+            if (samples == 0) return 0;
+        }
+
+        size_t reqSize = int(ceil(samples / m_pitchScale));
+        if (reqSize > cd.resamplebufSize) {
+            cerr << "WARNING: RubberBandStretcher::Impl::consumeChannel: resizing resampler buffer from "
+                 << cd.resamplebufSize << " to " << reqSize << endl;
+            cd.setResampleBufSize(reqSize);
+        }
+
+#ifndef NO_THREADING
+#if defined HAVE_IPP && !defined USE_SPEEX
+        if (m_threaded) {
+            m_resamplerMutex.lock();
+        }
+#endif
+#endif
+
+        if (useMidSide) {
+            prepareChannelMS(c, inputs, offset, samples, cd.ms);
+            input = cd.ms;
+        } else {
+            input = inputs[c] + offset;
+        }
+
+        toWrite = cd.resampler->resample(&cd.resamplebuf,
+                                         cd.resamplebufSize,
+                                         &input,
+                                         samples,
+                                         1.0 / m_pitchScale,
+                                         final);
+
+#ifndef NO_THREADING
+#if defined HAVE_IPP && !defined USE_SPEEX
+        if (m_threaded) {
+            m_resamplerMutex.unlock();
+        }
+#endif
+#endif
+    }
+
+    if (writable < toWrite) {
+        if (resampling) {
+            return 0;
+        }
+        toWrite = writable;
+    }
+
+    if (resampling) {
+
+        inbuf.write(cd.resamplebuf, toWrite);
+        cd.inCount += samples;
+        return samples;
+
+    } else {
+
+        if (useMidSide) {
+            prepareChannelMS(c, inputs, offset, toWrite, cd.ms);
+            input = cd.ms;
+        } else {
+            input = inputs[c] + offset;
+        }
+
+        inbuf.write(input, toWrite);
+        cd.inCount += toWrite;
+        return toWrite;
+    }
+}
+
+void
+RubberBandStretcher::Impl::processChunks(size_t c, bool &any, bool &last)
+{
+    Profiler profiler("RubberBandStretcher::Impl::processChunks");
+
+    // Process as many chunks as there are available on the input
+    // buffer for channel c.  This requires that the increments have
+    // already been calculated.
+
+    // This is the normal process method in offline mode.
+
+    ChannelData &cd = *m_channelData[c];
+
+    last = false;
+    any = false;
+
+    float *tmp = 0;
+
+    while (!last) {
+
+        if (!testInbufReadSpace(c)) {
+            if (m_debugLevel > 1) {
+                cerr << "processChunks: out of input" << endl;
+            }
+            break;
+        }
+
+        any = true;
+
+        if (!cd.draining) {
+            size_t ready = cd.inbuf->getReadSpace();
+            assert(ready >= m_aWindowSize || cd.inputSize >= 0);
+            cd.inbuf->peek(cd.fltbuf, std::min(ready, m_aWindowSize));
+            cd.inbuf->skip(m_increment);
+        }
+
+        bool phaseReset = false;
+        size_t phaseIncrement, shiftIncrement;
+        getIncrements(c, phaseIncrement, shiftIncrement, phaseReset);
+
+        if (shiftIncrement <= m_aWindowSize) {
+            analyseChunk(c);
+            last = processChunkForChannel
+                (c, phaseIncrement, shiftIncrement, phaseReset);
+        } else {
+            size_t bit = m_aWindowSize/4;
+            if (m_debugLevel > 1) {
+                cerr << "channel " << c << " breaking down overlong increment " << shiftIncrement << " into " << bit << "-size bits" << endl;
+            }
+            if (!tmp) tmp = allocate<float>(m_aWindowSize);
+            analyseChunk(c);
+            v_copy(tmp, cd.fltbuf, m_aWindowSize);
+            for (size_t i = 0; i < shiftIncrement; i += bit) {
+                v_copy(cd.fltbuf, tmp, m_aWindowSize);
+                size_t thisIncrement = bit;
+                if (i + thisIncrement > shiftIncrement) {
+                    thisIncrement = shiftIncrement - i;
+                }
+                last = processChunkForChannel
+                    (c, phaseIncrement + i, thisIncrement, phaseReset);
+                phaseReset = false;
+            }
+        }
+
+        cd.chunkCount++;
+        if (m_debugLevel > 2) {
+            cerr << "channel " << c << ": last = " << last << ", chunkCount = " << cd.chunkCount << endl;
+        }
+    }
+
+    if (tmp) deallocate(tmp);
+}
+
+bool
+RubberBandStretcher::Impl::processOneChunk()
+{
+    Profiler profiler("RubberBandStretcher::Impl::processOneChunk");
+
+    // Process a single chunk for all channels, provided there is
+    // enough data on each channel for at least one chunk.  This is
+    // able to calculate increments as it goes along.
+
+    // This is the normal process method in RT mode.
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        if (!testInbufReadSpace(c)) {
+            if (m_debugLevel > 1) {
+                cerr << "processOneChunk: out of input" << endl;
+            }
+            return false;
+        }
+        ChannelData &cd = *m_channelData[c];
+        if (!cd.draining) {
+            size_t ready = cd.inbuf->getReadSpace();
+            assert(ready >= m_aWindowSize || cd.inputSize >= 0);
+            cd.inbuf->peek(cd.fltbuf, std::min(ready, m_aWindowSize));
+            cd.inbuf->skip(m_increment);
+            analyseChunk(c);
+        }
+    }
+    
+    bool phaseReset = false;
+    size_t phaseIncrement, shiftIncrement;
+    if (!getIncrements(0, phaseIncrement, shiftIncrement, phaseReset)) {
+        calculateIncrements(phaseIncrement, shiftIncrement, phaseReset);
+    }
+
+    bool last = false;
+    for (size_t c = 0; c < m_channels; ++c) {
+        last = processChunkForChannel(c, phaseIncrement, shiftIncrement, phaseReset);
+        m_channelData[c]->chunkCount++;
+    }
+
+    return last;
+}
+
+bool
+RubberBandStretcher::Impl::testInbufReadSpace(size_t c)
+{
+    Profiler profiler("RubberBandStretcher::Impl::testInbufReadSpace");
+
+    ChannelData &cd = *m_channelData[c];
+    RingBuffer<float> &inbuf = *cd.inbuf;
+
+    size_t rs = inbuf.getReadSpace();
+
+    if (rs < m_aWindowSize && !cd.draining) {
+            
+        if (cd.inputSize == -1) {
+
+            // Not all the input data has been written to the inbuf
+            // (that's why the input size is not yet set).  We can't
+            // process, because we don't have a full chunk of data, so
+            // our process chunk would contain some empty padding in
+            // its input -- and that would give incorrect output, as
+            // we know there is more input to come.
+
+#ifndef NO_THREADING
+            if (!m_threaded) {
+#endif
+                if (m_debugLevel > 1) {
+                    cerr << "Note: RubberBandStretcher: read space < chunk size ("
+                         << inbuf.getReadSpace() << " < " << m_aWindowSize
+                         << ") when not all input written, on processChunks for channel " << c << endl;
+                }
+
+#ifndef NO_THREADING
+            }
+#endif
+            return false;
+        }
+        
+        if (rs == 0) {
+
+            if (m_debugLevel > 1) {
+                cerr << "read space = 0, giving up" << endl;
+            }
+            return false;
+
+        } else if (rs < m_aWindowSize/2) {
+
+            if (m_debugLevel > 1) {
+                cerr << "read space = " << rs << ", setting draining true" << endl;
+            }
+            
+            cd.draining = true;
+        }
+    }
+
+    return true;
+}
+
+bool 
+RubberBandStretcher::Impl::processChunkForChannel(size_t c,
+                                                  size_t phaseIncrement,
+                                                  size_t shiftIncrement,
+                                                  bool phaseReset)
+{
+    Profiler profiler("RubberBandStretcher::Impl::processChunkForChannel");
+
+    // Process a single chunk on a single channel.  This assumes
+    // enough input data is available; caller must have tested this
+    // using e.g. testInbufReadSpace first.  Return true if this is
+    // the last chunk on the channel.
+
+    if (phaseReset && (m_debugLevel > 1)) {
+        cerr << "processChunkForChannel: phase reset found, incrs "
+             << phaseIncrement << ":" << shiftIncrement << endl;
+    }
+
+    ChannelData &cd = *m_channelData[c];
+
+    if (!cd.draining) {
+        
+        // This is the normal processing case -- draining is only
+        // set when all the input has been used and we only need
+        // to write from the existing accumulator into the output.
+        
+        // We know we have enough samples available in m_inbuf --
+        // this is usually m_aWindowSize, but we know that if fewer
+        // are available, it's OK to use zeroes for the rest
+        // (which the ring buffer will provide) because we've
+        // reached the true end of the data.
+        
+        // We need to peek m_aWindowSize samples for processing, and
+        // then skip m_increment to advance the read pointer.
+
+        modifyChunk(c, phaseIncrement, phaseReset);
+        synthesiseChunk(c, shiftIncrement); // reads from cd.mag, cd.phase
+
+        if (m_debugLevel > 2) {
+            if (phaseReset) {
+                for (int i = 0; i < 10; ++i) {
+                    cd.accumulator[i] = 1.2f - (i % 3) * 1.2f;
+                }
+            }
+        }
+    }
+
+    bool last = false;
+
+    if (cd.draining) {
+        if (m_debugLevel > 1) {
+            cerr << "draining: accumulator fill = " << cd.accumulatorFill << " (shiftIncrement = " << shiftIncrement << ")" <<  endl;
+        }
+        if (shiftIncrement == 0) {
+            cerr << "WARNING: draining: shiftIncrement == 0, can't handle that in this context: setting to " << m_increment << endl;
+            shiftIncrement = m_increment;
+        }
+        if (cd.accumulatorFill <= shiftIncrement) {
+            if (m_debugLevel > 1) {
+                cerr << "reducing shift increment from " << shiftIncrement
+                          << " to " << cd.accumulatorFill
+                          << " and marking as last" << endl;
+            }
+            shiftIncrement = cd.accumulatorFill;
+            last = true;
+        }
+    }
+        
+    int required = shiftIncrement;
+
+    if (m_pitchScale != 1.0) {
+        required = int(required / m_pitchScale) + 1;
+    }
+
+    int ws = cd.outbuf->getWriteSpace();
+    if (ws < required) {
+        if (m_debugLevel > 0) {
+            cerr << "Buffer overrun on output for channel " << c << endl;
+        }
+
+        // The only correct thing we can do here is resize the buffer.
+        // We can't wait for the client thread to read some data out
+        // from the buffer so as to make more space, because the
+        // client thread (if we are threaded at all) is probably stuck
+        // in a process() call waiting for us to stow away enough
+        // input increments to allow the process() call to complete.
+        // This is an unhappy situation.
+
+        RingBuffer<float> *oldbuf = cd.outbuf;
+        cd.outbuf = oldbuf->resized(oldbuf->getSize() * 2);
+
+        if (m_debugLevel > 1) {
+            cerr << "(Write space was " << ws << ", needed " << required
+                 << ": resized output buffer from " << oldbuf->getSize()
+                 << " to " << cd.outbuf->getSize() << ")" << endl;
+        }
+
+        m_emergencyScavenger.claim(oldbuf);
+    }
+
+    writeChunk(c, shiftIncrement, last);
+    return last;
+}
+
+void
+RubberBandStretcher::Impl::calculateIncrements(size_t &phaseIncrementRtn,
+                                               size_t &shiftIncrementRtn,
+                                               bool &phaseReset)
+{
+    Profiler profiler("RubberBandStretcher::Impl::calculateIncrements");
+
+//    cerr << "calculateIncrements" << endl;
+    
+    // Calculate the next upcoming phase and shift increment, on the
+    // basis that both channels are in sync.  This is in contrast to
+    // getIncrements, which requires that all the increments have been
+    // calculated in advance but can then return increments
+    // corresponding to different chunks in different channels.
+
+    // Requires frequency domain representations of channel data in
+    // the mag and phase buffers in the channel.
+
+    // This function is only used in real-time mode.
+
+    phaseIncrementRtn = m_increment;
+    shiftIncrementRtn = m_increment;
+    phaseReset = false;
+
+    if (m_channels == 0) return;
+
+    ChannelData &cd = *m_channelData[0];
+
+    size_t bc = cd.chunkCount;
+    for (size_t c = 1; c < m_channels; ++c) {
+        if (m_channelData[c]->chunkCount != bc) {
+            cerr << "ERROR: RubberBandStretcher::Impl::calculateIncrements: Channels are not in sync" << endl;
+            return;
+        }
+    }
+
+    const int hs = m_fftSize/2 + 1;
+
+    // Normally we would mix down the time-domain signal and apply a
+    // single FFT, or else mix down the Cartesian form of the
+    // frequency-domain signal.  Both of those would be inefficient
+    // from this position.  Fortunately, the onset detectors should
+    // work reasonably well (maybe even better?) if we just sum the
+    // magnitudes of the frequency-domain channel signals and forget
+    // about phase entirely.  Normally we don't expect the channel
+    // phases to cancel each other, and broadband effects will still
+    // be apparent.
+
+    float df = 0.f;
+    bool silent = false;
+
+    if (m_channels == 1) {
+
+        if (sizeof(process_t) == sizeof(double)) {
+            df = m_phaseResetAudioCurve->processDouble((double *)cd.mag, m_increment);
+            silent = (m_silentAudioCurve->processDouble((double *)cd.mag, m_increment) > 0.f);
+        } else {
+            df = m_phaseResetAudioCurve->processFloat((float *)cd.mag, m_increment);
+            silent = (m_silentAudioCurve->processFloat((float *)cd.mag, m_increment) > 0.f);
+        }
+
+    } else {
+
+        process_t *tmp = (process_t *)alloca(hs * sizeof(process_t));
+
+        v_zero(tmp, hs);
+        for (size_t c = 0; c < m_channels; ++c) {
+            v_add(tmp, m_channelData[c]->mag, hs);
+        }
+
+        if (sizeof(process_t) == sizeof(double)) {
+            df = m_phaseResetAudioCurve->processDouble((double *)tmp, m_increment);
+            silent = (m_silentAudioCurve->processDouble((double *)tmp, m_increment) > 0.f);
+        } else {
+            df = m_phaseResetAudioCurve->processFloat((float *)tmp, m_increment);
+            silent = (m_silentAudioCurve->processFloat((float *)tmp, m_increment) > 0.f);
+        }
+    }
+
+    double effectivePitchRatio = 1.0 / m_pitchScale;
+    if (cd.resampler) {
+        effectivePitchRatio = cd.resampler->getEffectiveRatio(effectivePitchRatio);
+    }
+    
+    int incr = m_stretchCalculator->calculateSingle
+        (m_timeRatio, effectivePitchRatio, df, m_increment,
+         m_aWindowSize, m_sWindowSize);
+
+    if (m_lastProcessPhaseResetDf.getWriteSpace() > 0) {
+        m_lastProcessPhaseResetDf.write(&df, 1);
+    }
+    if (m_lastProcessOutputIncrements.getWriteSpace() > 0) {
+        m_lastProcessOutputIncrements.write(&incr, 1);
+    }
+
+    if (incr < 0) {
+        phaseReset = true;
+        incr = -incr;
+    }
+    
+    // The returned increment is the phase increment.  The shift
+    // increment for one chunk is the same as the phase increment for
+    // the following chunk (see comment below).  This means we don't
+    // actually know the shift increment until we see the following
+    // phase increment... which is a bit of a problem.
+
+    // This implies we should use this increment for the shift
+    // increment, and make the following phase increment the same as
+    // it.  This means in RT mode we'll be one chunk later with our
+    // phase reset than we would be in non-RT mode.  The sensitivity
+    // of the broadband onset detector may mean that this isn't a
+    // problem -- test it and see.
+
+    shiftIncrementRtn = incr;
+
+    if (cd.prevIncrement == 0) {
+        phaseIncrementRtn = shiftIncrementRtn;
+    } else {
+        phaseIncrementRtn = cd.prevIncrement;
+    }
+
+    cd.prevIncrement = shiftIncrementRtn;
+
+    if (silent) ++m_silentHistory;
+    else m_silentHistory = 0;
+
+    if (m_silentHistory >= int(m_aWindowSize / m_increment) && !phaseReset) {
+        phaseReset = true;
+        if (m_debugLevel > 1) {
+            cerr << "calculateIncrements: phase reset on silence (silent history == "
+                 << m_silentHistory << ")" << endl;
+        }
+    }
+}
+
+bool
+RubberBandStretcher::Impl::getIncrements(size_t channel,
+                                         size_t &phaseIncrementRtn,
+                                         size_t &shiftIncrementRtn,
+                                         bool &phaseReset)
+{
+    Profiler profiler("RubberBandStretcher::Impl::getIncrements");
+
+    if (channel >= m_channels) {
+        phaseIncrementRtn = m_increment;
+        shiftIncrementRtn = m_increment;
+        phaseReset = false;
+        return false;
+    }
+
+    // There are two relevant output increments here.  The first is
+    // the phase increment which we use when recalculating the phases
+    // for the current chunk; the second is the shift increment used
+    // to determine how far to shift the processing buffer after
+    // writing the chunk.  The shift increment for one chunk is the
+    // same as the phase increment for the following chunk.
+    
+    // When an onset occurs for which we need to reset phases, the
+    // increment given will be negative.
+    
+    // When we reset phases, the previous shift increment (and so
+    // current phase increments) must have been m_increment to ensure
+    // consistency.
+    
+    // m_outputIncrements stores phase increments.
+
+    ChannelData &cd = *m_channelData[channel];
+    bool gotData = true;
+
+    if (cd.chunkCount >= m_outputIncrements.size()) {
+//        cerr << "WARNING: RubberBandStretcher::Impl::getIncrements:"
+//             << " chunk count " << cd.chunkCount << " >= "
+//             << m_outputIncrements.size() << endl;
+        if (m_outputIncrements.size() == 0) {
+            phaseIncrementRtn = m_increment;
+            shiftIncrementRtn = m_increment;
+            phaseReset = false;
+            return false;
+        } else {
+            cd.chunkCount = m_outputIncrements.size()-1;
+            gotData = false;
+        }
+    }
+    
+    int phaseIncrement = m_outputIncrements[cd.chunkCount];
+    
+    int shiftIncrement = phaseIncrement;
+    if (cd.chunkCount + 1 < m_outputIncrements.size()) {
+        shiftIncrement = m_outputIncrements[cd.chunkCount + 1];
+    }
+    
+    if (phaseIncrement < 0) {
+        phaseIncrement = -phaseIncrement;
+        phaseReset = true;
+    }
+    
+    if (shiftIncrement < 0) {
+        shiftIncrement = -shiftIncrement;
+    }
+    /*
+    if (shiftIncrement >= int(m_windowSize)) {
+        cerr << "*** ERROR: RubberBandStretcher::Impl::processChunks: shiftIncrement " << shiftIncrement << " >= windowSize " << m_windowSize << " at " << cd.chunkCount << " (of " << m_outputIncrements.size() << ")" << endl;
+        shiftIncrement = m_windowSize;
+    }
+    */
+    phaseIncrementRtn = phaseIncrement;
+    shiftIncrementRtn = shiftIncrement;
+    if (cd.chunkCount == 0) phaseReset = true; // don't mess with the first chunk
+    return gotData;
+}
+
+void
+RubberBandStretcher::Impl::analyseChunk(size_t channel)
+{
+    Profiler profiler("RubberBandStretcher::Impl::analyseChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+
+    process_t *const R__ dblbuf = cd.dblbuf;
+    float *const R__ fltbuf = cd.fltbuf;
+
+    // cd.fltbuf is known to contain m_aWindowSize samples
+
+    if (m_aWindowSize > m_fftSize) {
+        m_afilter->cut(fltbuf);
+    }
+
+    cutShiftAndFold(dblbuf, m_fftSize, fltbuf, m_awindow);
+
+    cd.fft->forwardPolar(dblbuf, cd.mag, cd.phase);
+}
+
+void
+RubberBandStretcher::Impl::modifyChunk(size_t channel,
+                                       size_t outputIncrement,
+                                       bool phaseReset)
+{
+    Profiler profiler("RubberBandStretcher::Impl::modifyChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+
+    if (phaseReset && m_debugLevel > 1) {
+        cerr << "phase reset: leaving phases unmodified" << endl;
+    }
+
+    const process_t rate = process_t(m_sampleRate);
+    const int count = m_fftSize / 2;
+
+    bool unchanged = cd.unchanged && (outputIncrement == m_increment);
+    bool fullReset = phaseReset;
+    bool laminar = !(m_options & OptionPhaseIndependent);
+    bool bandlimited = (m_options & OptionTransientsMixed);
+    int bandlow = lrint((150 * m_fftSize) / rate);
+    int bandhigh = lrint((1000 * m_fftSize) / rate);
+
+    float freq0 = m_freq0;
+    float freq1 = m_freq1;
+    float freq2 = m_freq2;
+
+    if (laminar) {
+        float r = getEffectiveRatio();
+        if (r > 1) {
+            float rf0 = 600 + (600 * ((r-1)*(r-1)*(r-1)*2));
+            float f1ratio = freq1 / freq0;
+            float f2ratio = freq2 / freq0;
+            freq0 = std::max(freq0, rf0);
+            freq1 = freq0 * f1ratio;
+            freq2 = freq0 * f2ratio;
+        }
+    }
+
+    int limit0 = lrint((freq0 * m_fftSize) / rate);
+    int limit1 = lrint((freq1 * m_fftSize) / rate);
+    int limit2 = lrint((freq2 * m_fftSize) / rate);
+
+    if (limit1 < limit0) limit1 = limit0;
+    if (limit2 < limit1) limit2 = limit1;
+    
+    process_t prevInstability = 0.0;
+    bool prevDirection = false;
+
+    process_t distance = 0.0;
+    const process_t maxdist = 8.0;
+
+    const int lookback = 1;
+
+    process_t distacc = 0.0;
+
+    for (int i = count; i >= 0; i -= lookback) {
+
+        bool resetThis = phaseReset;
+
+        if (bandlimited) {
+            if (resetThis) {
+                if (i > bandlow && i < bandhigh) {
+                    resetThis = false;
+                    fullReset = false;
+                }
+            }
+        }
+
+        process_t p = cd.phase[i];
+        process_t perr = 0.0;
+        process_t outphase = p;
+
+        process_t mi = maxdist;
+        if (i <= limit0) mi = 0.0;
+        else if (i <= limit1) mi = 1.0;
+        else if (i <= limit2) mi = 3.0;
+
+        if (!resetThis) {
+
+            process_t omega = (2 * M_PI * m_increment * i) / (m_fftSize);
+
+            process_t pp = cd.prevPhase[i];
+            process_t ep = pp + omega;
+            perr = princarg(p - ep);
+
+            process_t instability = fabs(perr - cd.prevError[i]);
+            bool direction = (perr > cd.prevError[i]);
+
+            bool inherit = false;
+
+            if (laminar) {
+                if (distance >= mi || i == count) {
+                    inherit = false;
+                } else if (bandlimited && (i == bandhigh || i == bandlow)) {
+                    inherit = false;
+                } else if (instability > prevInstability &&
+                           direction == prevDirection) {
+                    inherit = true;
+                }
+            }
+
+            process_t advance = outputIncrement * ((omega + perr) / m_increment);
+
+            if (inherit) {
+                process_t inherited =
+                    cd.unwrappedPhase[i + lookback] - cd.prevPhase[i + lookback];
+                advance = ((advance * distance) +
+                           (inherited * (maxdist - distance)))
+                    / maxdist;
+                outphase = p + advance;
+                distacc += distance;
+                distance += 1.0;
+            } else {
+                outphase = cd.unwrappedPhase[i] + advance;
+                distance = 0.0;
+            }
+
+            prevInstability = instability;
+            prevDirection = direction;
+
+        } else {
+            distance = 0.0;
+        }
+
+        cd.prevError[i] = perr;
+        cd.prevPhase[i] = p;
+        cd.phase[i] = outphase;
+        cd.unwrappedPhase[i] = outphase;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "mean inheritance distance = " << distacc / count << endl;
+    }
+
+    if (fullReset) unchanged = true;
+    cd.unchanged = unchanged;
+
+    if (unchanged && m_debugLevel > 1) {
+        cerr << "frame unchanged on channel " << channel << endl;
+    }
+}    
+
+
+void
+RubberBandStretcher::Impl::formantShiftChunk(size_t channel)
+{
+    Profiler profiler("RubberBandStretcher::Impl::formantShiftChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+
+    process_t *const R__ mag = cd.mag;
+    process_t *const R__ envelope = cd.envelope;
+    process_t *const R__ dblbuf = cd.dblbuf;
+
+    const int sz = m_fftSize;
+    const int hs = sz / 2;
+    const process_t factor = 1.0 / sz;
+
+    cd.fft->inverseCepstral(mag, dblbuf);
+
+    const int cutoff = m_sampleRate / 700;
+
+//    cerr <<"cutoff = "<< cutoff << ", m_sampleRate/cutoff = " << m_sampleRate/cutoff << endl;
+
+    dblbuf[0] /= 2;
+    dblbuf[cutoff-1] /= 2;
+
+    for (int i = cutoff; i < sz; ++i) {
+        dblbuf[i] = 0.0;
+    }
+
+    v_scale(dblbuf, factor, cutoff);
+
+    process_t *spare = (process_t *)alloca((hs + 1) * sizeof(process_t));
+    cd.fft->forward(dblbuf, envelope, spare);
+
+    v_exp(envelope, hs + 1);
+    v_divide(mag, envelope, hs + 1);
+
+    if (m_pitchScale > 1.0) {
+        // scaling up, we want a new envelope that is lower by the pitch factor
+        for (int target = 0; target <= hs; ++target) {
+            int source = lrint(target * m_pitchScale);
+            if (source > hs) {
+                envelope[target] = 0.0;
+            } else {
+                envelope[target] = envelope[source];
+            }
+        }
+    } else {
+        // scaling down, we want a new envelope that is higher by the pitch factor
+        for (int target = hs; target > 0; ) {
+            --target;
+            int source = lrint(target * m_pitchScale);
+            envelope[target] = envelope[source];
+        }
+    }
+
+    v_multiply(mag, envelope, hs+1);
+
+    cd.unchanged = false;
+}
+
+void
+RubberBandStretcher::Impl::synthesiseChunk(size_t channel,
+                                           size_t shiftIncrement)
+{
+    Profiler profiler("RubberBandStretcher::Impl::synthesiseChunk");
+
+
+    if ((m_options & OptionFormantPreserved) &&
+        (m_pitchScale != 1.0)) {
+        formantShiftChunk(channel);
+    }
+
+    ChannelData &cd = *m_channelData[channel];
+
+    process_t *const R__ dblbuf = cd.dblbuf;
+    float *const R__ fltbuf = cd.fltbuf;
+    float *const R__ accumulator = cd.accumulator;
+    float *const R__ windowAccumulator = cd.windowAccumulator;
+    
+    const int fsz = m_fftSize;
+    const int hs = fsz / 2;
+
+    const int wsz = m_sWindowSize;
+
+    if (!cd.unchanged) {
+
+        // Our FFTs produced unscaled results. Scale before inverse
+        // transform rather than after, to avoid overflow if using a
+        // fixed-point FFT.
+        float factor = 1.f / fsz;
+        v_scale(cd.mag, factor, hs + 1);
+
+        cd.fft->inversePolar(cd.mag, cd.phase, cd.dblbuf);
+
+        if (wsz == fsz) {
+            v_convert(fltbuf, dblbuf + hs, hs);
+            v_convert(fltbuf + hs, dblbuf, hs);
+        } else {
+            v_zero(fltbuf, wsz);
+            int j = fsz - wsz/2;
+            while (j < 0) j += fsz;
+            for (int i = 0; i < wsz; ++i) {
+                fltbuf[i] += dblbuf[j];
+                if (++j == fsz) j = 0;
+            }
+        }
+    }
+
+    if (wsz > fsz) {
+        int p = shiftIncrement * 2;
+        if (cd.interpolatorScale != p) {
+            SincWindow<float>::write(cd.interpolator, wsz, p);
+            cd.interpolatorScale = p;
+        }
+        v_multiply(fltbuf, cd.interpolator, wsz);
+    }
+
+    m_swindow->cut(fltbuf);
+    v_add(accumulator, fltbuf, wsz);
+    cd.accumulatorFill = std::max(cd.accumulatorFill, size_t(wsz));
+
+    if (wsz > fsz) {
+        // reuse fltbuf to calculate interpolating window shape for
+        // window accumulator
+        v_copy(fltbuf, cd.interpolator, wsz);
+        m_swindow->cut(fltbuf);
+        v_add(windowAccumulator, fltbuf, wsz);
+    } else {
+        m_swindow->add(windowAccumulator, m_awindow->getArea() * 1.5f);
+    }
+}
+
+void
+RubberBandStretcher::Impl::writeChunk(size_t channel, size_t shiftIncrement, bool last)
+{
+    Profiler profiler("RubberBandStretcher::Impl::writeChunk");
+
+    ChannelData &cd = *m_channelData[channel];
+    
+    float *const R__ accumulator = cd.accumulator;
+    float *const R__ windowAccumulator = cd.windowAccumulator;
+
+    const int sz = cd.accumulatorFill;
+    const int si = shiftIncrement;
+
+    if (m_debugLevel > 2) {
+        cerr << "writeChunk(" << channel << ", " << shiftIncrement << ", " << last << ")" << endl;
+    }
+
+    v_divide(accumulator, windowAccumulator, si);
+
+    // for exact sample scaling (probably not meaningful if we
+    // were running in RT mode)
+    size_t theoreticalOut = 0;
+    if (cd.inputSize >= 0) {
+        theoreticalOut = lrint(cd.inputSize * m_timeRatio);
+    }
+
+    bool resampledAlready = resampleBeforeStretching();
+
+    if (!resampledAlready &&
+        (m_pitchScale != 1.0 || m_options & OptionPitchHighConsistency) &&
+        cd.resampler) {
+
+        Profiler profiler2("RubberBandStretcher::Impl::resample");
+
+        size_t reqSize = int(ceil(si / m_pitchScale));
+        if (reqSize > cd.resamplebufSize) {
+            // This shouldn't normally happen -- the buffer is
+            // supposed to be initialised with enough space in the
+            // first place.  But we retain this check in case the
+            // pitch scale has changed since then, or the stretch
+            // calculator has gone mad, or something.
+            cerr << "WARNING: RubberBandStretcher::Impl::writeChunk: resizing resampler buffer from "
+                      << cd.resamplebufSize << " to " << reqSize << endl;
+            cd.setResampleBufSize(reqSize);
+        }
+
+#ifndef NO_THREADING
+#if defined HAVE_IPP && !defined USE_SPEEX
+        if (m_threaded) {
+            m_resamplerMutex.lock();
+        }
+#endif
+#endif
+
+        size_t outframes = cd.resampler->resample(&cd.resamplebuf,
+                                                  cd.resamplebufSize,
+                                                  &cd.accumulator,
+                                                  si,
+                                                  1.0 / m_pitchScale,
+                                                  last);
+
+#ifndef NO_THREADING
+#if defined HAVE_IPP && !defined USE_SPEEX
+        if (m_threaded) {
+            m_resamplerMutex.unlock();
+        }
+#endif
+#endif
+
+        writeOutput(*cd.outbuf, cd.resamplebuf,
+                    outframes, cd.outCount, theoreticalOut);
+
+    } else {
+        writeOutput(*cd.outbuf, accumulator,
+                    si, cd.outCount, theoreticalOut);
+    }
+
+    v_move(accumulator, accumulator + si, sz - si);
+    v_zero(accumulator + sz - si, si);
+    
+    v_move(windowAccumulator, windowAccumulator + si, sz - si);
+    v_zero(windowAccumulator + sz - si, si);
+    
+    if (int(cd.accumulatorFill) > si) {
+        cd.accumulatorFill -= si;
+    } else {
+        cd.accumulatorFill = 0;
+        if (cd.draining) {
+            if (m_debugLevel > 1) {
+                cerr << "RubberBandStretcher::Impl::processChunks: setting outputComplete to true" << endl;
+            }
+            cd.outputComplete = true;
+        }
+    }
+}
+
+void
+RubberBandStretcher::Impl::writeOutput(RingBuffer<float> &to, float *from, size_t qty, size_t &outCount, size_t theoreticalOut)
+{
+    Profiler profiler("RubberBandStretcher::Impl::writeOutput");
+
+    // In non-RT mode, we don't want to write the first startSkip
+    // samples, because the first chunk is centred on the start of the
+    // output.  In RT mode we didn't apply any pre-padding in
+    // configure(), so we don't want to remove any here.
+
+    size_t startSkip = 0;
+    if (!m_realtime) {
+        startSkip = lrintf((m_sWindowSize/2) / m_pitchScale);
+    }
+
+    if (outCount > startSkip) {
+        
+        // this is the normal case
+
+        if (theoreticalOut > 0) {
+            if (m_debugLevel > 1) {
+                cerr << "theoreticalOut = " << theoreticalOut
+                     << ", outCount = " << outCount
+                     << ", startSkip = " << startSkip
+                     << ", qty = " << qty << endl;
+            }
+            if (outCount - startSkip <= theoreticalOut &&
+                outCount - startSkip + qty > theoreticalOut) {
+                qty = theoreticalOut - (outCount - startSkip);
+                if (m_debugLevel > 1) {
+                    cerr << "reduce qty to " << qty << endl;
+                }
+            }
+        }
+
+        if (m_debugLevel > 2) {
+            cerr << "writing " << qty << endl;
+        }
+
+        size_t written = to.write(from, qty);
+
+        if (written < qty) {
+            cerr << "WARNING: RubberBandStretcher::Impl::writeOutput: "
+                 << "Buffer overrun on output: wrote " << written
+                 << " of " << qty << " samples" << endl;
+        }
+
+        outCount += written;
+        return;
+    }
+
+    // the rest of this is only used during the first startSkip samples
+
+    if (outCount + qty <= startSkip) {
+        if (m_debugLevel > 1) {
+            cerr << "qty = " << qty << ", startSkip = "
+                 << startSkip << ", outCount = " << outCount
+                 << ", discarding" << endl;
+        }
+        outCount += qty;
+        return;
+    }
+
+    size_t off = startSkip - outCount;
+    if (m_debugLevel > 1) {
+        cerr << "qty = " << qty << ", startSkip = "
+             << startSkip << ", outCount = " << outCount
+             << ", writing " << qty - off
+             << " from start offset " << off << endl;
+    }
+    to.write(from + off, qty - off);
+    outCount += qty;
+}
+
+int
+RubberBandStretcher::Impl::available() const
+{
+    Profiler profiler("RubberBandStretcher::Impl::available");
+
+#ifndef NO_THREADING
+    if (m_threaded) {
+        MutexLocker locker(&m_threadSetMutex);
+        if (m_channelData.empty()) return 0;
+    } else {
+        if (m_channelData.empty()) return 0;
+    }
+#endif
+
+#ifndef NO_THREADING
+    if (!m_threaded) {
+#endif
+        for (size_t c = 0; c < m_channels; ++c) {
+            if (m_channelData[c]->inputSize >= 0) {
+//                cerr << "available: m_done true" << endl;
+                if (m_channelData[c]->inbuf->getReadSpace() > 0) {
+                    if (m_debugLevel > 1) {
+                        cerr << "calling processChunks(" << c << ") from available" << endl;
+                    }
+                    //!!! do we ever actually do this? if so, this method should not be const
+                    // ^^^ yes, we do sometimes -- e.g. when fed a very short file
+                    bool any = false, last = false;
+                    ((RubberBandStretcher::Impl *)this)->processChunks(c, any, last);
+                }
+            }
+        }
+#ifndef NO_THREADING
+    }
+#endif
+
+    size_t min = 0;
+    bool consumed = true;
+    bool haveResamplers = false;
+
+    for (size_t i = 0; i < m_channels; ++i) {
+        size_t availIn = m_channelData[i]->inbuf->getReadSpace();
+        size_t availOut = m_channelData[i]->outbuf->getReadSpace();
+        if (m_debugLevel > 2) {
+            cerr << "available on channel " << i << ": " << availOut << " (waiting: " << availIn << ")" << endl;
+        }
+        if (i == 0 || availOut < min) min = availOut;
+        if (!m_channelData[i]->outputComplete) consumed = false;
+        if (m_channelData[i]->resampler) haveResamplers = true;
+    }
+
+    if (min == 0 && consumed) return -1;
+    if (m_pitchScale == 1.0) return min;
+
+    if (haveResamplers) return min; // resampling has already happened
+    return int(floor(min / m_pitchScale));
+}
+
+size_t
+RubberBandStretcher::Impl::retrieve(float *const *output, size_t samples) const
+{
+    Profiler profiler("RubberBandStretcher::Impl::retrieve");
+
+    size_t got = samples;
+
+    for (size_t c = 0; c < m_channels; ++c) {
+        size_t gotHere = m_channelData[c]->outbuf->read(output[c], got);
+        if (gotHere < got) {
+            if (c > 0) {
+                if (m_debugLevel > 0) {
+                    cerr << "RubberBandStretcher::Impl::retrieve: WARNING: channel imbalance detected" << endl;
+                }
+            }
+            got = gotHere;
+        }
+    }
+
+    if ((m_options & OptionChannelsTogether) && (m_channels >= 2)) {
+        for (size_t i = 0; i < got; ++i) {
+            float mid = output[0][i];
+            float side = output[1][i];
+            float left = mid + side;
+            float right = mid - side;
+            output[0][i] = left;
+            output[1][i] = right;
+        }
+    }            
+
+    return got;
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/CompoundAudioCurve.cpp
+++ b/pedalboard/vendors/rubberband/src/audiocurves/CompoundAudioCurve.cpp
@@ -1,0 +1,167 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "CompoundAudioCurve.h"
+
+#include "../dsp/MovingMedian.h"
+
+#include <iostream>
+
+namespace RubberBand
+{
+
+
+CompoundAudioCurve::CompoundAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters),
+    m_percussive(parameters),
+    m_hf(parameters),
+    m_hfFilter(new MovingMedian<double>(19, 85)),
+    m_hfDerivFilter(new MovingMedian<double>(19, 90)),
+    m_type(CompoundDetector),
+    m_lastHf(0.0),
+    m_lastResult(0.0),
+    m_risingCount(0)
+{
+}
+
+CompoundAudioCurve::~CompoundAudioCurve()
+{
+    delete m_hfFilter;
+    delete m_hfDerivFilter;
+}
+
+void
+CompoundAudioCurve::setType(Type type)
+{
+    m_type = type;
+}
+
+void
+CompoundAudioCurve::reset()
+{
+    m_percussive.reset();
+    m_hf.reset();
+    m_hfFilter->reset();
+    m_hfDerivFilter->reset();
+    m_lastHf = 0.0;
+    m_lastResult = 0.0;
+}
+
+void
+CompoundAudioCurve::setFftSize(int newSize)
+{
+    m_percussive.setFftSize(newSize);
+    m_hf.setFftSize(newSize);
+    m_fftSize = newSize;
+    m_lastHf = 0.0;
+    m_lastResult = 0.0;
+}
+
+float
+CompoundAudioCurve::processFloat(const float *R__ mag, int increment)
+{
+    float percussive = 0.f;
+    float hf = 0.f;
+    switch (m_type) {
+    case PercussiveDetector:
+        percussive = m_percussive.processFloat(mag, increment);
+        break;
+    case CompoundDetector:
+        percussive = m_percussive.processFloat(mag, increment);
+        hf = m_hf.processFloat(mag, increment);
+        break;
+    case SoftDetector:
+        hf = m_hf.processFloat(mag, increment);
+        break;
+    }
+    return processFiltering(percussive, hf);
+}
+
+double
+CompoundAudioCurve::processDouble(const double *R__ mag, int increment)
+{
+    double percussive = 0.0;
+    double hf = 0.0;
+    switch (m_type) {
+    case PercussiveDetector:
+        percussive = m_percussive.processDouble(mag, increment);
+        break;
+    case CompoundDetector:
+        percussive = m_percussive.processDouble(mag, increment);
+        hf = m_hf.processDouble(mag, increment);
+        break;
+    case SoftDetector:
+        hf = m_hf.processDouble(mag, increment);
+        break;
+    }
+    return processFiltering(percussive, hf);
+}
+
+double
+CompoundAudioCurve::processFiltering(double percussive, double hf)
+{
+    if (m_type == PercussiveDetector) {
+        return percussive;
+    }
+
+    double rv = 0.f;
+    
+    double hfDeriv = hf - m_lastHf;
+
+    m_hfFilter->push(hf);
+    m_hfDerivFilter->push(hfDeriv);
+
+    double hfFiltered = m_hfFilter->get();
+    double hfDerivFiltered = m_hfDerivFilter->get();
+
+    m_lastHf = hf;
+
+    double result = 0.f;
+    
+    double hfExcess = hf - hfFiltered;
+
+    if (hfExcess > 0.0) {
+        result = hfDeriv - hfDerivFiltered;
+    }
+
+    if (result < m_lastResult) {
+        if (m_risingCount > 3 && m_lastResult > 0) rv = 0.5;
+        m_risingCount = 0;
+    } else {
+        m_risingCount ++;
+    }
+
+    if (m_type == CompoundDetector) {
+        if (percussive > 0.35 && percussive > rv) {
+            rv = percussive;
+        }
+    }
+
+    m_lastResult = result;
+
+    return rv;
+}
+
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/CompoundAudioCurve.h
+++ b/pedalboard/vendors/rubberband/src/audiocurves/CompoundAudioCurve.h
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_COMPOUND_AUDIO_CURVE_H
+#define RUBBERBAND_COMPOUND_AUDIO_CURVE_H
+
+#include "PercussiveAudioCurve.h"
+#include "HighFrequencyAudioCurve.h"
+#include "../dsp/SampleFilter.h"
+
+namespace RubberBand
+{
+
+class CompoundAudioCurve : public AudioCurveCalculator
+{
+public:
+    CompoundAudioCurve(Parameters parameters);
+
+    virtual ~CompoundAudioCurve();
+
+    enum Type {
+        PercussiveDetector,
+        CompoundDetector,
+        SoftDetector
+    };
+    virtual void setType(Type); // default is CompoundDetector
+    
+    virtual void setFftSize(int newSize);
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+
+    virtual void reset();
+
+protected:
+    PercussiveAudioCurve m_percussive;
+    HighFrequencyAudioCurve m_hf;
+
+    SampleFilter<double> *m_hfFilter;
+    SampleFilter<double> *m_hfDerivFilter;
+
+    Type m_type;
+
+    double m_lastHf;
+    double m_lastResult;
+    int m_risingCount;
+
+    double processFiltering(double percussive, double hf);
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/audiocurves/ConstantAudioCurve.cpp
+++ b/pedalboard/vendors/rubberband/src/audiocurves/ConstantAudioCurve.cpp
@@ -1,0 +1,57 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "ConstantAudioCurve.h"
+
+namespace RubberBand
+{
+
+
+ConstantAudioCurve::ConstantAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+}
+
+ConstantAudioCurve::~ConstantAudioCurve()
+{
+}
+
+void
+ConstantAudioCurve::reset()
+{
+}
+
+float
+ConstantAudioCurve::processFloat(const float *R__, int)
+{
+    return 1.f;
+}
+
+double
+ConstantAudioCurve::processDouble(const double *R__, int)
+{
+    return 1.0;
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/ConstantAudioCurve.h
+++ b/pedalboard/vendors/rubberband/src/audiocurves/ConstantAudioCurve.h
@@ -1,0 +1,45 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_CONSTANT_AUDIO_CURVE_H
+#define RUBBERBAND_CONSTANT_AUDIO_CURVE_H
+
+#include "../dsp/AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class ConstantAudioCurve : public AudioCurveCalculator
+{
+public:
+    ConstantAudioCurve(Parameters parameters);
+    virtual ~ConstantAudioCurve();
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+    virtual void reset();
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/audiocurves/HighFrequencyAudioCurve.cpp
+++ b/pedalboard/vendors/rubberband/src/audiocurves/HighFrequencyAudioCurve.cpp
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "HighFrequencyAudioCurve.h"
+
+namespace RubberBand
+{
+
+
+HighFrequencyAudioCurve::HighFrequencyAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+}
+
+HighFrequencyAudioCurve::~HighFrequencyAudioCurve()
+{
+}
+
+void
+HighFrequencyAudioCurve::reset()
+{
+}
+
+float
+HighFrequencyAudioCurve::processFloat(const float *R__ mag, int)
+{
+    float result = 0.0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 0; n <= sz; ++n) {
+        result = result + mag[n] * n;
+    }
+
+    return result;
+}
+
+double
+HighFrequencyAudioCurve::processDouble(const double *R__ mag, int)
+{
+    double result = 0.0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 0; n <= sz; ++n) {
+        result = result + mag[n] * n;
+    }
+    
+    return result;
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/HighFrequencyAudioCurve.h
+++ b/pedalboard/vendors/rubberband/src/audiocurves/HighFrequencyAudioCurve.h
@@ -1,0 +1,47 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_HIGHFREQUENCY_AUDIO_CURVE_H
+#define RUBBERBAND_HIGHFREQUENCY_AUDIO_CURVE_H
+
+#include "../dsp/AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class HighFrequencyAudioCurve : public AudioCurveCalculator
+{
+public:
+    HighFrequencyAudioCurve(Parameters parameters);
+
+    virtual ~HighFrequencyAudioCurve();
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+    virtual void reset();
+    virtual const char *getUnit() const { return "Vbin"; }
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/audiocurves/PercussiveAudioCurve.cpp
+++ b/pedalboard/vendors/rubberband/src/audiocurves/PercussiveAudioCurve.cpp
@@ -1,0 +1,114 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "PercussiveAudioCurve.h"
+
+#include "../system/Allocators.h"
+#include "../system/VectorOps.h"
+
+#include <cmath>
+#include <iostream>
+namespace RubberBand
+{
+
+
+PercussiveAudioCurve::PercussiveAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+    m_prevMag = allocate_and_zero<double>(m_fftSize/2 + 1);
+}
+
+PercussiveAudioCurve::~PercussiveAudioCurve()
+{
+    deallocate(m_prevMag);
+}
+
+void
+PercussiveAudioCurve::reset()
+{
+    v_zero(m_prevMag, m_fftSize/2 + 1);
+}
+
+void
+PercussiveAudioCurve::setFftSize(int newSize)
+{
+    m_prevMag = reallocate(m_prevMag, m_fftSize/2 + 1, newSize/2 + 1);
+    AudioCurveCalculator::setFftSize(newSize);
+    reset();
+}
+
+float
+PercussiveAudioCurve::processFloat(const float *R__ mag, int)
+{
+    static float threshold = powf(10.f, 0.15f); // 3dB rise in square of magnitude
+    static float zeroThresh = powf(10.f, -8);
+
+    int count = 0;
+    int nonZeroCount = 0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 1; n <= sz; ++n) {
+        float v = 0.f;
+        if (m_prevMag[n] > zeroThresh) v = mag[n] / m_prevMag[n];
+        else if (mag[n] > zeroThresh) v = threshold;
+        bool above = (v >= threshold);
+        if (above) ++count;
+        if (mag[n] > zeroThresh) ++nonZeroCount;
+    }
+
+    v_convert(m_prevMag, mag, sz + 1);
+
+    if (nonZeroCount == 0) return 0;
+    else return float(count) / float(nonZeroCount);
+}
+
+double
+PercussiveAudioCurve::processDouble(const double *R__ mag, int)
+{
+    static double threshold = pow(10., 0.15); // 3dB rise in square of magnitude
+    static double zeroThresh = pow(10., -8);
+
+    int count = 0;
+    int nonZeroCount = 0;
+
+    const int sz = m_lastPerceivedBin;
+
+    for (int n = 1; n <= sz; ++n) {
+        double v = 0.0;
+        if (m_prevMag[n] > zeroThresh) v = mag[n] / m_prevMag[n];
+        else if (mag[n] > zeroThresh) v = threshold;
+        bool above = (v >= threshold);
+        if (above) ++count;
+        if (mag[n] > zeroThresh) ++nonZeroCount;
+    }
+
+    v_copy(m_prevMag, mag, sz + 1);
+
+    if (nonZeroCount == 0) return 0;
+    else return double(count) / double(nonZeroCount);
+}
+
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/PercussiveAudioCurve.h
+++ b/pedalboard/vendors/rubberband/src/audiocurves/PercussiveAudioCurve.h
@@ -1,0 +1,54 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_PERCUSSIVE_AUDIO_CURVE_H
+#define RUBBERBAND_PERCUSSIVE_AUDIO_CURVE_H
+
+#include "../dsp/AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class PercussiveAudioCurve : public AudioCurveCalculator
+{
+public:
+    PercussiveAudioCurve(Parameters parameters);
+
+    virtual ~PercussiveAudioCurve();
+
+    virtual void setFftSize(int newSize);
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+
+
+    virtual void reset();
+    virtual const char *getUnit() const { return "bin/total"; }
+
+protected:
+    double *R__ m_prevMag;
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/audiocurves/SilentAudioCurve.cpp
+++ b/pedalboard/vendors/rubberband/src/audiocurves/SilentAudioCurve.cpp
@@ -1,0 +1,73 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "SilentAudioCurve.h"
+
+#include <cmath>
+
+namespace RubberBand
+{
+
+
+SilentAudioCurve::SilentAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+}
+
+SilentAudioCurve::~SilentAudioCurve()
+{
+}
+
+void
+SilentAudioCurve::reset()
+{
+}
+
+float
+SilentAudioCurve::processFloat(const float *R__ mag, int)
+{
+    const int hs = m_lastPerceivedBin;
+    static float threshold = powf(10.f, -6);
+
+    for (int i = 0; i <= hs; ++i) {
+        if (mag[i] > threshold) return 0.f;
+    }
+        
+    return 1.f;
+}
+
+double
+SilentAudioCurve::processDouble(const double *R__ mag, int)
+{
+    const int hs = m_lastPerceivedBin;
+    static double threshold = pow(10.0, -6);
+
+    for (int i = 0; i <= hs; ++i) {
+        if (mag[i] > threshold) return 0.f;
+    }
+        
+    return 1.f;
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/SilentAudioCurve.h
+++ b/pedalboard/vendors/rubberband/src/audiocurves/SilentAudioCurve.h
@@ -1,0 +1,46 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SILENT_AUDIO_CURVE_H
+#define RUBBERBAND_SILENT_AUDIO_CURVE_H
+
+#include "../dsp/AudioCurveCalculator.h"
+
+namespace RubberBand
+{
+
+class SilentAudioCurve : public AudioCurveCalculator
+{
+public:
+    SilentAudioCurve(Parameters parameters);
+    virtual ~SilentAudioCurve();
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+    virtual void reset();
+    virtual const char *getUnit() const { return "bool"; }
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/audiocurves/SpectralDifferenceAudioCurve.cpp
+++ b/pedalboard/vendors/rubberband/src/audiocurves/SpectralDifferenceAudioCurve.cpp
@@ -1,0 +1,107 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "SpectralDifferenceAudioCurve.h"
+
+#include "../system/Allocators.h"
+#include "../system/VectorOps.h"
+
+namespace RubberBand
+{
+
+
+SpectralDifferenceAudioCurve::SpectralDifferenceAudioCurve(Parameters parameters) :
+    AudioCurveCalculator(parameters)
+{
+    m_mag = allocate<double>(m_lastPerceivedBin + 1);
+    m_tmpbuf = allocate<double>(m_lastPerceivedBin + 1);
+    v_zero(m_mag, m_lastPerceivedBin + 1);
+}
+
+SpectralDifferenceAudioCurve::~SpectralDifferenceAudioCurve()
+{
+    deallocate(m_mag);
+    deallocate(m_tmpbuf);
+}
+
+void
+SpectralDifferenceAudioCurve::reset()
+{
+    v_zero(m_mag, m_lastPerceivedBin + 1);
+}
+
+void
+SpectralDifferenceAudioCurve::setFftSize(int newSize)
+{
+    deallocate(m_tmpbuf);
+    deallocate(m_mag);
+    AudioCurveCalculator::setFftSize(newSize);
+    m_mag = allocate<double>(m_lastPerceivedBin + 1);
+    m_tmpbuf = allocate<double>(m_lastPerceivedBin + 1);
+    reset();
+}
+
+float
+SpectralDifferenceAudioCurve::processFloat(const float *R__ mag, int)
+{
+    double result = 0.0;
+
+    const int hs1 = m_lastPerceivedBin + 1;
+
+    v_convert(m_tmpbuf, mag, hs1);
+    v_square(m_tmpbuf, hs1);
+    v_subtract(m_mag, m_tmpbuf, hs1);
+    v_abs(m_mag, hs1);
+    v_sqrt(m_mag, hs1);
+    
+    for (int i = 0; i < hs1; ++i) {
+        result += m_mag[i];
+    }
+
+    v_copy(m_mag, m_tmpbuf, hs1);
+    return result;
+}
+
+double
+SpectralDifferenceAudioCurve::processDouble(const double *R__ mag, int)
+{
+    double result = 0.0;
+
+    const int hs1 = m_lastPerceivedBin + 1;
+
+    v_convert(m_tmpbuf, mag, hs1);
+    v_square(m_tmpbuf, hs1);
+    v_subtract(m_mag, m_tmpbuf, hs1);
+    v_abs(m_mag, hs1);
+    v_sqrt(m_mag, hs1);
+    
+    for (int i = 0; i < hs1; ++i) {
+        result += m_mag[i];
+    }
+
+    v_copy(m_mag, m_tmpbuf, hs1);
+    return result;
+}
+
+}
+

--- a/pedalboard/vendors/rubberband/src/audiocurves/SpectralDifferenceAudioCurve.h
+++ b/pedalboard/vendors/rubberband/src/audiocurves/SpectralDifferenceAudioCurve.h
@@ -1,0 +1,54 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SPECTRALDIFFERENCE_AUDIO_CURVE_H
+#define RUBBERBAND_SPECTRALDIFFERENCE_AUDIO_CURVE_H
+
+#include "../dsp/AudioCurveCalculator.h"
+#include "../dsp/Window.h"
+
+namespace RubberBand
+{
+
+class SpectralDifferenceAudioCurve : public AudioCurveCalculator
+{
+public:
+    SpectralDifferenceAudioCurve(Parameters parameters);
+
+    virtual ~SpectralDifferenceAudioCurve();
+
+    virtual void setFftSize(int newSize);
+
+    virtual float processFloat(const float *R__ mag, int increment);
+    virtual double processDouble(const double *R__ mag, int increment);
+    virtual void reset();
+    virtual const char *getUnit() const { return "V"; }
+
+protected:
+    double *R__ m_mag;
+    double *R__ m_tmpbuf;
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/base/Profiler.cpp
+++ b/pedalboard/vendors/rubberband/src/base/Profiler.cpp
@@ -1,0 +1,239 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Profiler.h"
+
+#include "../system/Thread.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <map>
+
+#include <stdio.h>
+
+#ifdef _MSC_VER
+// Ugh --cc
+#define snprintf sprintf_s
+#endif
+
+namespace RubberBand {
+
+#ifndef NO_TIMING
+
+Profiler::ProfileMap
+Profiler::m_profiles;
+
+Profiler::WorstCallMap
+Profiler::m_worstCalls;
+
+static Mutex profileMutex;
+
+void
+Profiler::add(const char *id, float ms)
+{
+    profileMutex.lock();
+    
+    ProfileMap::iterator pmi = m_profiles.find(id);
+    if (pmi != m_profiles.end()) {
+        ++pmi->second.first;
+        pmi->second.second += ms;
+    } else {
+        m_profiles[id] = TimePair(1, ms);
+    }
+
+    WorstCallMap::iterator wci = m_worstCalls.find(id);
+    if (wci != m_worstCalls.end()) {
+        if (ms > wci->second) wci->second = ms;
+    } else {
+        m_worstCalls[id] = ms;
+    }
+
+    profileMutex.unlock();
+}
+
+void
+Profiler::dump()
+{
+    std::string report = getReport();
+    fprintf(stderr, "%s", report.c_str());
+}
+
+std::string
+Profiler::getReport()
+{
+    profileMutex.lock();
+    
+    static const int buflen = 256;
+    char buffer[buflen];
+    std::string report;
+
+#ifdef PROFILE_CLOCKS
+    snprintf(buffer, buflen, "Profiling points [CPU time]:\n");
+#else
+    snprintf(buffer, buflen, "Profiling points [Wall time]:\n");
+#endif
+    report += buffer;
+
+    typedef std::multimap<float, const char *> TimeRMap;
+    typedef std::multimap<int, const char *> IntRMap;
+    TimeRMap totmap, avgmap, worstmap;
+    IntRMap ncallmap;
+
+    for (ProfileMap::const_iterator i = m_profiles.begin();
+         i != m_profiles.end(); ++i) {
+        totmap.insert(TimeRMap::value_type(i->second.second, i->first));
+        avgmap.insert(TimeRMap::value_type(i->second.second /
+                                           i->second.first, i->first));
+        ncallmap.insert(IntRMap::value_type(i->second.first, i->first));
+    }
+
+    for (WorstCallMap::const_iterator i = m_worstCalls.begin();
+         i != m_worstCalls.end(); ++i) {
+        worstmap.insert(TimeRMap::value_type(i->second, i->first));
+    }
+
+    snprintf(buffer, buflen, "\nBy total:\n");
+    report += buffer;
+    for (TimeRMap::const_iterator i = totmap.end(); i != totmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %f ms\n", i->second, i->first);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy average:\n");
+    report += buffer;
+    for (TimeRMap::const_iterator i = avgmap.end(); i != avgmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %f ms\n", i->second, i->first);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy worst case:\n");
+    report += buffer;
+    for (TimeRMap::const_iterator i = worstmap.end(); i != worstmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %f ms\n", i->second, i->first);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy number of calls:\n");
+    report += buffer;
+    for (IntRMap::const_iterator i = ncallmap.end(); i != ncallmap.begin(); ) {
+        --i;
+        snprintf(buffer, buflen, "%-40s  %d\n", i->second, i->first);
+        report += buffer;
+    }
+
+    snprintf(buffer, buflen, "\nBy name:\n");
+    report += buffer;
+
+    typedef std::set<const char *, std::less<std::string> > StringSet;
+
+    StringSet profileNames;
+    for (ProfileMap::const_iterator i = m_profiles.begin();
+         i != m_profiles.end(); ++i) {
+        profileNames.insert(i->first);
+    }
+
+    for (StringSet::const_iterator i = profileNames.begin();
+         i != profileNames.end(); ++i) {
+
+        ProfileMap::const_iterator j = m_profiles.find(*i);
+        if (j == m_profiles.end()) continue;
+
+        const TimePair &pp(j->second);
+        snprintf(buffer, buflen, "%s(%d):\n", *i, pp.first);
+        report += buffer;
+        snprintf(buffer, buflen, "\tReal: \t%f ms      \t[%f ms total]\n",
+                (pp.second / pp.first),
+                (pp.second));
+        report += buffer;
+
+        WorstCallMap::const_iterator k = m_worstCalls.find(*i);
+        if (k == m_worstCalls.end()) continue;
+        
+        snprintf(buffer, buflen, "\tWorst:\t%f ms/call\n", k->second);
+        report += buffer;
+    }
+
+    profileMutex.unlock();
+    
+    return report;
+}
+
+Profiler::Profiler(const char* c) :
+    m_c(c),
+    m_ended(false)
+{
+#ifdef PROFILE_CLOCKS
+    m_start = clock();
+#else
+    (void)gettimeofday(&m_start, 0);
+#endif
+}
+
+Profiler::~Profiler()
+{
+    if (!m_ended) end();
+}
+
+void
+Profiler::end()
+{
+#ifdef PROFILE_CLOCKS
+    clock_t end = clock();
+    clock_t elapsed = end - m_start;
+    float ms = float((double(elapsed) / double(CLOCKS_PER_SEC)) * 1000.0);
+#else
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+
+    tv.tv_sec -= m_start.tv_sec;
+    if (tv.tv_usec < m_start.tv_usec) {
+        tv.tv_usec += 1000000;
+        tv.tv_sec -= 1;
+    }
+    tv.tv_usec -= m_start.tv_usec;
+    float ms = float((double(tv.tv_sec) + (double(tv.tv_usec) / 1000000.0)) * 1000.0);
+#endif
+
+    add(m_c, ms);
+
+    m_ended = true;
+}
+ 
+#else /* NO_TIMING */
+
+#ifndef NO_TIMING_COMPLETE_NOOP
+
+Profiler::Profiler(const char *) { }
+Profiler::~Profiler() { }
+void Profiler::end() { }
+void Profiler::dump() { }
+
+#endif
+
+#endif
+
+}

--- a/pedalboard/vendors/rubberband/src/base/Profiler.h
+++ b/pedalboard/vendors/rubberband/src/base/Profiler.h
@@ -1,0 +1,130 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_PROFILER_H
+#define RUBBERBAND_PROFILER_H
+
+//#define NO_TIMING 1
+//#define WANT_TIMING 1
+//#define PROFILE_CLOCKS 1
+
+// Define NO_TIMING or NDEBUG to switch off profilers
+#ifdef NDEBUG
+#define NO_TIMING 1
+#endif
+
+// But we always allow WANT_TIMING to switch them back on again
+#ifdef WANT_TIMING
+#undef NO_TIMING
+#endif
+
+#ifndef NO_TIMING
+#ifdef PROFILE_CLOCKS
+#include <time.h>
+#else
+#include "../system/sysutils.h"
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
+#endif
+#endif
+
+#ifndef NO_TIMING
+#include <map>
+#include <string>
+#endif
+
+namespace RubberBand {
+
+#ifndef NO_TIMING
+
+class Profiler
+{
+public:
+    Profiler(const char *name);
+    ~Profiler();
+
+    void end(); // same action as dtor
+
+    static void dump();
+
+    // Unlike the other functions, this is only defined if NO_TIMING
+    // is not set (because it uses std::string which is otherwise
+    // unused here). So, treat this as a tricksy internal function
+    // rather than an API call and guard any call to it appropriately.
+    static std::string getReport();
+
+protected:
+    const char* m_c;
+#ifdef PROFILE_CLOCKS
+    clock_t m_start;
+#else
+    struct timeval m_start;
+#endif
+    bool m_showOnDestruct;
+    bool m_ended;
+
+    typedef std::pair<int, float> TimePair;
+    typedef std::map<const char *, TimePair> ProfileMap;
+    typedef std::map<const char *, float> WorstCallMap;
+    static ProfileMap m_profiles;
+    static WorstCallMap m_worstCalls;
+    static void add(const char *, float);
+};
+
+#else
+
+#ifdef NO_TIMING_COMPLETE_NOOP
+
+// Fastest for release builds, but annoying because it can't be linked
+// with code built in debug mode (expecting non-inline functions), so
+// not preferred during development
+
+class Profiler
+{
+public:
+    Profiler(const char *) { }
+    ~Profiler() { }
+
+    void end() { }
+    static void dump() { }
+};
+
+#else
+
+class Profiler
+{
+public:
+    Profiler(const char *);
+    ~Profiler();
+
+    void end();
+    static void dump();
+};
+
+#endif
+#endif
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/base/RingBuffer.h
+++ b/pedalboard/vendors/rubberband/src/base/RingBuffer.h
@@ -1,0 +1,526 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_RINGBUFFER_H
+#define RUBBERBAND_RINGBUFFER_H
+
+#include <sys/types.h>
+
+//#define DEBUG_RINGBUFFER 1
+
+#include "../system/sysutils.h"
+#include "../system/Allocators.h"
+
+#include <iostream>
+
+#include <atomic>
+
+namespace RubberBand {
+
+/**
+ * RingBuffer implements a lock-free ring buffer for one writer and
+ * one reader, that is to be used to store a sample type T.
+ *
+ * RingBuffer is thread-safe provided only one thread writes and only
+ * one thread reads.
+ */
+
+template <typename T>
+class RingBuffer
+{
+public:
+    /**
+     * Create a ring buffer with room to write n samples.
+     *
+     * Note that the internal storage size will actually be n+1
+     * samples, as one element is unavailable for administrative
+     * reasons.  Since the ring buffer performs best if its size is a
+     * power of two, this means n should ideally be some power of two
+     * minus one.
+     */
+    RingBuffer(int n);
+
+    virtual ~RingBuffer();
+
+    /**
+     * Return the total capacity of the ring buffer in samples.
+     * (This is the argument n passed to the constructor.)
+     */
+    int getSize() const;
+
+    /**
+     * Return a new ring buffer (allocated with "new" -- caller must
+     * delete when no longer needed) of the given size, containing the
+     * same data as this one.  If another thread reads from or writes
+     * to this buffer during the call, the results may be incomplete
+     * or inconsistent.  If this buffer's data will not fit in the new
+     * size, the contents are undefined.
+     */
+    RingBuffer<T> *resized(int newSize) const;
+
+    /**
+     * Lock the ring buffer into physical memory.  Returns true
+     * for success.
+     */
+    bool mlock();
+
+    /**
+     * Reset read and write pointers, thus emptying the buffer.
+     * Should be called from the write thread.
+     */
+    void reset();
+
+    /**
+     * Return the amount of data available for reading, in samples.
+     */
+    int getReadSpace() const;
+
+    /**
+     * Return the amount of space available for writing, in samples.
+     */
+    int getWriteSpace() const;
+
+    /**
+     * Read n samples from the buffer.  If fewer than n are available,
+     * the remainder will be zeroed out.  Returns the number of
+     * samples actually read.
+     *
+     * This is a template function, taking an argument S for the target
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for arithmetic operations.
+     */
+    template <typename S>
+    int read(S *const R__ destination, int n);
+
+    /**
+     * Read n samples from the buffer, adding them to the destination.
+     * If fewer than n are available, the remainder will be left
+     * alone.  Returns the number of samples actually read.
+     *
+     * This is a template function, taking an argument S for the target
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for arithmetic operations.
+     */
+    template <typename S>
+    int readAdding(S *const R__ destination, int n);
+
+    /**
+     * Read one sample from the buffer.  If no sample is available,
+     * this will silently return zero.  Calling this repeatedly is
+     * obviously slower than calling read once, but it may be good
+     * enough if you don't want to allocate a buffer to read into.
+     */
+    T readOne();
+
+    /**
+     * Read n samples from the buffer, if available, without advancing
+     * the read pointer -- i.e. a subsequent read() or skip() will be
+     * necessary to empty the buffer.  If fewer than n are available,
+     * the remainder will be zeroed out.  Returns the number of
+     * samples actually read.
+     */
+    int peek(T *const R__ destination, int n) const;
+
+    /**
+     * Read one sample from the buffer, if available, without
+     * advancing the read pointer -- i.e. a subsequent read() or
+     * skip() will be necessary to empty the buffer.  Returns zero if
+     * no sample was available.
+     */
+    T peekOne() const;
+
+    /**
+     * Pretend to read n samples from the buffer, without actually
+     * returning them (i.e. discard the next n samples).  Returns the
+     * number of samples actually available for discarding.
+     */
+    int skip(int n);
+
+    /**
+     * Write n samples to the buffer.  If insufficient space is
+     * available, not all samples may actually be written.  Returns
+     * the number of samples actually written.
+     *
+     * This is a template function, taking an argument S for the source
+     * sample type, which is permitted to differ from T if the two
+     * types are compatible for assignment.
+     */
+    template <typename S>
+    int write(const S *const R__ source, int n);
+
+    /**
+     * Write n zero-value samples to the buffer.  If insufficient
+     * space is available, not all zeros may actually be written.
+     * Returns the number of zeroes actually written.
+     */
+    int zero(int n);
+
+protected:
+    T *const R__      m_buffer;
+    std::atomic<int>  m_writer;
+    std::atomic<int>  m_reader;
+    const int         m_size;
+    bool              m_mlocked;
+
+    int readSpaceFor(int w, int r) const {
+        int space;
+        if (w > r) space = w - r;
+        else if (w < r) space = (w + m_size) - r;
+        else space = 0;
+        return space;
+    }
+
+    int writeSpaceFor(int w, int r) const {
+        int space = (r + m_size - w - 1);
+        if (space >= m_size) space -= m_size;
+        return space;
+    }
+
+private:
+    RingBuffer(const RingBuffer &); // not provided
+    RingBuffer &operator=(const RingBuffer &); // not provided
+};
+
+template <typename T>
+RingBuffer<T>::RingBuffer(int n) :
+    m_buffer(allocate<T>(n + 1)),
+    m_writer(0),
+    m_size(n + 1),
+    m_mlocked(false)
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::RingBuffer(" << n << ")" << std::endl;
+#endif
+
+    m_reader = 0;
+}
+
+template <typename T>
+RingBuffer<T>::~RingBuffer()
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::~RingBuffer" << std::endl;
+#endif
+
+    if (m_mlocked) {
+	MUNLOCK((void *)m_buffer, m_size * sizeof(T));
+    }
+
+    deallocate(m_buffer);
+}
+
+template <typename T>
+int
+RingBuffer<T>::getSize() const
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::getSize(): " << m_size-1 << std::endl;
+#endif
+
+    return m_size - 1;
+}
+
+template <typename T>
+RingBuffer<T> *
+RingBuffer<T>::resized(int newSize) const
+{
+    RingBuffer<T> *newBuffer = new RingBuffer<T>(newSize);
+    
+    MBARRIER();
+    int w = m_writer;
+    int r = m_reader;
+
+    while (r != w) {
+        T value = m_buffer[r];
+        newBuffer->write(&value, 1);
+        if (++r == m_size) r = 0;
+    }
+
+    return newBuffer;
+}
+
+template <typename T>
+bool
+RingBuffer<T>::mlock()
+{
+    if (MLOCK((void *)m_buffer, m_size * sizeof(T))) return false;
+    m_mlocked = true;
+    return true;
+}
+
+template <typename T>
+void
+RingBuffer<T>::reset()
+{
+#ifdef DEBUG_RINGBUFFER
+    std::cerr << "RingBuffer<T>[" << this << "]::reset" << std::endl;
+#endif
+
+    int r = m_reader;
+    m_writer = r;
+}
+
+template <typename T>
+int
+RingBuffer<T>::getReadSpace() const
+{
+    return readSpaceFor(m_writer, m_reader);
+}
+
+template <typename T>
+int
+RingBuffer<T>::getWriteSpace() const
+{
+    return writeSpaceFor(m_writer, m_reader);
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::read(S *const R__ destination, int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::read: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - r;
+    T *const R__ bufbase = m_buffer + r;
+
+    if (here >= n) {
+        v_convert(destination, bufbase, n);
+    } else {
+        v_convert(destination, bufbase, here);
+        v_convert(destination + here, m_buffer, n - here);
+    }
+
+    r += n;
+    while (r >= m_size) r -= m_size;
+
+    m_reader = r;
+
+    return n;
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::readAdding(S *const R__ destination, int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::read: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - r;
+    T *const R__ bufbase = m_buffer + r;
+
+    if (here >= n) {
+        v_add(destination, bufbase, n);
+    } else {
+        v_add(destination, bufbase, here);
+        v_add(destination + here, m_buffer, n - here);
+    }
+
+    r += n;
+    while (r >= m_size) r -= m_size;
+
+    m_reader = r;
+
+    return n;
+}
+
+template <typename T>
+T
+RingBuffer<T>::readOne()
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    if (w == r) {
+	std::cerr << "WARNING: RingBuffer::readOne: no sample available"
+		  << std::endl;
+	return T();
+    }
+
+    T value = m_buffer[r];
+    if (++r == m_size) r = 0;
+
+    m_reader = r;
+
+    return value;
+}
+
+template <typename T>
+int
+RingBuffer<T>::peek(T *const R__ destination, int n) const
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::peek: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	memset(destination + available, 0, (n - available) * sizeof(T));
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - r;
+    const T *const R__ bufbase = m_buffer + r;
+
+    if (here >= n) {
+        v_copy(destination, bufbase, n);
+    } else {
+        v_copy(destination, bufbase, here);
+        v_copy(destination + here, m_buffer, n - here);
+    }
+
+    return n;
+}
+
+template <typename T>
+T
+RingBuffer<T>::peekOne() const
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    if (w == r) {
+	std::cerr << "WARNING: RingBuffer::peekOne: no sample available"
+		  << std::endl;
+	return 0;
+    }
+
+    T value = m_buffer[r];
+    return value;
+}
+
+template <typename T>
+int
+RingBuffer<T>::skip(int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = readSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::skip: " << n << " requested, only "
+                  << available << " available" << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    r += n;
+    while (r >= m_size) r -= m_size;
+
+    m_reader = r;
+
+    return n;
+}
+
+template <typename T>
+template <typename S>
+int
+RingBuffer<T>::write(const S *const R__ source, int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = writeSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::write: " << n
+                  << " requested, only room for " << available << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - w;
+    T *const R__ bufbase = m_buffer + w;
+
+    if (here >= n) {
+        v_convert<S, T>(bufbase, source, n);
+    } else {
+        v_convert<S, T>(bufbase, source, here);
+        v_convert<S, T>(m_buffer, source + here, n - here);
+    }
+
+    w += n;
+    while (w >= m_size) w -= m_size;
+
+    MBARRIER();
+    m_writer = w;
+
+    return n;
+}
+
+template <typename T>
+int
+RingBuffer<T>::zero(int n)
+{
+    int w = m_writer;
+    int r = m_reader;
+
+    int available = writeSpaceFor(w, r);
+    if (n > available) {
+	std::cerr << "WARNING: RingBuffer::zero: " << n
+                  << " requested, only room for " << available << std::endl;
+	n = available;
+    }
+    if (n == 0) return n;
+
+    int here = m_size - w;
+    T *const R__ bufbase = m_buffer + w;
+
+    if (here >= n) {
+        v_zero(bufbase, n);
+    } else {
+        v_zero(bufbase, here);
+        v_zero(m_buffer, n - here);
+    }
+
+    w += n;
+    while (w >= m_size) w -= m_size;
+
+    MBARRIER();
+    m_writer = w;
+
+    return n;
+}
+
+}
+
+#endif // _RINGBUFFER_H

--- a/pedalboard/vendors/rubberband/src/base/Scavenger.h
+++ b/pedalboard/vendors/rubberband/src/base/Scavenger.h
@@ -1,0 +1,250 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SCAVENGER_H
+#define RUBBERBAND_SCAVENGER_H
+
+#include <vector>
+#include <list>
+#include <utility>
+#include <iostream>
+
+#ifndef _MSC_VER
+#include <sys/time.h>
+#endif
+
+#include "../system/Thread.h"
+#include "../system/sysutils.h"
+#include "../system/Allocators.h"
+
+//#define DEBUG_SCAVENGER 1
+
+namespace RubberBand {
+
+/**
+ * A very simple class that facilitates running things like plugins
+ * without locking, by collecting unwanted objects and deleting them
+ * after a delay so as to be sure nobody's in the middle of using
+ * them.  Requires scavenge() to be called regularly from a non-RT
+ * thread.
+ *
+ * This is currently not at all suitable for large numbers of objects
+ * -- it's just a quick hack for use with things like plugins.
+ */
+
+//!!! should review this, it's not really thread safe owing to lack of
+//!!! atomic updates
+
+template <typename T>
+class Scavenger
+{
+public:
+    Scavenger(int sec = 2, int defaultObjectListSize = 200);
+    ~Scavenger();
+
+    /**
+     * Call from an RT thread etc., to pass ownership of t to us.
+     * Only one thread should be calling this on any given scavenger.
+     */
+    void claim(T *t);
+
+    /**
+     * Call from a non-RT thread.
+     * Only one thread should be calling this on any given scavenger.
+     */
+    void scavenge(bool clearNow = false);
+
+protected:
+    typedef std::pair<T *, int> ObjectTimePair;
+    typedef std::vector<ObjectTimePair> ObjectTimeList;
+    ObjectTimeList m_objects;
+    int m_sec;
+
+    typedef std::list<T *> ObjectList;
+    ObjectList m_excess;
+    int m_lastExcess;
+    Mutex m_excessMutex;
+    void pushExcess(T *);
+    void clearExcess(int);
+
+    unsigned int m_claimed;
+    unsigned int m_scavenged;
+    unsigned int m_asExcess;
+};
+
+
+/**
+ * A wrapper to permit arrays allocated with new[] to be scavenged.
+ */
+
+template <typename T>
+class ScavengerArrayWrapper
+{
+public:
+    ScavengerArrayWrapper(T *array) : m_array(array) { }
+    ~ScavengerArrayWrapper() { delete[] m_array; }
+
+private:
+    T *m_array;
+};
+
+
+/**
+ * A wrapper to permit arrays allocated with the Allocators functions
+ * to be scavenged.
+ */
+
+template <typename T>
+class ScavengerAllocArrayWrapper
+{
+public:
+    ScavengerAllocArrayWrapper(T *array) : m_array(array) { }
+    ~ScavengerAllocArrayWrapper() { deallocate<T>(m_array); }
+
+private:
+    T *m_array;
+};
+
+
+template <typename T>
+Scavenger<T>::Scavenger(int sec, int defaultObjectListSize) :
+    m_objects(ObjectTimeList(defaultObjectListSize)),
+    m_sec(sec),
+    m_lastExcess(0),
+    m_claimed(0),
+    m_scavenged(0),
+    m_asExcess(0)
+{
+}
+
+template <typename T>
+Scavenger<T>::~Scavenger()
+{
+    if (m_scavenged < m_claimed) {
+	for (size_t i = 0; i < m_objects.size(); ++i) {
+	    ObjectTimePair &pair = m_objects[i];
+	    if (pair.first != 0) {
+		T *ot = pair.first;
+		pair.first = 0;
+		delete ot;
+		++m_scavenged;
+	    }
+	}
+    }
+
+    clearExcess(0);
+}
+
+template <typename T>
+void
+Scavenger<T>::claim(T *t)
+{
+//    std::cerr << "Scavenger::claim(" << t << ")" << std::endl;
+
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+    int sec = tv.tv_sec;
+
+    for (size_t i = 0; i < m_objects.size(); ++i) {
+	ObjectTimePair &pair = m_objects[i];
+	if (pair.first == 0) {
+	    pair.second = sec;
+	    pair.first = t;
+	    ++m_claimed;
+	    return;
+	}
+    }
+
+#ifdef DEBUG_SCAVENGER
+    std::cerr << "WARNING: Scavenger::claim(" << t << "): run out of slots (at "
+              << m_objects.size() << "), using non-RT-safe method" << std::endl;
+#endif
+    pushExcess(t);
+}
+
+template <typename T>
+void
+Scavenger<T>::scavenge(bool clearNow)
+{
+#ifdef DEBUG_SCAVENGER
+    std::cerr << "Scavenger::scavenge: claimed " << m_claimed << ", scavenged " << m_scavenged << ", cleared as excess " << m_asExcess << std::endl;
+#endif
+
+    if (m_scavenged >= m_claimed) return;
+    
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+    int sec = tv.tv_sec;
+    bool anything = false;
+
+    for (size_t i = 0; i < m_objects.size(); ++i) {
+	ObjectTimePair &pair = m_objects[i];
+        if (!pair.first) continue;
+	if (clearNow || pair.second + m_sec < sec) {
+	    T *ot = pair.first;
+	    pair.first = 0;
+	    delete ot;
+	    ++m_scavenged;
+            anything = true;
+	}
+    }
+
+    if (clearNow || anything || (sec > m_lastExcess + m_sec)) {
+        clearExcess(sec);
+    }
+}
+
+template <typename T>
+void
+Scavenger<T>::pushExcess(T *t)
+{
+    m_excessMutex.lock();
+    m_excess.push_back(t);
+    struct timeval tv;
+    (void)gettimeofday(&tv, 0);
+    m_lastExcess = tv.tv_sec;
+    m_excessMutex.unlock();
+}
+
+template <typename T>
+void
+Scavenger<T>::clearExcess(int sec)
+{
+#ifdef DEBUG_SCAVENGER
+    std::cerr << "Scavenger::clearExcess: Excess now " << m_excess.size() << std::endl;
+#endif
+
+    m_excessMutex.lock();
+    for (typename ObjectList::iterator i = m_excess.begin();
+	 i != m_excess.end(); ++i) {
+	delete *i;
+        ++m_asExcess;
+    }
+    m_excess.clear();
+    m_lastExcess = sec;
+    m_excessMutex.unlock();
+}
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/dsp/AudioCurveCalculator.cpp
+++ b/pedalboard/vendors/rubberband/src/dsp/AudioCurveCalculator.cpp
@@ -1,0 +1,72 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "AudioCurveCalculator.h"
+
+#include <iostream>
+
+namespace RubberBand
+{
+
+static const int MaxPerceivedFreq = 16000;
+
+AudioCurveCalculator::AudioCurveCalculator(Parameters parameters) :
+    m_sampleRate(parameters.sampleRate),
+    m_fftSize(parameters.fftSize)
+{
+    recalculateLastPerceivedBin();
+}
+
+AudioCurveCalculator::~AudioCurveCalculator()
+{
+}
+
+void
+AudioCurveCalculator::setSampleRate(int newRate)
+{
+    m_sampleRate = newRate;
+    recalculateLastPerceivedBin();
+}
+
+void
+AudioCurveCalculator::setFftSize(int newSize)
+{
+    m_fftSize = newSize;
+    recalculateLastPerceivedBin();
+}
+
+void
+AudioCurveCalculator::recalculateLastPerceivedBin()
+{
+    if (m_sampleRate == 0) {
+        m_lastPerceivedBin = 0;
+        return;
+    }
+    m_lastPerceivedBin = ((MaxPerceivedFreq * m_fftSize) / m_sampleRate);
+    if (m_lastPerceivedBin > m_fftSize/2) {
+        m_lastPerceivedBin = m_fftSize/2;
+    }
+}
+
+
+}

--- a/pedalboard/vendors/rubberband/src/dsp/AudioCurveCalculator.h
+++ b/pedalboard/vendors/rubberband/src/dsp/AudioCurveCalculator.h
@@ -1,0 +1,134 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_AUDIO_CURVE_CALCULATOR_H
+#define RUBBERBAND_AUDIO_CURVE_CALCULATOR_H
+
+#include <sys/types.h>
+
+#include "../system/sysutils.h"
+
+namespace RubberBand 
+{
+
+/**
+ * AudioCurveCalculator turns a sequence of audio "columns" --
+ * short-time spectrum magnitude blocks -- into a sequence of numbers
+ * representing some quality of the input such as power or likelihood
+ * of an onset occurring.
+ *
+ * These are typically low-level building-blocks: AudioCurveCalculator
+ * is a simple causal interface in which each input column corresponds
+ * to exactly one output value which is returned immediately.  They
+ * have far less power (because of the causal interface and
+ * magnitude-only input) and flexibility (because of the limited
+ * return types) than for example the Vamp plugin interface.
+ *
+ * AudioCurveCalculator implementations typically remember the history
+ * of their processing data, and the caller must call reset() before
+ * resynchronising to an unrelated piece of input audio.
+ */
+class AudioCurveCalculator
+{
+public:
+    struct Parameters {
+        Parameters(int _sampleRate, int _fftSize) :
+            sampleRate(_sampleRate),
+            fftSize(_fftSize)
+        { }
+        int sampleRate;
+        int fftSize;
+    };
+
+    AudioCurveCalculator(Parameters parameters);
+    virtual ~AudioCurveCalculator();
+
+    int getSampleRate() const { return m_sampleRate; }
+    int getFftSize() const { return m_fftSize; }
+
+    virtual void setSampleRate(int newRate);
+    virtual void setFftSize(int newSize);
+
+    Parameters getParameters() const {
+        return Parameters(m_sampleRate, m_fftSize);
+    }
+    void setParameters(Parameters p) {
+        setSampleRate(p.sampleRate);
+        setFftSize(p.fftSize);
+    }
+
+    // You may not mix calls to the various process functions on a
+    // given instance
+
+
+    /**
+     * Process the given magnitude spectrum block and return the curve
+     * value for it.  The mag input contains (fftSize/2 + 1) values
+     * corresponding to the magnitudes of the complex FFT output bins
+     * for a windowed input of size fftSize.  The hop (expressed in
+     * time-domain audio samples) from the previous to the current
+     * input block is given by increment.
+     */
+    virtual float processFloat(const float *R__ mag, int increment) = 0;
+
+    /**
+     * Process the given magnitude spectrum block and return the curve
+     * value for it.  The mag input contains (fftSize/2 + 1) values
+     * corresponding to the magnitudes of the complex FFT output bins
+     * for a windowed input of size fftSize.  The hop (expressed in
+     * time-domain audio samples) from the previous to the current
+     * input block is given by increment.
+     */
+    virtual double processDouble(const double *R__ mag, int increment) = 0;
+
+    /**
+     * Obtain a confidence for the curve value (if applicable). A
+     * value of 1.0 indicates perfect confidence in the curve
+     * calculation, 0.0 indicates none.
+     */
+    virtual double getConfidence() const { return 1.0; }
+
+    /**
+     * Reset the calculator, forgetting the history of the audio input
+     * so far.
+     */
+    virtual void reset() = 0;
+
+    /**
+     * If the output of this calculator has a known unit, return it as
+     * text.  For example, "Hz" or "V".
+     */
+    virtual const char *getUnit() const { return ""; }
+
+protected:
+    int m_sampleRate;
+    int m_fftSize;
+    int m_lastPerceivedBin;
+    void recalculateLastPerceivedBin();
+};
+
+
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/dsp/BQResampler.cpp
+++ b/pedalboard/vendors/rubberband/src/dsp/BQResampler.cpp
@@ -1,0 +1,649 @@
+//* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "BQResampler.h"
+
+#include <cmath>
+
+#include <iostream>
+#include <algorithm>
+
+#include "../system/Allocators.h"
+#include "../system/VectorOps.h"
+
+#define BQ_R__ R__
+
+using std::vector;
+using std::cerr;
+using std::endl;
+using std::min;
+using std::max;
+
+namespace RubberBand {
+
+BQResampler::BQResampler(Parameters parameters, int channels) :
+    m_qparams(parameters.quality),
+    m_dynamism(parameters.dynamism),
+    m_ratio_change(parameters.ratioChange),
+    m_debug_level(parameters.debugLevel),
+    m_initial_rate(parameters.referenceSampleRate),
+    m_channels(channels),
+    m_fade_count(0),
+    m_initialised(false)
+{
+    if (m_debug_level > 0) {
+        cerr << "BQResampler::BQResampler: "
+             << (m_dynamism == RatioOftenChanging ? "often-changing" : "mostly-fixed")
+             << ", "
+             << (m_ratio_change == SmoothRatioChange ? "smooth" : "sudden")
+             << " ratio changes, ref " << m_initial_rate << " Hz" << endl;
+    }
+    
+    if (m_dynamism == RatioOftenChanging) {
+        m_proto_length = m_qparams.proto_p * m_qparams.p_multiple + 1;
+        if (m_debug_level > 0) {
+            cerr << "BQResampler: creating prototype filter of length "
+                 << m_proto_length << endl;
+        }
+        m_prototype = make_filter(m_proto_length, m_qparams.proto_p);
+        m_prototype.push_back(0.0); // interpolate without fear
+    }
+
+    int phase_reserve = 2 * int(round(m_initial_rate));
+    int buffer_reserve = 1000 * m_channels;
+    m_state_a.phase_info.reserve(phase_reserve);
+    m_state_a.buffer.reserve(buffer_reserve);
+
+    if (m_dynamism == RatioOftenChanging) {
+        m_state_b.phase_info.reserve(phase_reserve);
+        m_state_b.buffer.reserve(buffer_reserve);
+    }
+
+    m_s = &m_state_a;
+    m_fade = &m_state_b;
+}
+
+BQResampler::BQResampler(const BQResampler &other) :
+    m_qparams(other.m_qparams),
+    m_dynamism(other.m_dynamism),
+    m_ratio_change(other.m_ratio_change),
+    m_debug_level(other.m_debug_level),
+    m_initial_rate(other.m_initial_rate),
+    m_channels(other.m_channels),
+    m_state_a(other.m_state_a),
+    m_state_b(other.m_state_b),
+    m_fade_count(other.m_fade_count),
+    m_prototype(other.m_prototype),
+    m_proto_length(other.m_proto_length),
+    m_initialised(other.m_initialised)
+{
+    if (other.m_s == &(other.m_state_a)) {
+        m_s = &m_state_a;
+        m_fade = &m_state_b;
+    } else {
+        m_s = &m_state_b;
+        m_fade = &m_state_a;
+    }
+}
+
+void
+BQResampler::reset()
+{
+    m_initialised = false;
+    m_fade_count = 0;
+}
+
+BQResampler::QualityParams::QualityParams(Quality q)
+{
+    switch (q) {
+    case Fastest:
+        p_multiple = 12;
+        proto_p = 160;
+        k_snr = 70.0;
+        k_transition = 0.2;
+        cut = 0.9;
+        break;
+    case FastestTolerable:
+        p_multiple = 62;
+        proto_p = 160;
+        k_snr = 90.0;
+        k_transition = 0.05;
+        cut = 0.975;
+        break;
+    case Best:
+        p_multiple = 122;
+        proto_p = 800;
+        k_snr = 100.0;
+        k_transition = 0.01;
+        cut = 0.995;
+        break;
+    }
+}
+    
+int
+BQResampler::resampleInterleaved(float *const out,
+                                 int outspace,
+                                 const float *const in,
+                                 int incount,
+                                 double ratio,
+                                 bool final)
+{
+    int fade_length = int(round(m_initial_rate / 1000.0));
+    if (fade_length < 6) {
+        fade_length = 6;
+    }
+    int max_fade = min(outspace, int(floor(incount * ratio))) / 2;
+    if (fade_length > max_fade) {
+        fade_length = max_fade;
+    }
+        
+    if (!m_initialised) {
+        state_for_ratio(*m_s, ratio, *m_fade);
+        m_initialised = true;
+    } else if (ratio != m_s->parameters.ratio) {
+        state *tmp = m_fade;
+        m_fade = m_s;
+        m_s = tmp;
+        state_for_ratio(*m_s, ratio, *m_fade);
+        if (m_ratio_change == SmoothRatioChange) {
+            if (m_debug_level > 0) {
+                cerr << "BQResampler: ratio changed, beginning fade of length "
+                     << fade_length << endl;
+            }
+            m_fade_count = fade_length;
+        }
+    }
+
+    int i = 0, o = 0;
+    int bufsize = m_s->buffer.size();
+
+    int incount_samples = incount * m_channels;
+    int outspace_samples = outspace * m_channels;
+    
+    while (o < outspace_samples) {
+        while (i < incount_samples && m_s->fill < bufsize) {
+            m_s->buffer[m_s->fill++] = in[i++];
+        }
+        if (m_s->fill == bufsize) {
+            out[o++] = reconstruct_one(m_s);
+        } else if (final && m_s->fill > m_s->centre) {
+            out[o++] = reconstruct_one(m_s);
+        } else if (final && m_s->fill == m_s->centre &&
+                   m_s->current_phase != m_s->initial_phase) {
+            out[o++] = reconstruct_one(m_s);
+        } else {
+            break;
+        }
+    }
+
+    int fbufsize = m_fade->buffer.size();
+    int fi = 0, fo = 0;
+    while (fo < o && m_fade_count > 0) {
+        while (fi < incount_samples && m_fade->fill < fbufsize) {
+            m_fade->buffer[m_fade->fill++] = in[fi++];
+        }
+        if (m_fade->fill == fbufsize) {
+            double r = reconstruct_one(m_fade);
+            double fadeWith = out[fo];
+            double extent = double(m_fade_count - 1) / double(fade_length);
+            double mixture = 0.5 * (1.0 - cos(M_PI * extent));
+            double mixed = r * mixture + fadeWith * (1.0 - mixture);
+            out[fo] = mixed;
+            ++fo;
+            if (m_fade->current_channel == 0) {
+                --m_fade_count;
+            }
+        } else {
+            break;
+        }
+    }
+        
+    return o / m_channels;
+}
+
+double
+BQResampler::getEffectiveRatio(double ratio) const {
+    if (m_initialised && ratio == m_s->parameters.ratio) {
+        return m_s->parameters.effective;
+    } else {
+        return pick_params(ratio).effective;
+    }
+}
+    
+int
+BQResampler::gcd(int a, int b) const
+{
+    int c = a % b;
+    if (c == 0) return b;
+    else return gcd(b, c);
+}
+
+double
+BQResampler::bessel0(double x) const
+{
+    static double facsquared[] = {
+        0.0, 1.0, 4.0, 36.0,
+        576.0, 14400.0, 518400.0, 25401600.0,
+        1625702400.0, 131681894400.0, 1.316818944E13, 1.59335092224E15,
+        2.29442532803E17, 3.87757880436E19, 7.60005445655E21,
+        1.71001225272E24, 4.37763136697E26, 1.26513546506E29,
+        4.09903890678E31, 1.47975304535E34
+    };
+    static int nterms = sizeof(facsquared) / sizeof(facsquared[0]);
+    double b = 1.0;
+    for (int n = 1; n < nterms; ++n) {
+        double ff = facsquared[n];
+        double term = pow(x / 2.0, n * 2.0) / ff;
+        b += term;
+    }
+    return b;
+}
+
+vector<double>
+BQResampler::kaiser(double beta, int len) const
+{
+    double denominator = bessel0(beta);
+    int half = (len % 2 == 0 ? len/2 : (len+1)/2);
+    vector<double> v(len, 0.0);
+    for (int n = 0; n < half; ++n) {
+        double k = (2.0 * n) / (len-1) - 1.0;
+        v[n] = bessel0 (beta * sqrt(1.0 - k*k)) / denominator;
+    }
+    for (int n = half; n < len; ++n) {
+        v[n] = v[len-1 - n];
+    }
+    return v;
+}
+
+void
+BQResampler::kaiser_params(double attenuation,
+                           double transition,
+                           double &beta,
+                           int &len) const
+{
+    if (attenuation > 21.0) {
+        len = 1 + int(ceil((attenuation - 7.95) / (2.285 * transition)));
+    } else {
+        len = 1 + int(ceil(5.79 / transition));
+    }
+    beta = 0.0;
+    if (attenuation > 50.0) {
+        beta = 0.1102 * (attenuation - 8.7);
+    } else if (attenuation > 21.0) {
+        beta = 0.5842 * (pow (attenuation - 21.0, 0.4)) +
+            0.07886 * (attenuation - 21.0);
+    }
+}
+
+vector<double>
+BQResampler::kaiser_for(double attenuation,
+                        double transition,
+                        int minlen,
+                        int maxlen) const
+{
+    double beta;
+    int m;
+    kaiser_params(attenuation, transition, beta, m);
+    int mb = m;
+    if (maxlen > 0 && mb > maxlen - 1) {
+        mb = maxlen - 1;
+    } else if (minlen > 0 && mb < minlen) {
+        mb = minlen;
+    }
+    if (mb % 2 == 0) ++mb;
+    if (m_debug_level > 0) {
+        cerr << "BQResampler: window attenuation " << attenuation
+             << ", transition " << transition
+             << " -> length " << m << " adjusted to " << mb
+             << ", beta " << beta << endl;
+    }
+    return kaiser(beta, mb);
+}
+    
+void
+BQResampler::sinc_multiply(double peak_to_zero, vector<double> &buf) const
+{
+    int len = int(buf.size());
+    if (len < 2) return;
+
+    int left = len / 2;
+    int right = (len + 1) / 2;
+    double m = M_PI / peak_to_zero;
+
+    for (int i = 1; i <= right; ++i) {
+        double x = i * m;
+        double sinc = sin(x) / x;
+        if (i <= left) {
+            buf[left - i] *= sinc;
+        }
+        if (i < right) {
+            buf[i + left] *= sinc;
+        }
+    }
+}
+
+BQResampler::params
+BQResampler::fill_params(double ratio, double numd, double denomd) const
+{
+    int num = int(round(numd));
+    int denom = int(round(denomd));
+    params p;
+    int g = gcd (num, denom);
+    p.ratio = ratio;
+    p.numerator = num / g;
+    p.denominator = denom / g;
+    p.effective = double(p.numerator) / double(p.denominator);
+    p.peak_to_zero = max(p.denominator, p.numerator);
+    p.peak_to_zero /= m_qparams.cut;
+    p.scale = double(p.numerator) / double(p.peak_to_zero);
+
+    if (m_debug_level > 0) {
+        cerr << "BQResampler: ratio " << p.ratio
+             << " -> fraction " << p.numerator << "/" << p.denominator
+             << " with error " << p.effective - p.ratio
+             << endl;
+        cerr << "BQResampler: peak-to-zero " << p.peak_to_zero
+             << ", scale " << p.scale
+             << endl;
+    }
+    
+    return p;
+}
+    
+BQResampler::params
+BQResampler::pick_params(double ratio) const
+{
+    // Farey algorithm, see
+    // https://www.johndcook.com/blog/2010/10/20/best-rational-approximation/
+    int max_denom = 192000;
+    double a = 0.0, b = 1.0, c = 1.0, d = 0.0;
+    double pa = a, pb = b, pc = c, pd = d;
+    double eps = 1e-9;
+    while (b <= max_denom && d <= max_denom) {
+        double mediant = (a + c) / (b + d);
+        if (fabs(ratio - mediant) < eps) {
+            if (b + d <= max_denom) {
+                return fill_params(ratio, a + c, b + d);
+            } else if (d > b) {
+                return fill_params(ratio, c, d);
+            } else {
+                return fill_params(ratio, a, b);
+            }
+        }
+        if (ratio > mediant) {
+            pa = a; pb = b;
+            a += c; b += d;
+        } else {
+            pc = c; pd = d;
+            c += a; d += b;
+        }
+    }
+    if (fabs(ratio - (pc / pd)) < fabs(ratio - (pa / pb))) {
+        return fill_params(ratio, pc, pd);
+    } else {
+        return fill_params(ratio, pa, pb);
+    }
+}
+
+void
+BQResampler::phase_data_for(vector<BQResampler::phase_rec> &target_phase_data,
+                            floatbuf &target_phase_sorted_filter,
+                            int filter_length,
+                            const vector<double> *filter,
+                            int initial_phase,
+                            int input_spacing,
+                            int output_spacing) const
+{
+    target_phase_data.clear();
+    target_phase_data.reserve(input_spacing);
+        
+    for (int p = 0; p < input_spacing; ++p) {
+        int next_phase = p - output_spacing;
+        while (next_phase < 0) next_phase += input_spacing;
+        next_phase %= input_spacing;
+        double dspace = double(input_spacing);
+        int zip_length = int(ceil(double(filter_length - p) / dspace));
+        int drop = int(ceil(double(max(0, output_spacing - p)) / dspace));
+        phase_rec phase;
+        phase.next_phase = next_phase;
+        phase.drop = drop;
+        phase.length = zip_length;
+        phase.start_index = 0; // we fill this in below if needed
+        target_phase_data.push_back(phase);
+    }
+
+    if (m_dynamism == RatioMostlyFixed) {
+        if (!filter) throw std::logic_error("filter required at phase_data_for in RatioMostlyFixed mode");
+        target_phase_sorted_filter.clear();
+        target_phase_sorted_filter.reserve(filter_length);
+        for (int p = initial_phase; ; ) {
+            phase_rec &phase = target_phase_data[p];
+            phase.start_index = target_phase_sorted_filter.size();
+            for (int i = 0; i < phase.length; ++i) {
+                target_phase_sorted_filter.push_back
+                    ((*filter)[i * input_spacing + p]);
+            }
+            p = phase.next_phase;
+            if (p == initial_phase) {
+                break;
+            }
+        }
+    }
+}
+
+vector<double>
+BQResampler::make_filter(int filter_length, double peak_to_zero) const
+{
+    vector<double> filter;
+    filter.reserve(filter_length);
+
+    vector<double> kaiser = kaiser_for(m_qparams.k_snr, m_qparams.k_transition,
+                                       1, filter_length);
+    int k_length = kaiser.size();
+
+    if (k_length == filter_length) {
+        sinc_multiply(peak_to_zero, kaiser);
+        return kaiser;
+    } else {
+        kaiser.push_back(0.0);
+        double m = double(k_length - 1) / double(filter_length - 1);
+        for (int i = 0; i < filter_length; ++i) {
+            double ix = i * m;
+            int iix = int(floor(ix));
+            double remainder = ix - iix;
+            double value = 0.0;
+            value += kaiser[iix] * (1.0 - remainder);
+            value += kaiser[iix+1] * remainder;
+            filter.push_back(value);
+        }
+        sinc_multiply(peak_to_zero, filter);
+        return filter;
+    }
+}
+
+void
+BQResampler::state_for_ratio(BQResampler::state &target_state,
+                             double ratio,
+                             const BQResampler::state &BQ_R__ prev_state) const
+{
+    params parameters = pick_params(ratio);
+    target_state.parameters = parameters;
+    
+    target_state.filter_length =
+        int(parameters.peak_to_zero * m_qparams.p_multiple + 1);
+
+    if (target_state.filter_length % 2 == 0) {
+        ++target_state.filter_length;
+    }
+
+    int half_length = target_state.filter_length / 2; // nb length is odd
+    int input_spacing = parameters.numerator;
+    int initial_phase = half_length % input_spacing;
+
+    target_state.initial_phase = initial_phase;
+    target_state.current_phase = initial_phase;
+
+    if (m_dynamism == RatioMostlyFixed) {
+        
+        if (m_debug_level > 0) {
+            cerr << "BQResampler: creating filter of length "
+                 << target_state.filter_length << endl;
+        }
+
+        vector<double> filter =
+            make_filter(target_state.filter_length, parameters.peak_to_zero);
+
+        phase_data_for(target_state.phase_info,
+                       target_state.phase_sorted_filter,
+                       target_state.filter_length, &filter,
+                       target_state.initial_phase,
+                       input_spacing,
+                       parameters.denominator);
+    } else {
+        phase_data_for(target_state.phase_info,
+                       target_state.phase_sorted_filter,
+                       target_state.filter_length, 0,
+                       target_state.initial_phase,
+                       input_spacing,
+                       parameters.denominator);
+    }
+
+    int buffer_left = half_length / input_spacing;
+    int buffer_right = buffer_left + 1;
+
+    int buffer_length = buffer_left + buffer_right;
+    buffer_length = max(buffer_length,
+                        int(prev_state.buffer.size() / m_channels));
+
+    target_state.centre = buffer_length / 2;
+    target_state.left = target_state.centre - buffer_left;
+    target_state.fill = target_state.centre;
+
+    buffer_length *= m_channels;
+    target_state.centre *= m_channels;
+    target_state.left *= m_channels;
+    target_state.fill *= m_channels;
+    
+    int n_phases = int(target_state.phase_info.size());
+
+    if (m_debug_level > 0) {
+        cerr << "BQResampler: " << m_channels << " channel(s) interleaved"
+             << ", buffer left " << buffer_left
+             << ", right " << buffer_right
+             << ", total " << buffer_length << endl;
+    
+        cerr << "BQResampler: input spacing " << input_spacing
+             << ", output spacing " << parameters.denominator
+             << ", initial phase " << initial_phase
+             << " of " << n_phases << endl;
+    }
+
+    if (prev_state.buffer.size() > 0) {
+        if (int(prev_state.buffer.size()) == buffer_length) {
+            target_state.buffer = prev_state.buffer;
+            target_state.fill = prev_state.fill;
+        } else {
+            target_state.buffer = floatbuf(buffer_length, 0.0);
+            for (int i = 0; i < prev_state.fill; ++i) {
+                int offset = i - prev_state.centre;
+                int new_ix = offset + target_state.centre;
+                if (new_ix >= 0 && new_ix < buffer_length) {
+                    target_state.buffer[new_ix] = prev_state.buffer[i];
+                    target_state.fill = new_ix + 1;
+                }
+            }
+        }
+
+        int phases_then = int(prev_state.phase_info.size());
+        double distance_through =
+            double(prev_state.current_phase) / double(phases_then);
+        target_state.current_phase = int(round(n_phases * distance_through));
+        if (target_state.current_phase >= n_phases) {
+            target_state.current_phase = n_phases - 1;
+        }
+    } else {
+        target_state.buffer = floatbuf(buffer_length, 0.0);
+    }
+}
+
+double
+BQResampler::reconstruct_one(state *s) const
+{
+    const phase_rec &pr = s->phase_info[s->current_phase];
+    int phase_length = pr.length;
+    double result = 0.0;
+
+    int dot_length =
+        min(phase_length,
+            (int(s->buffer.size()) - s->left) / m_channels);
+
+    if (m_dynamism == RatioMostlyFixed) {
+        int phase_start = pr.start_index;
+        if (m_channels == 1) {
+            result = v_multiply_and_sum
+                (s->phase_sorted_filter.data() + phase_start,
+                 s->buffer.data() + s->left,
+                 dot_length);
+        } else {
+            for (int i = 0; i < dot_length; ++i) {
+                result +=
+                    s->phase_sorted_filter[phase_start + i] *
+                    s->buffer[s->left + i * m_channels + s->current_channel];
+            }
+        }
+    } else {
+        double m = double(m_proto_length - 1) / double(s->filter_length - 1);
+        for (int i = 0; i < dot_length; ++i) {
+            double sample =
+                s->buffer[s->left + i * m_channels + s->current_channel];
+            int filter_index = i * s->parameters.numerator + s->current_phase;
+            double proto_index = m * filter_index;
+            int iix = int(floor(proto_index));
+            double remainder = proto_index - iix;
+            double filter_value = m_prototype[iix] * (1.0 - remainder);
+            filter_value += m_prototype[iix+1] * remainder;
+            result += filter_value * sample;
+        }
+    }
+
+    s->current_channel = (s->current_channel + 1) % m_channels;
+    
+    if (s->current_channel == 0) {
+
+        if (pr.drop > 0) {
+            int drop = pr.drop * m_channels;
+            v_move(s->buffer.data(), s->buffer.data() + drop,
+                   int(s->buffer.size()) - drop);
+            for (int i = 1; i <= drop; ++i) {
+                s->buffer[s->buffer.size() - i] = 0.0;
+            }
+            s->fill -= drop;
+        }
+
+        s->current_phase = pr.next_phase;
+    }
+    
+    return result * s->parameters.scale;
+}
+
+}

--- a/pedalboard/vendors/rubberband/src/dsp/BQResampler.h
+++ b/pedalboard/vendors/rubberband/src/dsp/BQResampler.h
@@ -1,0 +1,167 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef BQ_BQRESAMPLER_H
+#define BQ_BQRESAMPLER_H
+
+#include <vector>
+
+#include "../system/Allocators.h"
+#include "../system/VectorOps.h"
+
+namespace RubberBand {
+
+class BQResampler
+{
+public:
+    enum Quality { Best, FastestTolerable, Fastest };
+    enum Dynamism { RatioOftenChanging, RatioMostlyFixed };
+    enum RatioChange { SmoothRatioChange, SuddenRatioChange };
+    
+    struct Parameters {
+        Quality quality;
+        Dynamism dynamism; 
+        RatioChange ratioChange;
+        double referenceSampleRate;
+        int debugLevel;
+
+        Parameters() :
+            quality(FastestTolerable),
+            dynamism(RatioMostlyFixed),
+            ratioChange(SmoothRatioChange),
+            referenceSampleRate(44100),
+            debugLevel(0) { }
+    };
+
+    BQResampler(Parameters parameters, int channels);
+    BQResampler(const BQResampler &);
+
+    int resampleInterleaved(float *const out, int outspace,
+                            const float *const in, int incount,
+                            double ratio, bool final);
+
+    double getEffectiveRatio(double ratio) const;
+    
+    void reset();
+
+private:
+    struct QualityParams {
+        int p_multiple;
+        int proto_p;
+        double k_snr;
+        double k_transition;
+        double cut;
+        QualityParams(Quality);
+    };
+
+    const QualityParams m_qparams;
+    const Dynamism m_dynamism;
+    const RatioChange m_ratio_change;
+    const int m_debug_level;
+    const double m_initial_rate;
+    const int m_channels;
+
+    struct params {
+        double ratio;
+        int numerator;
+        int denominator;
+        double effective;
+        double peak_to_zero;
+        double scale;
+        params() : ratio(1.0), numerator(1), denominator(1),
+                   effective(1.0), peak_to_zero(0), scale(1.0) { }
+    };
+
+    struct phase_rec {
+        int next_phase;
+        int length;
+        int start_index;
+        int drop;
+        phase_rec() : next_phase(0), length(0), start_index(0), drop(0) { }
+    };
+
+    typedef std::vector<float, RubberBand::StlAllocator<float> > floatbuf;
+    
+    struct state {
+        params parameters;
+        int initial_phase;
+        int current_phase;
+        int current_channel;
+        int filter_length;
+        std::vector<phase_rec> phase_info;
+        floatbuf phase_sorted_filter;
+        floatbuf buffer;
+        int left;
+        int centre;
+        int fill;
+        state() : initial_phase(0), current_phase(0), current_channel(0),
+                  filter_length(0), left(0), centre(0), fill(0) { }
+    };
+
+    state m_state_a;
+    state m_state_b;
+
+    state *m_s;        // points at either m_state_a or m_state_b
+    state *m_fade;     // whichever one m_s does not point to
+    
+    int m_fade_count;
+    
+    std::vector<double> m_prototype;
+    int m_proto_length;
+    bool m_initialised;
+
+    int gcd(int a, int b) const;
+    double bessel0(double x) const;
+    std::vector<double> kaiser(double beta, int len) const;
+    void kaiser_params(double attenuation, double transition,
+                       double &beta, int &len) const;
+    std::vector<double> kaiser_for(double attenuation, double transition,
+                                   int minlen, int maxlen) const;
+    void sinc_multiply(double peak_to_zero, std::vector<double> &buf) const;
+
+    params fill_params(double ratio, double numd, double denomd) const;
+    params pick_params(double ratio) const;
+
+    std::vector<double> make_filter(int filter_length,
+                                    double peak_to_zero) const;
+    
+    void phase_data_for(std::vector<phase_rec> &target_phase_data,
+                        floatbuf &target_phase_sorted_filter,
+                        int filter_length,
+                        const std::vector<double> *filter,
+                        int initial_phase,
+                        int input_spacing,
+                        int output_spacing) const;
+    
+    void state_for_ratio(state &target_state,
+                         double ratio,
+                         const state &R__ prev_state) const;
+    
+    double reconstruct_one(state *s) const;
+
+    BQResampler &operator=(const BQResampler &); // not provided
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/dsp/FFT.cpp
+++ b/pedalboard/vendors/rubberband/src/dsp/FFT.cpp
@@ -1,0 +1,2872 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "FFT.h"
+#include "../system/Thread.h"
+#include "../base/Profiler.h"
+#include "../system/Allocators.h"
+#include "../system/VectorOps.h"
+#include "../system/VectorOpsComplex.h"
+
+// Define USE_FFTW_WISDOM if you are defining HAVE_FFTW3 and you want
+// to use FFTW_MEASURE mode with persistent wisdom files. This will
+// make things much slower on first use if no suitable wisdom has been
+// saved, but may be faster during subsequent use.
+//#define USE_FFTW_WISDOM 1
+
+// Define FFT_MEASUREMENT to include timing measurement code callable
+// via the static method FFT::tune(). Must be defined when the header
+// is included as well.
+//#define FFT_MEASUREMENT 1
+
+#ifdef FFT_MEASUREMENT
+#define FFT_MEASUREMENT_RETURN_RESULT_TEXT 1
+#include <sstream>
+#endif
+
+#ifdef HAVE_IPP
+#include <ippversion.h>
+#include <ipps.h>
+#endif
+
+#ifdef HAVE_FFTW3
+#include <fftw3.h>
+#endif
+
+#ifdef HAVE_VDSP
+#include <Accelerate/Accelerate.h>
+#endif
+
+#ifdef HAVE_KISSFFT
+#include "kiss_fftr.h"
+#endif
+
+#ifndef HAVE_IPP
+#ifndef HAVE_FFTW3
+#ifndef HAVE_KISSFFT
+#ifndef USE_BUILTIN_FFT
+#ifndef HAVE_VDSP
+#error No FFT implementation selected!
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#ifdef FFT_MEASUREMENT
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+#endif
+
+#define BQ_R__ R__
+
+namespace RubberBand {
+
+class FFTImpl
+{
+public:
+    virtual ~FFTImpl() { }
+
+    virtual FFT::Precisions getSupportedPrecisions() const = 0;
+
+    virtual int getSize() const = 0;
+    
+    virtual void initFloat() = 0;
+    virtual void initDouble() = 0;
+
+    virtual void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) = 0;
+    virtual void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) = 0;
+    virtual void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) = 0;
+    virtual void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) = 0;
+
+    virtual void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) = 0;
+    virtual void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) = 0;
+    virtual void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) = 0;
+    virtual void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) = 0;
+
+    virtual void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) = 0;
+    virtual void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) = 0;
+    virtual void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) = 0;
+    virtual void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) = 0;
+
+    virtual void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) = 0;
+    virtual void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) = 0;
+    virtual void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) = 0;
+    virtual void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) = 0;
+};    
+
+namespace FFTs {
+
+#ifdef HAVE_IPP
+
+class D_IPP : public FFTImpl
+{
+public:
+    D_IPP(int size) :
+        m_size(size), m_fspec(0), m_dspec(0)
+    { 
+        for (int i = 0; ; ++i) {
+            if (m_size & (1 << i)) {
+                m_order = i;
+                break;
+            }
+        }
+    }
+
+    ~D_IPP() {
+        if (m_fspec) {
+#if (IPP_VERSION_MAJOR >= 9)
+            ippsFree(m_fspecbuf);
+#else
+            ippsFFTFree_R_32f(m_fspec);
+#endif
+            ippsFree(m_fbuf);
+            ippsFree(m_fpacked);
+            ippsFree(m_fspare);
+        }
+        if (m_dspec) {
+#if (IPP_VERSION_MAJOR >= 9)
+            ippsFree(m_dspecbuf);
+#else
+            ippsFFTFree_R_64f(m_dspec);
+#endif
+            ippsFree(m_dbuf);
+            ippsFree(m_dpacked);
+            ippsFree(m_dspare);
+        }
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+    
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+    }
+
+    //!!! rv check
+
+    void initFloat() {
+        if (m_fspec) return;
+#if (IPP_VERSION_MAJOR >= 9)
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_32f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_fspecbuf = ippsMalloc_8u(specSize);
+        Ipp8u *tmp = ippsMalloc_8u(specBufferSize);
+        m_fbuf = ippsMalloc_8u(bufferSize);
+        m_fpacked = ippsMalloc_32f(m_size + 2);
+        m_fspare = ippsMalloc_32f(m_size / 2 + 1);
+        ippsFFTInit_R_32f(&m_fspec,
+                          m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                          m_fspecbuf, tmp);
+        ippsFree(tmp);
+#else
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_32f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_fbuf = ippsMalloc_8u(bufferSize);
+        m_fpacked = ippsMalloc_32f(m_size + 2);
+        m_fspare = ippsMalloc_32f(m_size / 2 + 1);
+        ippsFFTInitAlloc_R_32f(&m_fspec, m_order, IPP_FFT_NODIV_BY_ANY, 
+                               ippAlgHintFast);
+#endif
+    }
+
+    void initDouble() {
+        if (m_dspec) return;
+#if (IPP_VERSION_MAJOR >= 9)
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_64f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_dspecbuf = ippsMalloc_8u(specSize);
+        Ipp8u *tmp = ippsMalloc_8u(specBufferSize);
+        m_dbuf = ippsMalloc_8u(bufferSize);
+        m_dpacked = ippsMalloc_64f(m_size + 2);
+        m_dspare = ippsMalloc_64f(m_size / 2 + 1);
+        ippsFFTInit_R_64f(&m_dspec,
+                          m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                          m_dspecbuf, tmp);
+        ippsFree(tmp);
+#else
+        int specSize, specBufferSize, bufferSize;
+        ippsFFTGetSize_R_64f(m_order, IPP_FFT_NODIV_BY_ANY, ippAlgHintFast,
+                             &specSize, &specBufferSize, &bufferSize);
+        m_dbuf = ippsMalloc_8u(bufferSize);
+        m_dpacked = ippsMalloc_64f(m_size + 2);
+        m_dspare = ippsMalloc_64f(m_size / 2 + 1);
+        ippsFFTInitAlloc_R_64f(&m_dspec, m_order, IPP_FFT_NODIV_BY_ANY, 
+                               ippAlgHintFast);
+#endif
+    }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        int index = 0;
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[index++] = re[i];
+            index++;
+        }
+        index = 0;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_fpacked[index++] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_fpacked[index++] = 0.f;
+            }
+        }
+    }
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        int index = 0;
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_dpacked[index++] = re[i];
+            index++;
+        }
+        index = 0;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_dpacked[index++] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                m_dpacked[index++] = 0.0;
+            }
+        }
+    }
+
+    void unpackFloat(float *re, float *BQ_R__ im) { // re may be equal to m_fpacked
+        int index = 0;
+        const int hs = m_size/2;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                im[i] = m_fpacked[index++];
+            }
+        }
+        index = 0;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_fpacked[index++];
+            index++;
+        }
+    }        
+
+    void unpackDouble(double *re, double *BQ_R__ im) { // re may be equal to m_dpacked
+        int index = 0;
+        const int hs = m_size/2;
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                index++;
+                im[i] = m_dpacked[index++];
+            }
+        }
+        index = 0;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_dpacked[index++];
+            index++;
+        }
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, m_dpacked, m_dspec, m_dbuf);
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, complexOut, m_dspec, m_dbuf);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, m_dpacked, m_dspec, m_dbuf);
+        unpackDouble(m_dpacked, m_dspare);
+        ippsCartToPolar_64f(m_dpacked, m_dspare, magOut, phaseOut, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTFwd_RToCCS_64f(realIn, m_dpacked, m_dspec, m_dbuf);
+        unpackDouble(m_dpacked, m_dspare);
+        ippsMagnitude_64f(m_dpacked, m_dspare, magOut, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, m_fpacked, m_fspec, m_fbuf);
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, complexOut, m_fspec, m_fbuf);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, m_fpacked, m_fspec, m_fbuf);
+        unpackFloat(m_fpacked, m_fspare);
+        ippsCartToPolar_32f(m_fpacked, m_fspare, magOut, phaseOut, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTFwd_RToCCS_32f(realIn, m_fpacked, m_fspec, m_fbuf);
+        unpackFloat(m_fpacked, m_fspare);
+        ippsMagnitude_32f(m_fpacked, m_fspare, magOut, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        packDouble(realIn, imagIn);
+        ippsFFTInv_CCSToR_64f(m_dpacked, realOut, m_dspec, m_dbuf);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        ippsFFTInv_CCSToR_64f(complexIn, realOut, m_dspec, m_dbuf);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        ippsPolarToCart_64f(magIn, phaseIn, realOut, m_dspare, m_size/2+1);
+        packDouble(realOut, m_dspare); // to m_dpacked
+        ippsFFTInv_CCSToR_64f(m_dpacked, realOut, m_dspec, m_dbuf);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2 + 1;
+        ippsCopy_64f(magIn, m_dspare, hs1);
+        ippsAddC_64f_I(0.000001, m_dspare, hs1);
+        ippsLn_64f_I(m_dspare, hs1);
+        packDouble(m_dspare, 0);
+        ippsFFTInv_CCSToR_64f(m_dpacked, cepOut, m_dspec, m_dbuf);
+    }
+    
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        packFloat(realIn, imagIn);
+        ippsFFTInv_CCSToR_32f(m_fpacked, realOut, m_fspec, m_fbuf);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        ippsFFTInv_CCSToR_32f(complexIn, realOut, m_fspec, m_fbuf);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        ippsPolarToCart_32f(magIn, phaseIn, realOut, m_fspare, m_size/2+1);
+        packFloat(realOut, m_fspare); // to m_fpacked
+        ippsFFTInv_CCSToR_32f(m_fpacked, realOut, m_fspec, m_fbuf);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fspec) initFloat();
+        const int hs1 = m_size/2 + 1;
+        ippsCopy_32f(magIn, m_fspare, hs1);
+        ippsAddC_32f_I(0.000001f, m_fspare, hs1);
+        ippsLn_32f_I(m_fspare, hs1);
+        packFloat(m_fspare, 0);
+        ippsFFTInv_CCSToR_32f(m_fpacked, cepOut, m_fspec, m_fbuf);
+    }
+
+private:
+    const int m_size;
+    int m_order;
+    IppsFFTSpec_R_32f *m_fspec;
+    IppsFFTSpec_R_64f *m_dspec;
+    Ipp8u *m_fspecbuf;
+    Ipp8u *m_dspecbuf;
+    Ipp8u *m_fbuf;
+    Ipp8u *m_dbuf;
+    float *m_fpacked;
+    float *m_fspare;
+    double *m_dpacked;
+    double *m_dspare;
+};
+
+#endif /* HAVE_IPP */
+
+#ifdef HAVE_VDSP
+
+class D_VDSP : public FFTImpl
+{
+public:
+    D_VDSP(int size) :
+        m_size(size), m_fspec(0), m_dspec(0),
+        m_fpacked(0), m_fspare(0),
+        m_dpacked(0), m_dspare(0)
+    { 
+        for (int i = 0; ; ++i) {
+            if (m_size & (1 << i)) {
+                m_order = i;
+                break;
+            }
+        }
+    }
+
+    ~D_VDSP() {
+        if (m_fspec) {
+            vDSP_destroy_fftsetup(m_fspec);
+            deallocate(m_fspare);
+            deallocate(m_fspare2);
+            deallocate(m_fbuf->realp);
+            deallocate(m_fbuf->imagp);
+            delete m_fbuf;
+            deallocate(m_fpacked->realp);
+            deallocate(m_fpacked->imagp);
+            delete m_fpacked;
+        }
+        if (m_dspec) {
+            vDSP_destroy_fftsetupD(m_dspec);
+            deallocate(m_dspare);
+            deallocate(m_dspare2);
+            deallocate(m_dbuf->realp);
+            deallocate(m_dbuf->imagp);
+            delete m_dbuf;
+            deallocate(m_dpacked->realp);
+            deallocate(m_dpacked->imagp);
+            delete m_dpacked;
+        }
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+    }
+
+    //!!! rv check
+
+    void initFloat() {
+        if (m_fspec) return;
+        m_fspec = vDSP_create_fftsetup(m_order, FFT_RADIX2);
+        m_fbuf = new DSPSplitComplex;
+        //!!! "If possible, tempBuffer->realp and tempBuffer->imagp should be 32-byte aligned for best performance."
+        m_fbuf->realp = allocate<float>(m_size);
+        m_fbuf->imagp = allocate<float>(m_size);
+        m_fpacked = new DSPSplitComplex;
+        m_fpacked->realp = allocate<float>(m_size / 2 + 1);
+        m_fpacked->imagp = allocate<float>(m_size / 2 + 1);
+        m_fspare = allocate<float>(m_size + 2);
+        m_fspare2 = allocate<float>(m_size + 2);
+    }
+
+    void initDouble() {
+        if (m_dspec) return;
+        m_dspec = vDSP_create_fftsetupD(m_order, FFT_RADIX2);
+        m_dbuf = new DSPDoubleSplitComplex;
+        //!!! "If possible, tempBuffer->realp and tempBuffer->imagp should be 32-byte aligned for best performance."
+        m_dbuf->realp = allocate<double>(m_size);
+        m_dbuf->imagp = allocate<double>(m_size);
+        m_dpacked = new DSPDoubleSplitComplex;
+        m_dpacked->realp = allocate<double>(m_size / 2 + 1);
+        m_dpacked->imagp = allocate<double>(m_size / 2 + 1);
+        m_dspare = allocate<double>(m_size + 2);
+        m_dspare2 = allocate<double>(m_size + 2);
+    }
+
+    void packReal(const float *BQ_R__ const re) {
+        // Pack input for forward transform 
+        vDSP_ctoz((DSPComplex *)re, 2, m_fpacked, 1, m_size/2);
+    }
+    void packComplex(const float *BQ_R__ const re, const float *BQ_R__ const im) {
+        // Pack input for inverse transform 
+        if (re) v_copy(m_fpacked->realp, re, m_size/2 + 1);
+        else v_zero(m_fpacked->realp, m_size/2 + 1);
+        if (im) v_copy(m_fpacked->imagp, im, m_size/2 + 1);
+        else v_zero(m_fpacked->imagp, m_size/2 + 1);
+        fnyq();
+    }
+
+    void unpackReal(float *BQ_R__ const re) {
+        // Unpack output for inverse transform
+        vDSP_ztoc(m_fpacked, 1, (DSPComplex *)re, 2, m_size/2);
+    }
+    void unpackComplex(float *BQ_R__ const re, float *BQ_R__ const im) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        float two = 2.f;
+        vDSP_vsdiv(m_fpacked->realp, 1, &two, re, 1, m_size/2 + 1);
+        vDSP_vsdiv(m_fpacked->imagp, 1, &two, im, 1, m_size/2 + 1);
+    }
+    void unpackComplex(float *BQ_R__ const cplx) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        const int hs1 = m_size/2 + 1;
+        for (int i = 0; i < hs1; ++i) {
+            cplx[i*2] = m_fpacked->realp[i] * 0.5f;
+            cplx[i*2+1] = m_fpacked->imagp[i] * 0.5f;
+        }
+    }
+
+    void packReal(const double *BQ_R__ const re) {
+        // Pack input for forward transform
+        vDSP_ctozD((DSPDoubleComplex *)re, 2, m_dpacked, 1, m_size/2);
+    }
+    void packComplex(const double *BQ_R__ const re, const double *BQ_R__ const im) {
+        // Pack input for inverse transform
+        if (re) v_copy(m_dpacked->realp, re, m_size/2 + 1);
+        else v_zero(m_dpacked->realp, m_size/2 + 1);
+        if (im) v_copy(m_dpacked->imagp, im, m_size/2 + 1);
+        else v_zero(m_dpacked->imagp, m_size/2 + 1);
+        dnyq();
+    }
+
+    void unpackReal(double *BQ_R__ const re) {
+        // Unpack output for inverse transform
+        vDSP_ztocD(m_dpacked, 1, (DSPDoubleComplex *)re, 2, m_size/2);
+    }
+    void unpackComplex(double *BQ_R__ const re, double *BQ_R__ const im) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        double two = 2.0;
+        vDSP_vsdivD(m_dpacked->realp, 1, &two, re, 1, m_size/2 + 1);
+        vDSP_vsdivD(m_dpacked->imagp, 1, &two, im, 1, m_size/2 + 1);
+    }
+    void unpackComplex(double *BQ_R__ const cplx) {
+        // Unpack output for forward transform
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        const int hs1 = m_size/2 + 1;
+        for (int i = 0; i < hs1; ++i) {
+            cplx[i*2] = m_dpacked->realp[i] * 0.5;
+            cplx[i*2+1] = m_dpacked->imagp[i] * 0.5;
+        }
+    }
+
+    void fdenyq() {
+        // for fft result in packed form, unpack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_fpacked->realp[hs] = m_fpacked->imagp[0];
+        m_fpacked->imagp[hs] = 0.f;
+        m_fpacked->imagp[0] = 0.f;
+    }
+    void ddenyq() {
+        // for fft result in packed form, unpack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_dpacked->realp[hs] = m_dpacked->imagp[0];
+        m_dpacked->imagp[hs] = 0.;
+        m_dpacked->imagp[0] = 0.;
+    }
+
+    void fnyq() {
+        // for ifft input in packed form, pack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_fpacked->imagp[0] = m_fpacked->realp[hs];
+        m_fpacked->realp[hs] = 0.f;
+        m_fpacked->imagp[hs] = 0.f;
+    }
+    void dnyq() {
+        // for ifft input in packed form, pack the DC and Nyquist bins
+        const int hs = m_size/2;
+        m_dpacked->imagp[0] = m_dpacked->realp[hs];
+        m_dpacked->realp[hs] = 0.;
+        m_dpacked->imagp[hs] = 0.;
+    }
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dspec) initDouble();
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        unpackComplex(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dspec) initDouble();
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        unpackComplex(complexOut);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2+1;
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        for (int i = 0; i < hs1; ++i) m_dpacked->realp[i] *= 0.5;
+        for (int i = 0; i < hs1; ++i) m_dpacked->imagp[i] *= 0.5;
+        v_cartesian_to_polar(magOut, phaseOut,
+                             m_dpacked->realp, m_dpacked->imagp, hs1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dspec) initDouble();
+        packReal(realIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_FORWARD);
+        ddenyq();
+        const int hs1 = m_size/2+1;
+        vDSP_zvmagsD(m_dpacked, 1, m_dspare, 1, hs1);
+        vvsqrt(m_dspare2, m_dspare, &hs1);
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        double two = 2.0;
+        vDSP_vsdivD(m_dspare2, 1, &two, magOut, 1, hs1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fspec) initFloat();
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        unpackComplex(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fspec) initFloat();
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        unpackComplex(complexOut);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fspec) initFloat();
+        const int hs1 = m_size/2+1;
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        for (int i = 0; i < hs1; ++i) m_fpacked->realp[i] *= 0.5f;
+        for (int i = 0; i < hs1; ++i) m_fpacked->imagp[i] *= 0.5f;
+        v_cartesian_to_polar(magOut, phaseOut,
+                             m_fpacked->realp, m_fpacked->imagp, hs1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fspec) initFloat();
+        packReal(realIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_FORWARD);
+        fdenyq();
+        const int hs1 = m_size/2 + 1;
+        vDSP_zvmags(m_fpacked, 1, m_fspare, 1, hs1);
+        vvsqrtf(m_fspare2, m_fspare, &hs1);
+        // vDSP forward FFTs are scaled 2x (for some reason)
+        float two = 2.f;
+        vDSP_vsdiv(m_fspare2, 1, &two, magOut, 1, hs1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        packComplex(realIn, imagIn);
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        double *d[2] = { m_dpacked->realp, m_dpacked->imagp };
+        v_deinterleave(d, complexIn, 2, m_size/2 + 1);
+        dnyq();
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2+1;
+        vvsincos(m_dpacked->imagp, m_dpacked->realp, phaseIn, &hs1);
+        double *const rp = m_dpacked->realp;
+        double *const ip = m_dpacked->imagp;
+        for (int i = 0; i < hs1; ++i) rp[i] *= magIn[i];
+        for (int i = 0; i < hs1; ++i) ip[i] *= magIn[i];
+        dnyq();
+        vDSP_fft_zriptD(m_dspec, m_dpacked, 1, m_dbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dspec) initDouble();
+        const int hs1 = m_size/2 + 1;
+        v_copy(m_dspare, magIn, hs1);
+        for (int i = 0; i < hs1; ++i) m_dspare[i] += 0.000001;
+        vvlog(m_dspare2, m_dspare, &hs1);
+        inverse(m_dspare2, 0, cepOut);
+    }
+    
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        packComplex(realIn, imagIn);
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+        float *f[2] = { m_fpacked->realp, m_fpacked->imagp };
+        v_deinterleave(f, complexIn, 2, m_size/2 + 1);
+        fnyq();
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fspec) initFloat();
+
+        const int hs1 = m_size/2+1;
+        vvsincosf(m_fpacked->imagp, m_fpacked->realp, phaseIn, &hs1);
+        float *const rp = m_fpacked->realp;
+        float *const ip = m_fpacked->imagp;
+        for (int i = 0; i < hs1; ++i) rp[i] *= magIn[i];
+        for (int i = 0; i < hs1; ++i) ip[i] *= magIn[i];
+        fnyq();
+        vDSP_fft_zript(m_fspec, m_fpacked, 1, m_fbuf, m_order, FFT_INVERSE);
+        unpackReal(realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fspec) initFloat();
+        const int hs1 = m_size/2 + 1;
+        v_copy(m_fspare, magIn, hs1);
+        for (int i = 0; i < hs1; ++i) m_fspare[i] += 0.000001f;
+        vvlogf(m_fspare2, m_fspare, &hs1);
+        inverse(m_fspare2, 0, cepOut);
+    }
+
+private:
+    const int m_size;
+    int m_order;
+    FFTSetup m_fspec;
+    FFTSetupD m_dspec;
+    DSPSplitComplex *m_fbuf;
+    DSPDoubleSplitComplex *m_dbuf;
+    DSPSplitComplex *m_fpacked;
+    float *m_fspare;
+    float *m_fspare2;
+    DSPDoubleSplitComplex *m_dpacked;
+    double *m_dspare;
+    double *m_dspare2;
+};
+
+#endif /* HAVE_VDSP */
+
+#ifdef HAVE_FFTW3
+
+/*
+ Define FFTW_DOUBLE_ONLY to make all uses of FFTW functions be
+ double-precision (so "float" FFTs are calculated by casting to
+ doubles and using the double-precision FFTW function).
+
+ Define FFTW_SINGLE_ONLY to make all uses of FFTW functions be
+ single-precision (so "double" FFTs are calculated by casting to
+ floats and using the single-precision FFTW function).
+
+ Neither of these flags is desirable for either performance or
+ precision. The main reason to define either flag is to avoid linking
+ against both fftw3 and fftw3f libraries.
+*/
+
+//#define FFTW_DOUBLE_ONLY 1
+//#define FFTW_SINGLE_ONLY 1
+
+#if defined(FFTW_DOUBLE_ONLY) && defined(FFTW_SINGLE_ONLY)
+// Can't meaningfully define both
+#error Can only define one of FFTW_DOUBLE_ONLY and FFTW_SINGLE_ONLY
+#endif
+
+#if defined(FFTW_FLOAT_ONLY)
+#warning FFTW_FLOAT_ONLY is deprecated, use FFTW_SINGLE_ONLY instead
+#define FFTW_SINGLE_ONLY 1
+#endif
+
+#ifdef FFTW_DOUBLE_ONLY
+#define fft_float_type double
+#define fftwf_complex fftw_complex
+#define fftwf_plan fftw_plan
+#define fftwf_plan_dft_r2c_1d fftw_plan_dft_r2c_1d
+#define fftwf_plan_dft_c2r_1d fftw_plan_dft_c2r_1d
+#define fftwf_destroy_plan fftw_destroy_plan
+#define fftwf_malloc fftw_malloc
+#define fftwf_free fftw_free
+#define fftwf_execute fftw_execute
+#define atan2f atan2
+#define sqrtf sqrt
+#define cosf cos
+#define sinf sin
+#else
+#define fft_float_type float
+#endif /* FFTW_DOUBLE_ONLY */
+
+#ifdef FFTW_SINGLE_ONLY
+#define fft_double_type float
+#define fftw_complex fftwf_complex
+#define fftw_plan fftwf_plan
+#define fftw_plan_dft_r2c_1d fftwf_plan_dft_r2c_1d
+#define fftw_plan_dft_c2r_1d fftwf_plan_dft_c2r_1d
+#define fftw_destroy_plan fftwf_destroy_plan
+#define fftw_malloc fftwf_malloc
+#define fftw_free fftwf_free
+#define fftw_execute fftwf_execute
+#define atan2 atan2f
+#define sqrt sqrtf
+#define cos cosf
+#define sin sinf
+#else
+#define fft_double_type double
+#endif /* FFTW_SINGLE_ONLY */
+
+class D_FFTW : public FFTImpl
+{
+public:
+    D_FFTW(int size) :
+        m_fplanf(0), m_dplanf(0), m_size(size)
+    {
+    }
+
+    ~D_FFTW() {
+        if (m_fplanf) {
+            lock();
+            bool save = false;
+            if (m_extantf > 0 && --m_extantf == 0) save = true;
+            (void)save; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifndef FFTW_DOUBLE_ONLY
+            if (save) saveWisdom('f');
+#endif
+#endif
+            fftwf_destroy_plan(m_fplanf);
+            fftwf_destroy_plan(m_fplani);
+            fftwf_free(m_fbuf);
+            fftwf_free(m_fpacked);
+            unlock();
+        }
+        if (m_dplanf) {
+            lock();
+            bool save = false;
+            if (m_extantd > 0 && --m_extantd == 0) save = true;
+            (void)save; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifndef FFTW_SINGLE_ONLY
+            if (save) saveWisdom('d');
+#endif
+#endif
+            fftw_destroy_plan(m_dplanf);
+            fftw_destroy_plan(m_dplani);
+            fftw_free(m_dbuf);
+            fftw_free(m_dpacked);
+            unlock();
+        }
+        lock();
+        if (m_extantf <= 0 && m_extantd <= 0) {
+#ifndef FFTW_DOUBLE_ONLY
+            fftwf_cleanup();
+#endif
+#ifndef FFTW_SINGLE_ONLY
+            fftw_cleanup();
+#endif
+        }
+        unlock();
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+#ifdef FFTW_SINGLE_ONLY
+        return FFT::SinglePrecision;
+#else
+#ifdef FFTW_DOUBLE_ONLY
+        return FFT::DoublePrecision;
+#else
+        return FFT::SinglePrecision | FFT::DoublePrecision;
+#endif
+#endif
+    }
+
+    void initFloat() {
+        if (m_fplanf) return;
+        bool load = false;
+        lock();
+        if (m_extantf++ == 0) load = true;
+        (void)load; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifdef FFTW_DOUBLE_ONLY
+        if (load) loadWisdom('d');
+#else
+        if (load) loadWisdom('f');
+#endif
+#endif
+        m_fbuf = (fft_float_type *)fftw_malloc(m_size * sizeof(fft_float_type));
+        m_fpacked = (fftwf_complex *)fftw_malloc
+            ((m_size/2 + 1) * sizeof(fftwf_complex));
+#ifdef USE_FFTW_WISDOM
+        m_fplanf = fftwf_plan_dft_r2c_1d
+            (m_size, m_fbuf, m_fpacked, FFTW_MEASURE);
+        m_fplani = fftwf_plan_dft_c2r_1d
+            (m_size, m_fpacked, m_fbuf, FFTW_MEASURE);
+#else
+        m_fplanf = fftwf_plan_dft_r2c_1d
+            (m_size, m_fbuf, m_fpacked, FFTW_ESTIMATE);
+        m_fplani = fftwf_plan_dft_c2r_1d
+            (m_size, m_fpacked, m_fbuf, FFTW_ESTIMATE);
+#endif
+        unlock();
+    }
+
+    void initDouble() {
+        if (m_dplanf) return;
+        bool load = false;
+        lock();
+        if (m_extantd++ == 0) load = true;
+        (void)load; // avoid compiler warning
+#ifdef USE_FFTW_WISDOM
+#ifdef FFTW_SINGLE_ONLY
+        if (load) loadWisdom('f');
+#else
+        if (load) loadWisdom('d');
+#endif
+#endif
+        m_dbuf = (fft_double_type *)fftw_malloc(m_size * sizeof(fft_double_type));
+        m_dpacked = (fftw_complex *)fftw_malloc
+            ((m_size/2 + 1) * sizeof(fftw_complex));
+#ifdef USE_FFTW_WISDOM
+        m_dplanf = fftw_plan_dft_r2c_1d
+            (m_size, m_dbuf, m_dpacked, FFTW_MEASURE);
+        m_dplani = fftw_plan_dft_c2r_1d
+            (m_size, m_dpacked, m_dbuf, FFTW_MEASURE);
+#else
+        m_dplanf = fftw_plan_dft_r2c_1d
+            (m_size, m_dbuf, m_dpacked, FFTW_ESTIMATE);
+        m_dplani = fftw_plan_dft_c2r_1d
+            (m_size, m_dpacked, m_dbuf, FFTW_ESTIMATE);
+#endif
+        unlock();
+    }
+
+    void loadWisdom(char type) { wisdom(false, type); }
+    void saveWisdom(char type) { wisdom(true, type); }
+
+    void wisdom(bool save, char type) {
+#ifdef USE_FFTW_WISDOM
+#ifdef FFTW_DOUBLE_ONLY
+        if (type == 'f') return;
+#endif
+#ifdef FFTW_SINGLE_ONLY
+        if (type == 'd') return;
+#endif
+
+        const char *home = getenv("HOME");
+        if (!home) return;
+
+        char fn[256];
+        snprintf(fn, 256, "%s/%s.%c", home, ".bqfft.wisdom", type);
+
+        FILE *f = fopen(fn, save ? "wb" : "rb");
+        if (!f) return;
+
+        if (save) {
+            switch (type) {
+#ifdef FFTW_DOUBLE_ONLY
+            case 'f': break;
+#else
+            case 'f': fftwf_export_wisdom_to_file(f); break;
+#endif
+#ifdef FFTW_SINGLE_ONLY
+            case 'd': break;
+#else
+            case 'd': fftw_export_wisdom_to_file(f); break;
+#endif
+            default: break;
+            }
+        } else {
+            switch (type) {
+#ifdef FFTW_DOUBLE_ONLY
+            case 'f': break;
+#else
+            case 'f': fftwf_import_wisdom_from_file(f); break;
+#endif
+#ifdef FFTW_SINGLE_ONLY
+            case 'd': break;
+#else
+            case 'd': fftw_import_wisdom_from_file(f); break;
+#endif
+            default: break;
+            }
+        }
+
+        fclose(f);
+#else
+        (void)save;
+        (void)type;
+#endif
+    }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        const int hs = m_size/2;
+        fftwf_complex *const BQ_R__ fpacked = m_fpacked; 
+        for (int i = 0; i <= hs; ++i) {
+            fpacked[i][0] = re[i];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                fpacked[i][1] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                fpacked[i][1] = 0.f;
+            }
+        }                
+    }
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        const int hs = m_size/2;
+        fftw_complex *const BQ_R__ dpacked = m_dpacked; 
+        for (int i = 0; i <= hs; ++i) {
+            dpacked[i][0] = re[i];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                dpacked[i][1] = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                dpacked[i][1] = 0.0;
+            }
+        }
+    }
+
+    void unpackFloat(float *BQ_R__ re, float *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_fpacked[i][0];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = m_fpacked[i][1];
+            }
+        }
+    }        
+
+    void unpackDouble(double *BQ_R__ re, double *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_dpacked[i][0];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = m_dpacked[i][1];
+            }
+        }
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        if (!m_dplanf) initDouble();
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        if (!m_dplanf) initDouble();
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        v_convert(complexOut, (const fft_double_type *)m_dpacked, sz + 2);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        if (!m_dplanf) initDouble();
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+        const int sz = m_size;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (const fft_double_type *)m_dpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        if (!m_dplanf) initDouble();
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+        const int sz = m_size;
+#ifndef FFTW_SINGLE_ONLY
+        if (realIn != m_dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                dbuf[i] = realIn[i];
+            }
+        fftw_execute(m_dplanf);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (const fft_double_type *)m_dpacked, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        v_convert(complexOut, (const fft_float_type *)m_fpacked, sz + 2);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (const fft_float_type *)m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        if (!m_fplanf) initFloat();
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+        const int sz = m_size;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realIn != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                fbuf[i] = realIn[i];
+            }
+        fftwf_execute(m_fplanf);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (const fft_float_type *)m_fpacked, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        packDouble(realIn, imagIn);
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realOut != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = dbuf[i];
+            }
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        v_convert((fft_double_type *)m_dpacked, complexIn, m_size + 2);
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realOut != dbuf) 
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = dbuf[i];
+            }
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        if (!m_dplanf) initDouble();
+        v_polar_to_cartesian_interleaved
+            ((fft_double_type *)m_dpacked, magIn, phaseIn, m_size/2+1);
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+#ifndef FFTW_SINGLE_ONLY
+        if (realOut != dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = dbuf[i];
+            }
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        if (!m_dplanf) initDouble();
+        fft_double_type *const BQ_R__ dbuf = m_dbuf;
+        fftw_complex *const BQ_R__ dpacked = m_dpacked;
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            dpacked[i][0] = log(magIn[i] + 0.000001);
+        }
+        for (int i = 0; i <= hs; ++i) {
+            dpacked[i][1] = 0.0;
+        }
+        fftw_execute(m_dplani);
+        const int sz = m_size;
+#ifndef FFTW_SINGLE_ONLY
+        if (cepOut != dbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                cepOut[i] = dbuf[i];
+            }
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        packFloat(realIn, imagIn);
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = fbuf[i];
+            }
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        v_convert((fft_float_type *)m_fpacked, complexIn, m_size + 2);
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = fbuf[i];
+            }
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        if (!m_fplanf) initFloat();
+        v_polar_to_cartesian_interleaved
+            ((fft_float_type *)m_fpacked, magIn, phaseIn, m_size/2+1);
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (realOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                realOut[i] = fbuf[i];
+            }
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        if (!m_fplanf) initFloat();
+        const int hs = m_size/2;
+        fftwf_complex *const BQ_R__ fpacked = m_fpacked;
+        for (int i = 0; i <= hs; ++i) {
+            fpacked[i][0] = logf(magIn[i] + 0.000001f);
+        }
+        for (int i = 0; i <= hs; ++i) {
+            fpacked[i][1] = 0.f;
+        }
+        fftwf_execute(m_fplani);
+        const int sz = m_size;
+        fft_float_type *const BQ_R__ fbuf = m_fbuf;
+#ifndef FFTW_DOUBLE_ONLY
+        if (cepOut != fbuf)
+#endif
+            for (int i = 0; i < sz; ++i) {
+                cepOut[i] = fbuf[i];
+            }
+    }
+
+private:
+    fftwf_plan m_fplanf;
+    fftwf_plan m_fplani;
+#ifdef FFTW_DOUBLE_ONLY
+    double *m_fbuf;
+#else
+    float *m_fbuf;
+#endif
+    fftwf_complex *m_fpacked;
+    fftw_plan m_dplanf;
+    fftw_plan m_dplani;
+#ifdef FFTW_SINGLE_ONLY
+    float *m_dbuf;
+#else
+    double *m_dbuf;
+#endif
+    fftw_complex *m_dpacked;
+    const int m_size;
+    static int m_extantf;
+    static int m_extantd;
+#ifdef NO_THREADING
+    void lock() {}
+    void unlock() {}
+#else
+#ifdef _WIN32
+    static HANDLE m_commonMutex;
+    void lock() { WaitForSingleObject(m_commonMutex, INFINITE); }
+    void unlock() { ReleaseMutex(m_commonMutex); }
+#else
+    static pthread_mutex_t m_commonMutex;
+    static bool m_haveMutex;
+    void lock() { pthread_mutex_lock(&m_commonMutex); }
+    void unlock() { pthread_mutex_unlock(&m_commonMutex); }
+#endif
+#endif
+};
+
+int
+D_FFTW::m_extantf = 0;
+
+int
+D_FFTW::m_extantd = 0;
+
+#ifndef NO_THREADING
+#ifdef _WIN32
+HANDLE D_FFTW::m_commonMutex = CreateMutex(NULL, FALSE, NULL);
+#else
+pthread_mutex_t D_FFTW::m_commonMutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+#endif
+
+#undef fft_float_type
+#undef fft_double_type
+
+#ifdef FFTW_DOUBLE_ONLY
+#undef fftwf_complex
+#undef fftwf_plan 
+#undef fftwf_plan_dft_r2c_1d
+#undef fftwf_plan_dft_c2r_1d
+#undef fftwf_destroy_plan 
+#undef fftwf_malloc 
+#undef fftwf_free 
+#undef fftwf_execute
+#undef atan2f 
+#undef sqrtf 
+#undef cosf 
+#undef sinf
+#endif /* FFTW_DOUBLE_ONLY */
+
+#ifdef FFTW_SINGLE_ONLY
+#undef fftw_complex
+#undef fftw_plan
+#undef fftw_plan_dft_r2c_1d
+#undef fftw_plan_dft_c2r_1d 
+#undef fftw_destroy_plan
+#undef fftw_malloc
+#undef fftw_free
+#undef fftw_execute
+#undef atan2
+#undef sqrt
+#undef cos
+#undef sin
+#endif /* FFTW_SINGLE_ONLY */
+
+#endif /* HAVE_FFTW3 */
+
+#ifdef HAVE_KISSFFT
+
+class D_KISSFFT : public FFTImpl
+{
+public:
+    D_KISSFFT(int size) :
+        m_size(size),
+        m_fplanf(0),  
+        m_fplani(0)
+    {
+#ifdef FIXED_POINT
+#error KISSFFT is not configured for float values
+#endif
+        if (sizeof(kiss_fft_scalar) != sizeof(float)) {
+            std::cerr << "ERROR: KISSFFT is not configured for float values"
+                      << std::endl;
+        }
+
+        m_fbuf = new kiss_fft_scalar[m_size + 2];
+        m_fpacked = new kiss_fft_cpx[m_size + 2];
+        m_fplanf = kiss_fftr_alloc(m_size, 0, NULL, NULL);
+        m_fplani = kiss_fftr_alloc(m_size, 1, NULL, NULL);
+    }
+
+    ~D_KISSFFT() {
+        kiss_fftr_free(m_fplanf);
+        kiss_fftr_free(m_fplani);
+
+        delete[] m_fbuf;
+        delete[] m_fpacked;
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::SinglePrecision;
+    }
+
+    void initFloat() { }
+    void initDouble() { }
+
+    void packFloat(const float *BQ_R__ re, const float *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = re[i];
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = im[i];
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = 0.f;
+            }
+        }
+    }
+
+    void unpackFloat(float *BQ_R__ re, float *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = m_fpacked[i].r;
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = m_fpacked[i].i;
+            }
+        }
+    }        
+
+    void packDouble(const double *BQ_R__ re, const double *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = float(re[i]);
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = float(im[i]);
+            }
+        } else {
+            for (int i = 0; i <= hs; ++i) {
+                m_fpacked[i].i = 0.f;
+            }
+        }
+    }
+
+    void unpackDouble(double *BQ_R__ re, double *BQ_R__ im) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            re[i] = double(m_fpacked[i].r);
+        }
+        if (im) {
+            for (int i = 0; i <= hs; ++i) {
+                im[i] = double(m_fpacked[i].i);
+            }
+        }
+    }        
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        unpackDouble(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        v_convert(complexOut, (float *)m_fpacked, m_size + 2);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        v_convert(m_fbuf, realIn, m_size);
+        kiss_fftr(m_fplanf, m_fbuf, m_fpacked);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        kiss_fftr(m_fplanf, realIn, m_fpacked);
+        unpackFloat(realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        kiss_fftr(m_fplanf, realIn, (kiss_fft_cpx *)complexOut);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        kiss_fftr(m_fplanf, realIn, m_fpacked);
+        v_cartesian_interleaved_to_polar
+            (magOut, phaseOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        kiss_fftr(m_fplanf, realIn, m_fpacked);
+        v_cartesian_interleaved_to_magnitudes
+            (magOut, (float *)m_fpacked, m_size/2+1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        packDouble(realIn, imagIn);
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(realOut, m_fbuf, m_size);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        v_convert((float *)m_fpacked, complexIn, m_size + 2);
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(realOut, m_fbuf, m_size);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        v_polar_to_cartesian_interleaved
+            ((float *)m_fpacked, magIn, phaseIn, m_size/2+1);
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(realOut, m_fbuf, m_size);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = float(log(magIn[i] + 0.000001));
+            m_fpacked[i].i = 0.0f;
+        }
+        kiss_fftri(m_fplani, m_fpacked, m_fbuf);
+        v_convert(cepOut, m_fbuf, m_size);
+    }
+    
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        packFloat(realIn, imagIn);
+        kiss_fftri(m_fplani, m_fpacked, realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        v_copy((float *)m_fpacked, complexIn, m_size + 2);
+        kiss_fftri(m_fplani, m_fpacked, realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        v_polar_to_cartesian_interleaved
+            ((float *)m_fpacked, magIn, phaseIn, m_size/2+1);
+        kiss_fftri(m_fplani, m_fpacked, realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        const int hs = m_size/2;
+        for (int i = 0; i <= hs; ++i) {
+            m_fpacked[i].r = logf(magIn[i] + 0.000001f);
+            m_fpacked[i].i = 0.0f;
+        }
+        kiss_fftri(m_fplani, m_fpacked, cepOut);
+    }
+
+private:
+    const int m_size;
+    kiss_fftr_cfg m_fplanf;
+    kiss_fftr_cfg m_fplani;
+    kiss_fft_scalar *m_fbuf;
+    kiss_fft_cpx *m_fpacked;
+};
+
+#endif /* HAVE_KISSFFT */
+
+#ifdef USE_BUILTIN_FFT
+
+class D_Builtin : public FFTImpl
+{
+public:
+    D_Builtin(int size) :
+        m_size(size),
+        m_half(size/2),
+        m_blockTableSize(16),
+        m_maxTabledBlock(1 << m_blockTableSize)
+    {
+        m_table = allocate_and_zero<int>(m_half);
+        m_sincos = allocate_and_zero<double>(m_blockTableSize * 4);
+        m_sincos_r = allocate_and_zero<double>(m_half);
+        m_vr = allocate_and_zero<double>(m_half);
+        m_vi = allocate_and_zero<double>(m_half);
+        m_a = allocate_and_zero<double>(m_half + 1);
+        m_b = allocate_and_zero<double>(m_half + 1);
+        m_c = allocate_and_zero<double>(m_half + 1);
+        m_d = allocate_and_zero<double>(m_half + 1);
+        m_a_and_b[0] = m_a;
+        m_a_and_b[1] = m_b;
+        m_c_and_d[0] = m_c;
+        m_c_and_d[1] = m_d;
+        makeTables();
+    }
+
+    ~D_Builtin() {
+        deallocate(m_table);
+        deallocate(m_sincos);
+        deallocate(m_sincos_r);
+        deallocate(m_vr);
+        deallocate(m_vi);
+        deallocate(m_a);
+        deallocate(m_b);
+        deallocate(m_c);
+        deallocate(m_d);
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::DoublePrecision;
+    }
+
+    void initFloat() { }
+    void initDouble() { }
+
+    void forward(const double *BQ_R__ realIn,
+                 double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        transformF(realIn, realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn,
+                            double *BQ_R__ complexOut) {
+        transformF(realIn, m_c, m_d);
+        v_interleave(complexOut, m_c_and_d, 2, m_half + 1);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn,
+                      double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_polar(magOut, phaseOut, m_c, m_d, m_half + 1);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn,
+                          double *BQ_R__ magOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_magnitudes(magOut, m_c, m_d, m_half + 1);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut,
+                 float *BQ_R__ imagOut) {
+        transformF(realIn, m_c, m_d);
+        v_convert(realOut, m_c, m_half + 1);
+        v_convert(imagOut, m_d, m_half + 1);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn,
+                            float *BQ_R__ complexOut) {
+        transformF(realIn, m_c, m_d);
+        for (int i = 0; i <= m_half; ++i) complexOut[i*2] = m_c[i];
+        for (int i = 0; i <= m_half; ++i) complexOut[i*2+1] = m_d[i];
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn,
+                      float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_polar(magOut, phaseOut, m_c, m_d, m_half + 1);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn,
+                          float *BQ_R__ magOut) {
+        transformF(realIn, m_c, m_d);
+        v_cartesian_to_magnitudes(magOut, m_c, m_d, m_half + 1);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn,
+                 double *BQ_R__ realOut) {
+        transformI(realIn, imagIn, realOut);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn,
+                            double *BQ_R__ realOut) {
+        v_deinterleave(m_a_and_b, complexIn, 2, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn,
+                      double *BQ_R__ realOut) {
+        v_polar_to_cartesian(m_a, m_b, magIn, phaseIn, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn,
+                         double *BQ_R__ cepOut) {
+        for (int i = 0; i <= m_half; ++i) {
+            double real = log(magIn[i] + 0.000001);
+            m_a[i] = real;
+            m_b[i] = 0.0;
+        }
+        transformI(m_a, m_b, cepOut);
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn,
+                 float *BQ_R__ realOut) {
+        v_convert(m_a, realIn, m_half + 1);
+        v_convert(m_b, imagIn, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn,
+                            float *BQ_R__ realOut) {
+        for (int i = 0; i <= m_half; ++i) m_a[i] = complexIn[i*2];
+        for (int i = 0; i <= m_half; ++i) m_b[i] = complexIn[i*2+1];
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn,
+                      float *BQ_R__ realOut) {
+        v_polar_to_cartesian(m_a, m_b, magIn, phaseIn, m_half + 1);
+        transformI(m_a, m_b, realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn,
+                         float *BQ_R__ cepOut) {
+        for (int i = 0; i <= m_half; ++i) {
+            float real = logf(magIn[i] + 0.000001);
+            m_a[i] = real;
+            m_b[i] = 0.0;
+        }
+        transformI(m_a, m_b, cepOut);
+    }
+
+private:
+    const int m_size;
+    const int m_half;
+    const int m_blockTableSize;
+    const int m_maxTabledBlock;
+    int *m_table;
+    double *m_sincos;
+    double *m_sincos_r;
+    double *m_vr;
+    double *m_vi;
+    double *m_a;
+    double *m_b;
+    double *m_c;
+    double *m_d;
+    double *m_a_and_b[2];
+    double *m_c_and_d[2];
+
+    void makeTables() {
+
+        // main table for complex fft - this is of size m_half,
+        // because we are at heart a real-complex fft only
+        
+        int bits;
+        int i, j, k, m;
+
+        int n = m_half;
+        
+        for (i = 0; ; ++i) {
+            if (n & (1 << i)) {
+                bits = i;
+                break;
+            }
+        }
+        
+        for (i = 0; i < n; ++i) {
+            m = i;
+            for (j = k = 0; j < bits; ++j) {
+                k = (k << 1) | (m & 1);
+                m >>= 1;
+            }
+            m_table[i] = k;
+        }
+
+        // sin and cos tables for complex fft
+        int ix = 0;
+        for (i = 2; i <= m_maxTabledBlock; i <<= 1) {
+            double phase = 2.0 * M_PI / double(i);
+            m_sincos[ix++] = sin(phase);
+            m_sincos[ix++] = sin(2.0 * phase);
+            m_sincos[ix++] = cos(phase);
+            m_sincos[ix++] = cos(2.0 * phase);
+        }
+        
+        // sin and cos tables for real-complex transform
+        ix = 0;
+        for (i = 0; i < n/2; ++i) {
+            double phase = M_PI * (double(i + 1) / double(m_half) + 0.5);
+            m_sincos_r[ix++] = sin(phase);
+            m_sincos_r[ix++] = cos(phase);
+        }
+    }        
+
+    // Uses m_a and m_b internally; does not touch m_c or m_d
+    template <typename T>
+    void transformF(const T *BQ_R__ ri,
+                    double *BQ_R__ ro, double *BQ_R__ io) {
+
+        int halfhalf = m_half / 2;
+        for (int i = 0; i < m_half; ++i) {
+            m_a[i] = ri[i * 2];
+            m_b[i] = ri[i * 2 + 1];
+        }
+        transformComplex(m_a, m_b, m_vr, m_vi, false);
+        ro[0] = m_vr[0] + m_vi[0];
+        ro[m_half] = m_vr[0] - m_vi[0];
+        io[0] = io[m_half] = 0.0;
+        int ix = 0;
+        for (int i = 0; i < halfhalf; ++i) {
+            double s = -m_sincos_r[ix++];
+            double c =  m_sincos_r[ix++];
+            int k = i + 1;
+            double r0 = m_vr[k];
+            double i0 = m_vi[k];
+            double r1 = m_vr[m_half - k];
+            double i1 = -m_vi[m_half - k];
+            double tw_r = (r0 - r1) * c - (i0 - i1) * s;
+            double tw_i = (r0 - r1) * s + (i0 - i1) * c;
+            ro[k] = (r0 + r1 + tw_r) * 0.5;
+            ro[m_half - k] = (r0 + r1 - tw_r) * 0.5;
+            io[k] = (i0 + i1 + tw_i) * 0.5;
+            io[m_half - k] = (tw_i - i0 - i1) * 0.5;
+        }
+    }
+
+    // Uses m_c and m_d internally; does not touch m_a or m_b
+    template <typename T>
+    void transformI(const double *BQ_R__ ri, const double *BQ_R__ ii,
+                    T *BQ_R__ ro) {
+        
+        int halfhalf = m_half / 2;
+        m_vr[0] = ri[0] + ri[m_half];
+        m_vi[0] = ri[0] - ri[m_half];
+        int ix = 0;
+        for (int i = 0; i < halfhalf; ++i) {
+            double s = m_sincos_r[ix++];
+            double c = m_sincos_r[ix++];
+            int k = i + 1;
+            double r0 = ri[k];
+            double r1 = ri[m_half - k];
+            double i0 = ii[k];
+            double i1 = -ii[m_half - k];
+            double tw_r = (r0 - r1) * c - (i0 - i1) * s;
+            double tw_i = (r0 - r1) * s + (i0 - i1) * c;
+            m_vr[k] = (r0 + r1 + tw_r);
+            m_vr[m_half - k] = (r0 + r1 - tw_r);
+            m_vi[k] = (i0 + i1 + tw_i);
+            m_vi[m_half - k] = (tw_i - i0 - i1);
+        }
+        transformComplex(m_vr, m_vi, m_c, m_d, true);
+        for (int i = 0; i < m_half; ++i) {
+            ro[i*2] = m_c[i];
+            ro[i*2+1] = m_d[i];
+        }
+    }
+    
+    void transformComplex(const double *BQ_R__ ri, const double *BQ_R__ ii,
+                          double *BQ_R__ ro, double *BQ_R__ io,
+                          bool inverse) {
+
+        // Following Don Cross's 1998 implementation, described by its
+        // author as public domain.
+        
+        // Because we are at heart a real-complex fft only, and we know that:
+        const int n = m_half;
+
+        for (int i = 0; i < n; ++i) {
+            int j = m_table[i];
+            ro[j] = ri[i];
+            io[j] = ii[i];
+        }
+        
+        int ix = 0;
+        int blockEnd = 1;
+        double ifactor = (inverse ? -1.0 : 1.0);
+        
+        for (int blockSize = 2; blockSize <= n; blockSize <<= 1) {
+
+            double sm1, sm2, cm1, cm2;
+
+            if (blockSize <= m_maxTabledBlock) {
+                sm1 = ifactor * m_sincos[ix++];
+                sm2 = ifactor * m_sincos[ix++];
+                cm1 = m_sincos[ix++];
+                cm2 = m_sincos[ix++];
+            } else {
+                double phase = 2.0 * M_PI / double(blockSize);
+                sm1 = ifactor * sin(phase);
+                sm2 = ifactor * sin(2.0 * phase);
+                cm1 = cos(phase);
+                cm2 = cos(2.0 * phase);
+            }
+            
+            double w = 2 * cm1;
+            double ar[3], ai[3];
+            
+            for (int i = 0; i < n; i += blockSize) {
+                
+                ar[2] = cm2;
+                ar[1] = cm1;
+                
+                ai[2] = sm2;
+                ai[1] = sm1;
+
+                int j = i;
+                
+                for (int m = 0; m < blockEnd; ++m) {
+                    
+                    ar[0] = w * ar[1] - ar[2];
+                    ar[2] = ar[1];
+                    ar[1] = ar[0];
+
+                    ai[0] = w * ai[1] - ai[2];
+                    ai[2] = ai[1];
+                    ai[1] = ai[0];
+
+                    int k = j + blockEnd;
+                    double tr = ar[0] * ro[k] - ai[0] * io[k];
+                    double ti = ar[0] * io[k] + ai[0] * ro[k];
+
+                    ro[k] = ro[j] - tr;
+                    io[k] = io[j] - ti;
+
+                    ro[j] += tr;
+                    io[j] += ti;
+
+                    ++j;
+                }
+            }
+
+            blockEnd = blockSize;
+        }
+    }
+};
+
+#endif /* USE_BUILTIN_FFT */
+
+class D_DFT : public FFTImpl
+{
+private:
+    template <typename T>
+    class DFT
+    {
+    public:
+        DFT(int size) : m_size(size), m_bins(size/2 + 1) {
+            
+            m_sin = allocate_channels<double>(m_size, m_size);
+            m_cos = allocate_channels<double>(m_size, m_size);
+
+            for (int i = 0; i < m_size; ++i) {
+                for (int j = 0; j < m_size; ++j) {
+                    double arg = (double(i) * double(j) * M_PI * 2.0) / m_size;
+                    m_sin[i][j] = sin(arg);
+                    m_cos[i][j] = cos(arg);
+                }
+            }
+
+            m_tmp = allocate_channels<double>(2, m_size);
+        }
+
+        ~DFT() {
+            deallocate_channels(m_tmp, 2);
+            deallocate_channels(m_sin, m_size);
+            deallocate_channels(m_cos, m_size);
+        }
+
+        void forward(const T *BQ_R__ realIn, T *BQ_R__ realOut, T *BQ_R__ imagOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                double re = 0.0, im = 0.0;
+                for (int j = 0; j < m_size; ++j) re += realIn[j] * m_cos[i][j];
+                for (int j = 0; j < m_size; ++j) im -= realIn[j] * m_sin[i][j];
+                realOut[i] = T(re);
+                imagOut[i] = T(im);
+            }
+        }
+
+        void forwardInterleaved(const T *BQ_R__ realIn, T *BQ_R__ complexOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                double re = 0.0, im = 0.0;
+                for (int j = 0; j < m_size; ++j) re += realIn[j] * m_cos[i][j];
+                for (int j = 0; j < m_size; ++j) im -= realIn[j] * m_sin[i][j];
+                complexOut[i*2] = T(re);
+                complexOut[i*2 + 1] = T(im);
+            }
+        }
+
+        void forwardPolar(const T *BQ_R__ realIn, T *BQ_R__ magOut, T *BQ_R__ phaseOut) {
+            forward(realIn, magOut, phaseOut); // temporarily
+            for (int i = 0; i < m_bins; ++i) {
+                T re = magOut[i], im = phaseOut[i];
+                c_magphase(magOut + i, phaseOut + i, re, im);
+            }
+        }
+
+        void forwardMagnitude(const T *BQ_R__ realIn, T *BQ_R__ magOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                double re = 0.0, im = 0.0;
+                for (int j = 0; j < m_size; ++j) re += realIn[j] * m_cos[i][j];
+                for (int j = 0; j < m_size; ++j) im -= realIn[j] * m_sin[i][j];
+                magOut[i] = T(sqrt(re * re + im * im));
+            }
+        }
+
+        void inverse(const T *BQ_R__ realIn, const T *BQ_R__ imagIn, T *BQ_R__ realOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                m_tmp[0][i] = realIn[i];
+                m_tmp[1][i] = imagIn[i];
+            }
+            for (int i = m_bins; i < m_size; ++i) {
+                m_tmp[0][i] = realIn[m_size - i];
+                m_tmp[1][i] = -imagIn[m_size - i];
+            }
+            for (int i = 0; i < m_size; ++i) {
+                double re = 0.0;
+                const double *const cos = m_cos[i];
+                const double *const sin = m_sin[i];
+                for (int j = 0; j < m_size; ++j) re += m_tmp[0][j] * cos[j];
+                for (int j = 0; j < m_size; ++j) re -= m_tmp[1][j] * sin[j];
+                realOut[i] = T(re);
+            }
+        }
+
+        void inverseInterleaved(const T *BQ_R__ complexIn, T *BQ_R__ realOut) {
+            for (int i = 0; i < m_bins; ++i) {
+                m_tmp[0][i] = complexIn[i*2];
+                m_tmp[1][i] = complexIn[i*2+1];
+            }
+            for (int i = m_bins; i < m_size; ++i) {
+                m_tmp[0][i] = complexIn[(m_size - i) * 2];
+                m_tmp[1][i] = -complexIn[(m_size - i) * 2 + 1];
+            }
+            for (int i = 0; i < m_size; ++i) {
+                double re = 0.0;
+                const double *const cos = m_cos[i];
+                const double *const sin = m_sin[i];
+                for (int j = 0; j < m_size; ++j) re += m_tmp[0][j] * cos[j];
+                for (int j = 0; j < m_size; ++j) re -= m_tmp[1][j] * sin[j];
+                realOut[i] = T(re);
+            }
+        }
+
+        void inversePolar(const T *BQ_R__ magIn, const T *BQ_R__ phaseIn, T *BQ_R__ realOut) {
+            T *complexIn = allocate<T>(m_bins * 2);
+            v_polar_to_cartesian_interleaved(complexIn, magIn, phaseIn, m_bins);
+            inverseInterleaved(complexIn, realOut);
+            deallocate(complexIn);
+        }
+
+        void inverseCepstral(const T *BQ_R__ magIn, T *BQ_R__ cepOut) {
+            T *complexIn = allocate_and_zero<T>(m_bins * 2);
+            for (int i = 0; i < m_bins; ++i) {
+                complexIn[i*2] = T(log(magIn[i] + 0.000001));
+            }
+            inverseInterleaved(complexIn, cepOut);
+            deallocate(complexIn);
+        }
+
+    private:
+        const int m_size;
+        const int m_bins;
+        double **m_sin;
+        double **m_cos;
+        double **m_tmp;
+    };
+    
+public:
+    D_DFT(int size) : m_size(size), m_double(0), m_float(0) { }
+
+    ~D_DFT() {
+        delete m_double;
+        delete m_float;
+    }
+
+    int getSize() const {
+        return m_size;
+    }
+
+    FFT::Precisions
+    getSupportedPrecisions() const {
+        return FFT::DoublePrecision;
+    }
+
+    void initFloat() {
+        if (!m_float) {
+            m_float = new DFT<float>(m_size);
+        }
+    }
+        
+    void initDouble() {
+        if (!m_double) {
+            m_double = new DFT<double>(m_size);
+        }
+    }
+
+    void forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut) {
+        initDouble();
+        m_double->forward(realIn, realOut, imagOut);
+    }
+
+    void forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut) {
+        initDouble();
+        m_double->forwardInterleaved(realIn, complexOut);
+    }
+
+    void forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut) {
+        initDouble();
+        m_double->forwardPolar(realIn, magOut, phaseOut);
+    }
+
+    void forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut) {
+        initDouble();
+        m_double->forwardMagnitude(realIn, magOut);
+    }
+
+    void forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut) {
+        initFloat();
+        m_float->forward(realIn, realOut, imagOut);
+    }
+
+    void forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut) {
+        initFloat();
+        m_float->forwardInterleaved(realIn, complexOut);
+    }
+
+    void forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut) {
+        initFloat();
+        m_float->forwardPolar(realIn, magOut, phaseOut);
+    }
+
+    void forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut) {
+        initFloat();
+        m_float->forwardMagnitude(realIn, magOut);
+    }
+
+    void inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut) {
+        initDouble();
+        m_double->inverse(realIn, imagIn, realOut);
+    }
+
+    void inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut) {
+        initDouble();
+        m_double->inverseInterleaved(complexIn, realOut);
+    }
+
+    void inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut) {
+        initDouble();
+        m_double->inversePolar(magIn, phaseIn, realOut);
+    }
+
+    void inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut) {
+        initDouble();
+        m_double->inverseCepstral(magIn, cepOut);
+    }
+
+    void inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut) {
+        initFloat();
+        m_float->inverse(realIn, imagIn, realOut);
+    }
+
+    void inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut) {
+        initFloat();
+        m_float->inverseInterleaved(complexIn, realOut);
+    }
+
+    void inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut) {
+        initFloat();
+        m_float->inversePolar(magIn, phaseIn, realOut);
+    }
+
+    void inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut) {
+        initFloat();
+        m_float->inverseCepstral(magIn, cepOut);
+    }
+
+private:
+    int m_size;
+    DFT<double> *m_double;
+    DFT<float> *m_float;
+};
+
+} /* end namespace FFTs */
+
+enum SizeConstraint {
+    SizeConstraintNone           = 0x0,
+    SizeConstraintEven           = 0x1,
+    SizeConstraintPowerOfTwo     = 0x2,
+    SizeConstraintEvenPowerOfTwo = 0x3 // i.e. 0x1 | 0x2. Excludes size 1 obvs
+};
+
+typedef std::map<std::string, SizeConstraint> ImplMap;
+
+static std::string defaultImplementation;
+
+static ImplMap
+getImplementationDetails()
+{
+    ImplMap impls;
+    
+#ifdef HAVE_IPP
+    impls["ipp"] = SizeConstraintEvenPowerOfTwo;
+#endif
+#ifdef HAVE_FFTW3
+    impls["fftw"] = SizeConstraintNone;
+#endif
+#ifdef HAVE_KISSFFT
+    impls["kissfft"] = SizeConstraintEven;
+#endif
+#ifdef HAVE_VDSP
+    impls["vdsp"] = SizeConstraintEvenPowerOfTwo;
+#endif
+#ifdef USE_BUILTIN_FFT
+    impls["builtin"] = SizeConstraintEvenPowerOfTwo;
+#endif
+
+    impls["dft"] = SizeConstraintNone;
+
+    return impls;
+}
+
+static std::string
+pickImplementation(int size)
+{
+    ImplMap impls = getImplementationDetails();
+
+    bool isPowerOfTwo = !(size & (size-1));
+    bool isEven = !(size & 1);
+
+    if (defaultImplementation != "") {
+        ImplMap::const_iterator itr = impls.find(defaultImplementation);
+        if (itr != impls.end()) {
+            if (((itr->second & SizeConstraintPowerOfTwo) && !isPowerOfTwo) ||
+                ((itr->second & SizeConstraintEven) && !isEven)) {
+//                std::cerr << "NOTE: bqfft: Explicitly-set default "
+//                          << "implementation \"" << defaultImplementation
+//                          << "\" does not support size " << size
+//                          << ", trying other compiled-in implementations"
+//                          << std::endl;
+            } else {
+                return defaultImplementation;
+            }
+        } else {
+            std::cerr << "WARNING: bqfft: Default implementation \""
+                      << defaultImplementation << "\" is not compiled in"
+                      << std::endl;
+        }
+    } 
+    
+    std::string preference[] = {
+        "ipp", "vdsp", "fftw", "builtin", "kissfft"
+    };
+
+    for (int i = 0; i < int(sizeof(preference)/sizeof(preference[0])); ++i) {
+        ImplMap::const_iterator itr = impls.find(preference[i]);
+        if (itr != impls.end()) {
+            if ((itr->second & SizeConstraintPowerOfTwo) &&
+                // out of an abundance of caution we don't attempt to
+                // use power-of-two implementations with size 2
+                // either, as they may involve a half-half
+                // complex-complex underneath (which would end up with
+                // size 0)
+                (!isPowerOfTwo || size < 4)) {
+                continue;
+            }
+            if ((itr->second & SizeConstraintEven) && !isEven) {
+                continue;
+            }
+            return preference[i];
+        }
+    }
+
+    std::cerr << "WARNING: bqfft: No compiled-in implementation supports size "
+              << size << ", falling back to slow DFT" << std::endl;
+    
+    return "dft";
+}
+
+std::set<std::string>
+FFT::getImplementations()
+{
+    ImplMap impls = getImplementationDetails();
+    std::set<std::string> toReturn;
+    for (ImplMap::const_iterator i = impls.begin(); i != impls.end(); ++i) {
+        toReturn.insert(i->first);
+    }
+    return toReturn;
+}
+
+std::string
+FFT::getDefaultImplementation()
+{
+    return defaultImplementation;
+}
+
+void
+FFT::setDefaultImplementation(std::string i)
+{
+    if (i == "") {
+        defaultImplementation = i;
+        return;
+    } 
+    ImplMap impls = getImplementationDetails();
+    ImplMap::const_iterator itr = impls.find(i);
+    if (itr == impls.end()) {
+        std::cerr << "WARNING: bqfft: setDefaultImplementation: "
+                  << "requested implementation \"" << i
+                  << "\" is not compiled in" << std::endl;
+    } else {
+        defaultImplementation = i;
+    }
+}
+
+FFT::FFT(int size, int debugLevel) :
+    d(0)
+{
+    std::string impl = pickImplementation(size);
+
+    if (debugLevel > 0) {
+        std::cerr << "FFT::FFT(" << size << "): using implementation: "
+                  << impl << std::endl;
+    }
+
+    if (impl == "ipp") {
+#ifdef HAVE_IPP
+        d = new FFTs::D_IPP(size);
+#endif
+    } else if (impl == "fftw") {
+#ifdef HAVE_FFTW3
+        d = new FFTs::D_FFTW(size);
+#endif
+    } else if (impl == "kissfft") {        
+#ifdef HAVE_KISSFFT
+        d = new FFTs::D_KISSFFT(size);
+#endif
+    } else if (impl == "vdsp") {
+#ifdef HAVE_VDSP
+        d = new FFTs::D_VDSP(size);
+#endif
+    } else if (impl == "builtin") {
+#ifdef USE_BUILTIN_FFT
+        d = new FFTs::D_Builtin(size);
+#endif
+    } else if (impl == "dft") {
+        d = new FFTs::D_DFT(size);
+    }
+
+    if (!d) {
+        std::cerr << "FFT::FFT(" << size << "): ERROR: implementation "
+                  << impl << " is not compiled in" << std::endl;
+#ifndef NO_EXCEPTIONS
+        throw InvalidImplementation;
+#else
+        abort();
+#endif
+    }
+}
+
+FFT::~FFT()
+{
+    delete d;
+}
+
+#ifndef NO_EXCEPTIONS
+#define CHECK_NOT_NULL(x) \
+    if (!(x)) { \
+        std::cerr << "FFT: ERROR: Null argument " #x << std::endl;  \
+        throw NullArgument; \
+    }
+#else
+#define CHECK_NOT_NULL(x) \
+    if (!(x)) { \
+        std::cerr << "FFT: ERROR: Null argument " #x << std::endl;  \
+        std::cerr << "FFT: Would be throwing NullArgument here, if exceptions were not disabled" << std::endl;  \
+        return; \
+    }
+#endif
+
+void
+FFT::forward(const double *BQ_R__ realIn, double *BQ_R__ realOut, double *BQ_R__ imagOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(realOut);
+    CHECK_NOT_NULL(imagOut);
+    d->forward(realIn, realOut, imagOut);
+}
+
+void
+FFT::forwardInterleaved(const double *BQ_R__ realIn, double *BQ_R__ complexOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(complexOut);
+    d->forwardInterleaved(realIn, complexOut);
+}
+
+void
+FFT::forwardPolar(const double *BQ_R__ realIn, double *BQ_R__ magOut, double *BQ_R__ phaseOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    CHECK_NOT_NULL(phaseOut);
+    d->forwardPolar(realIn, magOut, phaseOut);
+}
+
+void
+FFT::forwardMagnitude(const double *BQ_R__ realIn, double *BQ_R__ magOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    d->forwardMagnitude(realIn, magOut);
+}
+
+void
+FFT::forward(const float *BQ_R__ realIn, float *BQ_R__ realOut, float *BQ_R__ imagOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(realOut);
+    CHECK_NOT_NULL(imagOut);
+    d->forward(realIn, realOut, imagOut);
+}
+
+void
+FFT::forwardInterleaved(const float *BQ_R__ realIn, float *BQ_R__ complexOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(complexOut);
+    d->forwardInterleaved(realIn, complexOut);
+}
+
+void
+FFT::forwardPolar(const float *BQ_R__ realIn, float *BQ_R__ magOut, float *BQ_R__ phaseOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    CHECK_NOT_NULL(phaseOut);
+    d->forwardPolar(realIn, magOut, phaseOut);
+}
+
+void
+FFT::forwardMagnitude(const float *BQ_R__ realIn, float *BQ_R__ magOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(magOut);
+    d->forwardMagnitude(realIn, magOut);
+}
+
+void
+FFT::inverse(const double *BQ_R__ realIn, const double *BQ_R__ imagIn, double *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(imagIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverse(realIn, imagIn, realOut);
+}
+
+void
+FFT::inverseInterleaved(const double *BQ_R__ complexIn, double *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(complexIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverseInterleaved(complexIn, realOut);
+}
+
+void
+FFT::inversePolar(const double *BQ_R__ magIn, const double *BQ_R__ phaseIn, double *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(phaseIn);
+    CHECK_NOT_NULL(realOut);
+    d->inversePolar(magIn, phaseIn, realOut);
+}
+
+void
+FFT::inverseCepstral(const double *BQ_R__ magIn, double *BQ_R__ cepOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(cepOut);
+    d->inverseCepstral(magIn, cepOut);
+}
+
+void
+FFT::inverse(const float *BQ_R__ realIn, const float *BQ_R__ imagIn, float *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(realIn);
+    CHECK_NOT_NULL(imagIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverse(realIn, imagIn, realOut);
+}
+
+void
+FFT::inverseInterleaved(const float *BQ_R__ complexIn, float *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(complexIn);
+    CHECK_NOT_NULL(realOut);
+    d->inverseInterleaved(complexIn, realOut);
+}
+
+void
+FFT::inversePolar(const float *BQ_R__ magIn, const float *BQ_R__ phaseIn, float *BQ_R__ realOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(phaseIn);
+    CHECK_NOT_NULL(realOut);
+    d->inversePolar(magIn, phaseIn, realOut);
+}
+
+void
+FFT::inverseCepstral(const float *BQ_R__ magIn, float *BQ_R__ cepOut)
+{
+    CHECK_NOT_NULL(magIn);
+    CHECK_NOT_NULL(cepOut);
+    d->inverseCepstral(magIn, cepOut);
+}
+
+void
+FFT::initFloat() 
+{
+    d->initFloat();
+}
+
+void
+FFT::initDouble() 
+{
+    d->initDouble();
+}
+
+int
+FFT::getSize() const
+{
+    return d->getSize();
+}
+
+FFT::Precisions
+FFT::getSupportedPrecisions() const
+{
+    return d->getSupportedPrecisions();
+}
+
+#ifdef FFT_MEASUREMENT
+
+#ifdef FFT_MEASUREMENT_RETURN_RESULT_TEXT
+std::string
+#else
+void
+#endif
+FFT::tune()
+{
+#ifdef FFT_MEASUREMENT_RETURN_RESULT_TEXT
+    std::ostringstream os;
+#else
+#define os std::cerr
+#endif
+    os << "FFT::tune()..." << std::endl;
+
+    std::vector<int> sizes;
+    std::map<std::string, FFTImpl *> candidates;
+    std::map<std::string, int> wins;
+
+    sizes.push_back(512);
+    sizes.push_back(1024);
+    sizes.push_back(2048);
+    sizes.push_back(4096);
+    
+    for (unsigned int si = 0; si < sizes.size(); ++si) {
+
+        int size = sizes[si];
+
+        while (!candidates.empty()) {
+            delete candidates.begin()->second;
+            candidates.erase(candidates.begin());
+        }
+
+        FFTImpl *d;
+        
+#ifdef HAVE_IPP
+        os << "Constructing new IPP FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_IPP(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["ipp"] = d;
+#endif
+        
+#ifdef HAVE_FFTW3
+        os << "Constructing new FFTW3 FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_FFTW(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["fftw"] = d;
+#endif
+
+#ifdef HAVE_KISSFFT
+        os << "Constructing new KISSFFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_KISSFFT(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["kissfft"] = d;
+#endif        
+
+#ifdef USE_BUILTIN_FFT
+        os << "Constructing new Builtin FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_Builtin(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["builtin"] = d;
+#endif
+        
+#ifdef HAVE_VDSP
+        os << "Constructing new vDSP FFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_VDSP(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["vdsp"] = d;
+#endif
+
+        os << "Constructing new DFT object for size " << size << "..." << std::endl;
+        d = new FFTs::D_DFT(size);
+        d->initFloat();
+        d->initDouble();
+        candidates["dft"] = d;
+
+        os << "CLOCKS_PER_SEC = " << CLOCKS_PER_SEC << std::endl;
+        float divisor = float(CLOCKS_PER_SEC) / 1000.f;
+        
+        os << "Timing order is: ";
+        for (std::map<std::string, FFTImpl *>::iterator ci = candidates.begin();
+             ci != candidates.end(); ++ci) {
+            os << ci->first << " ";
+        }
+        os << std::endl;
+
+        int iterations = 500;
+        os << "Iterations: " << iterations << std::endl;
+
+        double *da = new double[size];
+        double *db = new double[size];
+        double *dc = new double[size];
+        double *dd = new double[size];
+        double *di = new double[size + 2];
+        double *dj = new double[size + 2];
+
+        float *fa = new float[size];
+        float *fb = new float[size];
+        float *fc = new float[size];
+        float *fd = new float[size];
+        float *fi = new float[size + 2];
+        float *fj = new float[size + 2];
+
+        for (int type = 0; type < 16; ++type) {
+    
+            //!!!
+            if ((type > 3 && type < 8) ||
+                (type > 11)) {
+                continue;
+            }
+
+            if (type > 7) {
+                // inverse transform: bigger inputs, to simulate the
+                // fact that the forward transform is unscaled
+                for (int i = 0; i < size; ++i) {
+                    da[i] = drand48() * size;
+                    fa[i] = da[i];
+                    db[i] = drand48() * size;
+                    fb[i] = db[i];
+                }
+            } else {    
+                for (int i = 0; i < size; ++i) {
+                    da[i] = drand48();
+                    fa[i] = da[i];
+                    db[i] = drand48();
+                    fb[i] = db[i];
+                }
+            }
+                
+            for (int i = 0; i < size + 2; ++i) {
+                di[i] = drand48();
+                fi[i] = di[i];
+            }
+
+            std::string low;
+            clock_t lowscore = 0;
+
+            const char *names[] = {
+
+                "Forward Cartesian Double",
+                "Forward Interleaved Double",
+                "Forward Polar Double",
+                "Forward Magnitude Double",
+                "Forward Cartesian Float",
+                "Forward Interleaved Float",
+                "Forward Polar Float",
+                "Forward Magnitude Float",
+
+                "Inverse Cartesian Double",
+                "Inverse Interleaved Double",
+                "Inverse Polar Double",
+                "Inverse Cepstral Double",
+                "Inverse Cartesian Float",
+                "Inverse Interleaved Float",
+                "Inverse Polar Float",
+                "Inverse Cepstral Float"
+            };
+            os << names[type] << " :: ";
+
+            for (std::map<std::string, FFTImpl *>::iterator ci = candidates.begin();
+                 ci != candidates.end(); ++ci) {
+
+                FFTImpl *d = ci->second;
+
+                double mean = 0;
+
+                clock_t start = clock();
+                
+                for (int i = 0; i < iterations; ++i) {
+
+                    if (i == 0) {
+                        for (int j = 0; j < size; ++j) {
+                            dc[j] = 0;
+                            dd[j] = 0;
+                            fc[j] = 0;
+                            fd[j] = 0;
+                            fj[j] = 0;
+                            dj[j] = 0;
+                        }
+                    }
+
+                    switch (type) {
+                    case 0: d->forward(da, dc, dd); break;
+                    case 1: d->forwardInterleaved(da, dj); break;
+                    case 2: d->forwardPolar(da, dc, dd); break;
+                    case 3: d->forwardMagnitude(da, dc); break;
+                    case 4: d->forward(fa, fc, fd); break;
+                    case 5: d->forwardInterleaved(fa, fj); break;
+                    case 6: d->forwardPolar(fa, fc, fd); break;
+                    case 7: d->forwardMagnitude(fa, fc); break;
+                    case 8: d->inverse(da, db, dc); break;
+                    case 9: d->inverseInterleaved(di, dc); break;
+                    case 10: d->inversePolar(da, db, dc); break;
+                    case 11: d->inverseCepstral(da, dc); break;
+                    case 12: d->inverse(fa, fb, fc); break;
+                    case 13: d->inverseInterleaved(fi, fc); break;
+                    case 14: d->inversePolar(fa, fb, fc); break;
+                    case 15: d->inverseCepstral(fa, fc); break;
+                    }
+
+                    if (i == 0) {
+                        mean = 0;
+                        for (int j = 0; j < size; ++j) {
+                            mean += dc[j];
+                            mean += dd[j];
+                            mean += fc[j];
+                            mean += fd[j];
+                            mean += fj[j];
+                            mean += dj[j];
+                        }
+                        mean /= size * 6;
+                    }
+                }
+
+                clock_t end = clock();
+
+                os << float(end - start)/divisor << " (" << mean << ") ";
+
+                if (low == "" || (end - start) < lowscore) {
+                    low = ci->first;
+                    lowscore = end - start;
+                }
+            }
+
+            os << std::endl;
+
+            os << "  size " << size << ", type " << type << ": fastest is " << low << " (time " << float(lowscore)/divisor << ")" << std::endl;
+
+            wins[low]++;
+        }
+        
+        delete[] fa;
+        delete[] fb;
+        delete[] fc;
+        delete[] fd;
+        delete[] da;
+        delete[] db;
+        delete[] dc;
+        delete[] dd;
+    }
+
+    while (!candidates.empty()) {
+        delete candidates.begin()->second;
+        candidates.erase(candidates.begin());
+    }
+
+    int bestscore = 0;
+    std::string best;
+
+    for (std::map<std::string, int>::iterator wi = wins.begin(); wi != wins.end(); ++wi) {
+        if (best == "" || wi->second > bestscore) {
+            best = wi->first;
+            bestscore = wi->second;
+        }
+    }
+
+    os << "overall winner is " << best << " with " << bestscore << " wins" << std::endl;
+
+#ifdef FFT_MEASUREMENT_RETURN_RESULT_TEXT
+    return os.str();
+#endif
+}
+
+#endif
+
+}

--- a/pedalboard/vendors/rubberband/src/dsp/FFT.h
+++ b/pedalboard/vendors/rubberband/src/dsp/FFT.h
@@ -1,0 +1,135 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_FFT_H
+#define RUBBERBAND_FFT_H
+
+#include "../system/sysutils.h"
+
+#include <string>
+#include <set>
+
+namespace RubberBand {
+
+class FFTImpl;
+
+/**
+ * Provide the basic FFT computations we need, using one of a set of
+ * candidate FFT implementations (depending on compile flags).
+ *
+ * Implements real->complex FFTs of power-of-two sizes only.  Note
+ * that only the first half of the output signal is returned (the
+ * complex conjugates half is omitted), so the "complex" arrays need
+ * room for size/2+1 elements.
+ *
+ * The "interleaved" functions use the format sometimes called CCS --
+ * size/2+1 real+imaginary pairs.  So, the array elements at indices 1
+ * and size+1 will always be zero (since the signal is real).
+ * 
+ * All pointer arguments must point to valid data. A NullArgument
+ * exception is thrown if any argument is NULL.
+ *
+ * Neither forward nor inverse transform is scaled.
+ *
+ * This class is reentrant but not thread safe: use a separate
+ * instance per thread, or use a mutex.
+ */
+class FFT
+{
+public:
+    enum Exception {
+        NullArgument, InvalidSize, InvalidImplementation, InternalError
+    };
+
+    FFT(int size, int debugLevel = 0); // may throw InvalidSize
+    ~FFT();
+
+    int getSize() const;
+    
+    void forward(const double *R__ realIn, double *R__ realOut, double *R__ imagOut);
+    void forwardInterleaved(const double *R__ realIn, double *R__ complexOut);
+    void forwardPolar(const double *R__ realIn, double *R__ magOut, double *R__ phaseOut);
+    void forwardMagnitude(const double *R__ realIn, double *R__ magOut);
+
+    void forward(const float *R__ realIn, float *R__ realOut, float *R__ imagOut);
+    void forwardInterleaved(const float *R__ realIn, float *R__ complexOut);
+    void forwardPolar(const float *R__ realIn, float *R__ magOut, float *R__ phaseOut);
+    void forwardMagnitude(const float *R__ realIn, float *R__ magOut);
+
+    void inverse(const double *R__ realIn, const double *R__ imagIn, double *R__ realOut);
+    void inverseInterleaved(const double *R__ complexIn, double *R__ realOut);
+    void inversePolar(const double *R__ magIn, const double *R__ phaseIn, double *R__ realOut);
+    void inverseCepstral(const double *R__ magIn, double *R__ cepOut);
+
+    void inverse(const float *R__ realIn, const float *R__ imagIn, float *R__ realOut);
+    void inverseInterleaved(const float *R__ complexIn, float *R__ realOut);
+    void inversePolar(const float *R__ magIn, const float *R__ phaseIn, float *R__ realOut);
+    void inverseCepstral(const float *R__ magIn, float *R__ cepOut);
+
+    // Calling one or both of these is optional -- if neither is
+    // called, the first call to a forward or inverse method will call
+    // init().  You only need call these if you don't want to risk
+    // expensive allocations etc happening in forward or inverse.
+    void initFloat();
+    void initDouble();
+
+    enum Precision {
+        SinglePrecision = 0x1,
+        DoublePrecision = 0x2
+    };
+    typedef int Precisions;
+
+    /**
+     * Return the OR of all precisions supported by this
+     * implementation. All of the functions (float and double) are
+     * available regardless of the supported implementations, but they
+     * will be calculated at the proper precision only if it is
+     * available. (So float functions will be calculated using doubles
+     * and then truncated if single-precision is unavailable, and
+     * double functions will use single-precision arithmetic if double
+     * is unavailable.)
+     */
+    Precisions getSupportedPrecisions() const;
+
+    static std::set<std::string> getImplementations();
+    static std::string getDefaultImplementation();
+    static void setDefaultImplementation(std::string);
+
+#ifdef FFT_MEASUREMENT
+    static std::string tune();
+#endif
+
+protected:
+    FFTImpl *d;
+    static std::string m_implementation;
+    static void pickDefaultImplementation();
+    
+private:
+    FFT(const FFT &); // not provided
+    FFT &operator=(const FFT &); // not provided
+};
+
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/dsp/MovingMedian.h
+++ b/pedalboard/vendors/rubberband/src/dsp/MovingMedian.h
@@ -1,0 +1,110 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_MOVING_MEDIAN_H
+#define RUBBERBAND_MOVING_MEDIAN_H
+
+#include "SampleFilter.h"
+
+#include "../system/Allocators.h"
+
+#include <algorithm>
+
+#include <iostream>
+
+namespace RubberBand
+{
+
+template <typename T>
+class MovingMedian : public SampleFilter<T>
+{
+    typedef SampleFilter<T> P;
+
+public:
+    MovingMedian(int size, float percentile = 50.f) :
+        SampleFilter<T>(size),
+	m_frame(allocate_and_zero<T>(size)),
+	m_sorted(allocate_and_zero<T>(size)),
+	m_sortend(m_sorted + P::m_size - 1) {
+        setPercentile(percentile);
+    }
+
+    ~MovingMedian() { 
+	deallocate(m_frame);
+	deallocate(m_sorted);
+    }
+
+    void setPercentile(float p) {
+        m_index = int((P::m_size * p) / 100.f);
+        if (m_index >= P::m_size) m_index = P::m_size-1;
+        if (m_index < 0) m_index = 0;
+    }
+
+    void push(T value) {
+        if (value != value) {
+            std::cerr << "WARNING: MovingMedian: NaN encountered" << std::endl;
+            value = T();
+        }
+	drop(m_frame[0]);
+	v_move(m_frame, m_frame+1, P::m_size-1);
+	m_frame[P::m_size-1] = value;
+	put(value);
+    }
+
+    T get() const {
+	return m_sorted[m_index];
+    }
+
+    void reset() {
+	v_zero(m_frame, P::m_size);
+	v_zero(m_sorted, P::m_size);
+    }
+
+private:
+    T *const m_frame;
+    T *const m_sorted;
+    T *const m_sortend;
+    int m_index;
+
+    void put(T value) {
+	// precondition: m_sorted contains m_size-1 values, packed at start
+	// postcondition: m_sorted contains m_size values, one of which is value
+	T *index = std::lower_bound(m_sorted, m_sortend, value);
+	v_move(index + 1, index, m_sortend - index);
+	*index = value;
+    }
+
+    void drop(T value) {
+	// precondition: m_sorted contains m_size values, one of which is value
+	// postcondition: m_sorted contains m_size-1 values, packed at start
+	T *index = std::lower_bound(m_sorted, m_sortend + 1, value);
+	assert(*index == value);
+	v_move(index, index + 1, m_sortend - index);
+	*m_sortend = T(0);
+    }
+};
+
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/dsp/Resampler.cpp
+++ b/pedalboard/vendors/rubberband/src/dsp/Resampler.cpp
@@ -1,0 +1,1571 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Resampler.h"
+
+#include "../system/Allocators.h"
+#include "../system/VectorOps.h"
+
+#include <cstdlib>
+#include <cmath>
+
+#include <iostream>
+#include <algorithm>
+
+#ifdef HAVE_IPP
+#include <ippversion.h>
+#if (IPP_VERSION_MAJOR < 7)
+#error Unsupported IPP version, must be >= 7
+#else
+#include <ipps.h>
+#endif
+#endif
+
+#ifdef HAVE_SAMPLERATE
+#define HAVE_LIBSAMPLERATE 1
+#endif
+
+#ifdef HAVE_LIBSAMPLERATE
+#include <samplerate.h>
+#endif
+
+#ifdef HAVE_LIBRESAMPLE
+#include <libresample.h>
+#endif
+
+#ifdef USE_SPEEX
+#include "../speex/speex_resampler.h"
+#endif
+
+#ifdef USE_BQRESAMPLER
+#include "BQResampler.h"
+#endif
+
+#ifndef HAVE_IPP
+#ifndef HAVE_LIBSAMPLERATE
+#ifndef HAVE_LIBRESAMPLE
+#ifndef USE_SPEEX
+#ifndef USE_BQRESAMPLER
+#error No resampler implementation selected!
+#endif
+#endif
+#endif
+#endif
+#endif
+
+#define BQ_R__ R__
+
+using namespace std;
+
+namespace RubberBand {
+
+class Resampler::Impl
+{
+public:
+    virtual ~Impl() { }
+    
+    virtual int resample(float *const BQ_R__ *const BQ_R__ out,
+                         int outcount,
+                         const float *const BQ_R__ *const BQ_R__ in, 
+                         int incount,
+                         double ratio,
+                         bool final) = 0;
+    
+    virtual int resampleInterleaved(float *const BQ_R__ out,
+                                    int outcount,
+                                    const float *const BQ_R__ in, 
+                                    int incount,
+                                    double ratio,
+                                    bool final) = 0;
+
+    virtual int getChannelCount() const = 0;
+    virtual double getEffectiveRatio(double ratio) const = 0;
+
+    virtual void reset() = 0;
+};
+
+namespace Resamplers {
+
+#ifdef HAVE_IPP
+
+class D_IPP : public Resampler::Impl
+{
+public:
+    D_IPP(Resampler::Quality quality, Resampler::RatioChange,
+          int channels, double initialSampleRate,
+          int maxBufferSize, int debugLevel);
+    ~D_IPP();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    // to m_outbuf
+    int doResample(int outcount, double ratio, bool final);
+    
+    IppsResamplingPolyphase_32f **m_state;
+    double m_initialSampleRate;
+    float **m_inbuf;
+    size_t m_inbufsz;
+    float **m_outbuf;
+    size_t m_outbufsz;
+    int m_bufsize;
+    int m_channels;
+    int m_window;
+    float m_factor;
+    int m_history;
+    int *m_lastread;
+    double *m_time;
+    int m_debugLevel;
+    
+    void setBufSize(int);
+};
+
+D_IPP::D_IPP(Resampler::Quality /* quality */,
+             Resampler::RatioChange /* ratioChange */,
+             int channels, double initialSampleRate,
+             int maxBufferSize, int debugLevel) :
+    m_state(0),
+    m_initialSampleRate(initialSampleRate),
+    m_channels(channels),
+    m_debugLevel(debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: IPP" << endl;
+    }
+
+    m_window = 32;
+    int nStep = 64;
+    IppHintAlgorithm hint = ippAlgHintFast;
+    m_factor = 8; // initial upper bound on m_ratio, may be amended later
+
+    // This is largely based on the IPP docs and examples. Adapted
+    // from the docs:
+    //
+    //    m_time defines the time value for which the first output
+    //    sample is calculated. The input vector with indices less
+    //    than m_time [whose initial value is m_history below]
+    //    contains the history data of filters.
+    //
+    //    The history length is [(1/2) window * max(1, 1/factor) ]+1
+    //    where window is the size of the ideal lowpass filter
+    //    window. The input vector must contain the same number of
+    //    elements with indices greater than m_time + length for the
+    //    right filter wing for the last element.
+    
+    m_history = int(m_window * 0.5 * max(1.0, 1.0 / m_factor)) + 1;
+
+    m_state = new IppsResamplingPolyphase_32f *[m_channels];
+
+    m_lastread = new int[m_channels];
+    m_time = new double[m_channels];
+
+    m_inbufsz = 0;
+    m_outbufsz = 0;
+    m_inbuf = 0;
+    m_outbuf = 0;
+    m_bufsize = 0;
+    
+    setBufSize(maxBufferSize + m_history);
+
+    if (m_debugLevel > 1) {
+        cerr << "bufsize = " << m_bufsize << ", window = " << m_window << ", nStep = " << nStep << ", history = " << m_history << endl;
+    }
+
+    int specSize = 0;
+    ippsResamplePolyphaseGetSize_32f(float(m_window),
+                                     nStep,
+                                     &specSize,
+                                     hint);
+    if (specSize == 0) {
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#else        
+        abort();
+#endif
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        m_state[c] = (IppsResamplingPolyphase_32f *)ippsMalloc_8u(specSize);
+        ippsResamplePolyphaseInit_32f(float(m_window),
+                                      nStep,
+                                      0.95f,
+                                      9.0f,
+                                      m_state[c],
+                                      hint);
+        
+        m_lastread[c] = m_history;
+        m_time[c] = m_history;
+    }
+
+    if (m_debugLevel > 1) {
+        cerr << "Resampler init done" << endl;
+    }
+}
+
+D_IPP::~D_IPP()
+{
+    for (int c = 0; c < m_channels; ++c) {
+        ippsFree(m_state[c]);
+    }
+
+    deallocate_channels(m_inbuf, m_channels);
+    deallocate_channels(m_outbuf, m_channels);
+
+    delete[] m_lastread;
+    delete[] m_time;
+    delete[] m_state;
+}
+
+void
+D_IPP::setBufSize(int sz)
+{
+    if (m_debugLevel > 1) {
+        if (m_bufsize > 0) {
+            cerr << "resize bufsize " << m_bufsize << " -> ";
+        } else {
+            cerr << "initialise bufsize to ";
+        }
+    }
+
+    m_bufsize = sz;
+
+    if (m_debugLevel > 1) {
+        cerr << m_bufsize << endl;
+    }
+
+    int n1 = m_bufsize + m_history + 2;
+
+    if (m_debugLevel > 1) {
+        cerr << "inbuf allocating " << m_bufsize << " + " << m_history << " + 2 = " << n1 << endl;
+    }
+
+    int n2 = (int)lrintf(ceil((m_bufsize - m_history) * m_factor + 2));
+
+    if (m_debugLevel > 1) {
+        cerr << "outbuf allocating (" << m_bufsize << " - " << m_history << ") * " << m_factor << " + 2 = " << n2 << endl;
+    }
+
+    m_inbuf = reallocate_and_zero_extend_channels
+        (m_inbuf, m_channels, m_inbufsz, m_channels, n1);
+
+    m_outbuf = reallocate_and_zero_extend_channels
+        (m_outbuf, m_channels, m_outbufsz, m_channels, n2);
+            
+    m_inbufsz = n1;
+    m_outbufsz = n2;
+}
+
+int
+D_IPP::resample(float *const BQ_R__ *const BQ_R__ out,
+                int outspace,
+                const float *const BQ_R__ *const BQ_R__ in,
+                int incount,
+                double ratio,
+                bool final)
+{
+    if (ratio > m_factor) {
+        m_factor = ratio;
+        m_history = int(m_window * 0.5 * max(1.0, 1.0 / m_factor)) + 1;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "incount = " << incount << ", ratio = " << ratio << ", est space = " << lrintf(ceil(incount * ratio)) << ", outspace = " << outspace << ", final = " << final << endl;
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        if (m_lastread[c] + incount + m_history > m_bufsize) {
+            setBufSize(m_lastread[c] + incount + m_history);
+        }
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        for (int i = 0; i < incount; ++i) {
+            m_inbuf[c][m_lastread[c] + i] = in[c][i];
+        }
+        m_lastread[c] += incount;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "lastread advanced to " << m_lastread[0] << endl;
+    }
+
+    int got = doResample(outspace, ratio, final);
+
+    for (int c = 0; c < m_channels; ++c) {
+        v_copy(out[c], m_outbuf[c], got);
+    }
+
+    return got;
+}
+
+int
+D_IPP::resampleInterleaved(float *const BQ_R__ out,
+                           int outspace,
+                           const float *const BQ_R__ in,
+                           int incount,
+                           double ratio,
+                           bool final)
+{
+    if (ratio > m_factor) {
+        m_factor = ratio;
+        m_history = int(m_window * 0.5 * max(1.0, 1.0 / m_factor)) + 1;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "incount = " << incount << ", ratio = " << ratio << ", est space = " << lrintf(ceil(incount * ratio)) << ", outspace = " << outspace << ", final = " << final << endl;
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        if (m_lastread[c] + incount + m_history > m_bufsize) {
+            setBufSize(m_lastread[c] + incount + m_history);
+        }
+    }
+
+    for (int c = 0; c < m_channels; ++c) {
+        for (int i = 0; i < incount; ++i) {
+            m_inbuf[c][m_lastread[c] + i] = in[i * m_channels + c];
+        }
+        m_lastread[c] += incount;
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "lastread advanced to " << m_lastread[0] << " after injection of "
+             << incount << " samples" << endl;
+    }
+
+    int got = doResample(outspace, ratio, final);
+
+    v_interleave(out, m_outbuf, m_channels, got);
+
+    return got;
+}
+
+int
+D_IPP::doResample(int outspace, double ratio, bool final)
+{
+    int outcount = 0;
+    
+    for (int c = 0; c < m_channels; ++c) {
+
+        int n = m_lastread[c] - m_history - int(m_time[c]);
+
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "at start, lastread = " << m_lastread[c] << ", history = "
+                 << m_history << ", time = " << m_time[c] << ", therefore n = "
+                 << n << endl;
+        }
+
+        if (n <= 0) {
+            if (c == 0 && m_debugLevel > 1) {
+                cerr << "not enough input samples to do anything" << endl;
+            }
+            continue;
+        }
+        
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "before resample call, time = " << m_time[c] << endl;
+        }
+
+        // We're committed to not overrunning outspace, so we need to
+        // offer the resampler only enough samples to ensure it won't
+
+        int limit = int(floor(outspace / ratio));
+        if (n > limit) {
+            if (c == 0 && m_debugLevel > 1) {
+                cerr << "trimming input samples from " << n << " to " << limit
+                     << " to avoid overrunning " << outspace << " at output"
+                     << endl;
+            }
+            n = limit;
+        }
+        
+        ippsResamplePolyphase_32f(m_inbuf[c],
+                                  n,
+                                  m_outbuf[c],
+                                  ratio,
+                                  1.0f,
+                                  &m_time[c],
+                                  &outcount,
+                                  m_state[c]);
+
+        int t = int(floor(m_time[c]));
+        
+        int moveFrom = t - m_history;
+        
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "converted " << n << " samples to " << outcount
+                 << " (nb outbufsz = " << m_outbufsz
+                 << "), time advanced to " << m_time[c] << endl;
+            cerr << "rounding time to " << t << ", lastread = "
+                 << m_lastread[c] << ", history = " << m_history << endl;
+            cerr << "will move " << m_lastread[c] - moveFrom
+                 << " unconverted samples back from index " << moveFrom
+                 << " to 0" << endl;
+        }
+
+        if (moveFrom >= m_lastread[c]) {
+
+            moveFrom = m_lastread[c];
+
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "number of samples to move is <= 0, "
+                     << "not actually moving any" << endl;
+            }
+        } else {
+        
+            v_move(m_inbuf[c],
+                   m_inbuf[c] + moveFrom,
+                   m_lastread[c] - moveFrom);
+        }
+
+        m_lastread[c] -= moveFrom;
+        m_time[c] -= moveFrom;
+
+        if (c == 0 && m_debugLevel > 2) {
+            cerr << "lastread reduced to " << m_lastread[c]
+                 << ", time reduced to " << m_time[c]
+                 << endl;
+        }
+        
+        if (final && n < limit) {
+
+            // Looks like this actually produces too many samples
+            // (additionalcount is a few samples too large).
+
+            // Also, we aren't likely to have enough space in the
+            // output buffer as the caller won't have allowed for
+            // all the samples we're retrieving here.
+
+            // What to do?
+
+            int additionalcount = 0;
+
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "final call, padding input with " << m_history
+                     << " zeros (symmetrical with m_history)" << endl;
+            }
+            
+            for (int i = 0; i < m_history; ++i) {
+                m_inbuf[c][m_lastread[c] + i] = 0.f;
+            }
+
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "before resample call, time = " << m_time[c] << endl;
+            }
+
+            int nAdditional = m_lastread[c] - int(m_time[c]);
+
+            if (n + nAdditional > limit) {
+                if (c == 0 && m_debugLevel > 1) {
+                    cerr << "trimming final input samples from " << nAdditional
+                         << " to " << (limit - n)
+                         << " to avoid overrunning " << outspace << " at output"
+                         << endl;
+                }
+                nAdditional = limit - n;
+            }
+            
+            ippsResamplePolyphase_32f(m_inbuf[c],
+                                      nAdditional,
+                                      m_outbuf[c],
+                                      ratio,
+                                      1.0f,
+                                      &m_time[c],
+                                      &additionalcount,
+                                      m_state[c]);
+        
+            if (c == 0 && m_debugLevel > 2) {
+                cerr << "converted " << n << " samples to " << additionalcount
+                     << ", time advanced to " << m_time[c] << endl;
+                cerr << "outcount = " << outcount << ", additionalcount = " << additionalcount << ", sum " << outcount + additionalcount << endl;
+            }
+
+            if (c == 0) {
+                outcount += additionalcount;
+            }
+        }
+    }
+
+    if (m_debugLevel > 2) {
+        cerr << "returning " << outcount << " samples" << endl;
+    }
+    
+    return outcount;
+}
+
+void
+D_IPP::reset()
+{
+    //!!!
+}
+
+#endif /* HAVE_IPP */
+
+#ifdef HAVE_LIBSAMPLERATE
+
+class D_SRC : public Resampler::Impl
+{
+public:
+    D_SRC(Resampler::Quality quality, Resampler::RatioChange ratioChange,
+          int channels, double initialSampleRate,
+          int maxBufferSize, int m_debugLevel);
+    ~D_SRC();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    SRC_STATE *m_src;
+    float *m_iin;
+    float *m_iout;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    double m_prevRatio;
+    bool m_ratioUnset;
+    bool m_smoothRatios;
+    int m_debugLevel;
+};
+
+D_SRC::D_SRC(Resampler::Quality quality, Resampler::RatioChange ratioChange,
+             int channels, double, int maxBufferSize, int debugLevel) :
+    m_src(0),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_prevRatio(1.0),
+    m_ratioUnset(true),
+    m_smoothRatios(ratioChange == Resampler::SmoothRatioChange),
+    m_debugLevel(debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: libsamplerate"
+             << endl;
+    }
+
+    if (channels < 1) {
+        cerr << "Resampler::Resampler: unable to create resampler: invalid channel count " << channels << " supplied" << endl;
+#ifdef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+        return;
+    }
+    
+    int err = 0;
+    m_src = src_new(quality == Resampler::Best ? SRC_SINC_BEST_QUALITY :
+                    quality == Resampler::Fastest ? SRC_SINC_FASTEST :
+                    SRC_SINC_MEDIUM_QUALITY,
+                    channels, &err);
+
+    if (err) {
+        cerr << "Resampler::Resampler: failed to create libsamplerate resampler: " 
+             << src_strerror(err) << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+        return;
+    } else if (!m_src) {
+        cerr << "Resampler::Resampler: failed to create libsamplerate resampler, but no error reported?" << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+        return;
+    }
+
+    if (maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = maxBufferSize * m_channels;
+        m_ioutsize = maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+
+    reset();
+}
+
+D_SRC::~D_SRC()
+{
+    src_delete(m_src);
+    deallocate(m_iin);
+    deallocate(m_iout);
+}
+
+int
+D_SRC::resample(float *const BQ_R__ *const BQ_R__ out,
+                int outcount,
+                const float *const BQ_R__ *const BQ_R__ in,
+                int incount,
+                double ratio,
+                bool final)
+{
+    if (m_channels == 1) {
+        return resampleInterleaved(*out, outcount, *in, incount, ratio, final);
+    }
+
+    if (incount * m_channels > m_iinsize) {
+        m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+        m_iinsize = incount * m_channels;
+    }
+    if (outcount * m_channels > m_ioutsize) {
+        m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+        m_ioutsize = outcount * m_channels;
+    }
+    
+    v_interleave(m_iin, in, m_channels, incount);
+
+    int n = resampleInterleaved(m_iout, outcount, m_iin, incount, ratio, final);
+
+    v_deinterleave(out, m_iout, m_channels, n);
+
+    return n;
+}
+
+int
+D_SRC::resampleInterleaved(float *const BQ_R__ out,
+                           int outcount,
+                           const float *const BQ_R__ in,
+                           int incount,
+                           double ratio,
+                           bool final)
+{
+    SRC_DATA data;
+
+    // libsamplerate smooths the filter change over the duration of
+    // the processing block to avoid artifacts due to sudden changes,
+    // and it uses outcount to determine how long to smooth the change
+    // over. This is a good thing, but it does mean (a) we should
+    // never pass outcount significantly longer than the actual
+    // expected output, and (b) when the ratio has just changed, we
+    // should aim to supply a shortish block next
+    
+    if (outcount > int(ceil(incount * ratio) + 5)) {
+        outcount = int(ceil(incount * ratio) + 5);
+    }
+
+    if (m_ratioUnset || !m_smoothRatios) {
+
+        // The first time we set a ratio, we want to do it directly
+        src_set_ratio(m_src, ratio);
+        m_ratioUnset = false;
+        m_prevRatio = ratio;
+
+    } else if (ratio != m_prevRatio) {
+
+        // If we are processing a block of appreciable length, turn it
+        // into two recursive calls, one for the short smoothing block
+        // and the other for the rest. Update m_prevRatio before doing
+        // this so that the calls don't themselves recurse!
+        m_prevRatio = ratio;
+
+        int shortBlock = 200;
+        if (outcount > shortBlock * 2) {
+            int shortIn = int(floor(shortBlock / ratio));
+            if (shortIn >= 10) {
+                int shortOut =
+                    resampleInterleaved(out, shortBlock,
+                                        in, shortIn,
+                                        ratio, false);
+                int remainingOut = 0;
+                if (shortOut < outcount) {
+                    remainingOut =
+                        resampleInterleaved(out + shortOut * m_channels,
+                                            outcount - shortOut,
+                                            in + shortIn * m_channels,
+                                            incount - shortIn,
+                                            ratio, final);
+                }
+                return shortOut + remainingOut;
+            }
+        }
+    }
+
+    data.data_in = const_cast<float *>(in);
+    data.data_out = out;
+
+    data.input_frames = incount;
+    data.output_frames = outcount;
+    data.src_ratio = ratio;
+    data.end_of_input = (final ? 1 : 0);
+
+    int err = src_process(m_src, &data);
+
+    if (err) {
+        cerr << "Resampler::process: libsamplerate error: "
+             << src_strerror(err) << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+
+    return (int)data.output_frames_gen;
+}
+
+void
+D_SRC::reset()
+{
+    src_reset(m_src);
+    m_ratioUnset = true;
+}
+
+#endif /* HAVE_LIBSAMPLERATE */
+
+#ifdef HAVE_LIBRESAMPLE
+
+class D_Resample : public Resampler::Impl
+{
+public:
+    D_Resample(Resampler::Quality quality, Resampler::RatioChange,
+               int channels, double initialSampleRate,
+               int maxBufferSize, int m_debugLevel);
+    ~D_Resample();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    void *m_src;
+    float *m_iin;
+    float *m_iout;
+    double m_lastRatio;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    int m_debugLevel;
+};
+
+D_Resample::D_Resample(Resampler::Quality quality,
+                       int channels, double, int maxBufferSize, int debugLevel) :
+    m_src(0),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_debugLevel(debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: libresample"
+                  << endl;
+    }
+
+    float min_factor = 0.125f;
+    float max_factor = 8.0f;
+
+    m_src = resample_open(quality == Resampler::Best ? 1 : 0, min_factor, max_factor);
+
+    if (!m_src) {
+        cerr << "Resampler::Resampler: failed to create libresample resampler: " 
+                  << endl;
+        throw Resampler::ImplementationError; //!!! of course, need to catch this!
+    }
+
+    if (maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = maxBufferSize * m_channels;
+        m_ioutsize = maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+
+    reset();
+}
+
+D_Resample::~D_Resample()
+{
+    resample_close(m_src);
+    if (m_iinsize > 0) {
+        deallocate(m_iin);
+    }
+    if (m_ioutsize > 0) {
+        deallocate(m_iout);
+    }
+}
+
+int
+D_Resample::resample(float *const BQ_R__ *const BQ_R__ out,
+                     int outcount,
+                     const float *const BQ_R__ *const BQ_R__ in,
+                     int incount,
+                     double ratio,
+                     bool final)
+{
+    float *data_in;
+    float *data_out;
+    int input_frames, output_frames, end_of_input, source_used;
+    float src_ratio;
+
+    int outcount = (int)lrint(ceil(incount * ratio));
+
+    if (m_channels == 1) {
+        data_in = const_cast<float *>(*in); //!!!???
+        data_out = *out;
+    } else {
+        if (incount * m_channels > m_iinsize) {
+            m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+            m_iinsize = incount * m_channels;
+        }
+        if (outcount * m_channels > m_ioutsize) {
+            m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+            m_ioutsize = outcount * m_channels;
+        }
+        v_interleave(m_iin, in, m_channels, incount);
+        data_in = m_iin;
+        data_out = m_iout;
+    }
+
+    input_frames = incount;
+    output_frames = outcount;
+    src_ratio = ratio;
+    end_of_input = (final ? 1 : 0);
+
+    int output_frames_gen = resample_process(m_src,
+                                             src_ratio,
+                                             data_in,
+                                             input_frames,
+                                             end_of_input,
+                                             &source_used,
+                                             data_out,
+                                             output_frames);
+
+    if (output_frames_gen < 0) {
+        cerr << "Resampler::process: libresample error: "
+                  << endl;
+        throw Resampler::ImplementationError; //!!! of course, need to catch this!
+    }
+
+    if (m_channels > 1) {
+        v_deinterleave(out, m_iout, m_channels, output_frames_gen);
+    }
+
+    return output_frames_gen;
+}
+
+int
+D_Resample::resampleInterleaved(float *const BQ_R__ out,
+                                int outcount,
+                                const float *const BQ_R__ in,
+                                int incount,
+                                double ratio,
+                                bool final)
+{
+    int input_frames, output_frames, end_of_input, source_used;
+    float src_ratio;
+
+    int outcount = (int)lrint(ceil(incount * ratio));
+
+    input_frames = incount;
+    output_frames = outcount;
+    src_ratio = ratio;
+    end_of_input = (final ? 1 : 0);
+
+    int output_frames_gen = resample_process(m_src,
+                                             src_ratio,
+                                             const_cast<float *>(in),
+                                             input_frames,
+                                             end_of_input,
+                                             &source_used,
+                                             out,
+                                             output_frames);
+
+    if (output_frames_gen < 0) {
+        cerr << "Resampler::process: libresample error: "
+                  << endl;
+        throw Resampler::ImplementationError; //!!! of course, need to catch this!
+    }
+
+    return output_frames_gen;
+}
+
+void
+D_Resample::reset()
+{
+}
+
+#endif /* HAVE_LIBRESAMPLE */
+
+#ifdef USE_BQRESAMPLER
+    
+class D_BQResampler : public Resampler::Impl
+{
+public:
+    D_BQResampler(Resampler::Parameters params, int channels);
+    ~D_BQResampler();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const {
+        return m_channels;
+    }
+
+    double getEffectiveRatio(double ratio) const {
+        return m_resampler->getEffectiveRatio(ratio);
+    }
+
+    void reset();
+
+protected:
+    BQResampler *m_resampler;
+    float *m_iin;
+    float *m_iout;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    int m_debugLevel;
+};
+
+D_BQResampler::D_BQResampler(Resampler::Parameters params, int channels) :
+    m_resampler(0),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_debugLevel(params.debugLevel)
+{
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: BQResampler" << endl;
+    }
+
+    BQResampler::Parameters rparams;
+    switch (params.quality) {
+    case Resampler::Best:
+        rparams.quality = BQResampler::Best;
+        break;
+    case Resampler::FastestTolerable:
+        rparams.quality = BQResampler::FastestTolerable;
+        break;
+    case Resampler::Fastest:
+        rparams.quality = BQResampler::Fastest;
+        break;
+    }
+    switch (params.dynamism) {
+    case Resampler::RatioOftenChanging:
+        rparams.dynamism = BQResampler::RatioOftenChanging;
+        break;
+    case Resampler::RatioMostlyFixed:
+        rparams.dynamism = BQResampler::RatioMostlyFixed;
+        break;
+    }
+    switch (params.ratioChange) {
+    case Resampler::SmoothRatioChange:
+        rparams.ratioChange = BQResampler::SmoothRatioChange;
+        break;
+    case Resampler::SuddenRatioChange:
+        rparams.ratioChange = BQResampler::SuddenRatioChange;
+        break;
+    }
+    rparams.referenceSampleRate = params.initialSampleRate;
+    rparams.debugLevel = params.debugLevel;
+
+    m_resampler = new BQResampler(rparams, m_channels);
+    
+    if (params.maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = params.maxBufferSize * m_channels;
+        m_ioutsize = params.maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+}
+
+D_BQResampler::~D_BQResampler()
+{
+    delete m_resampler;
+    deallocate(m_iin);
+    deallocate(m_iout);
+}
+
+int
+D_BQResampler::resample(float *const BQ_R__ *const BQ_R__ out,
+                        int outcount,
+                        const float *const BQ_R__ *const BQ_R__ in,
+                        int incount,
+                        double ratio,
+                        bool final)
+{
+    if (m_channels == 1) {
+        return resampleInterleaved(*out, outcount, *in, incount, ratio, final);
+    }
+
+    if (incount * m_channels > m_iinsize) {
+        m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+        m_iinsize = incount * m_channels;
+    }
+    if (outcount * m_channels > m_ioutsize) {
+        m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+        m_ioutsize = outcount * m_channels;
+    }
+    
+    v_interleave(m_iin, in, m_channels, incount);
+    
+    int n = resampleInterleaved(m_iout, outcount, m_iin, incount, ratio, final);
+
+    v_deinterleave(out, m_iout, m_channels, n);
+
+    return n;
+}
+
+int
+D_BQResampler::resampleInterleaved(float *const BQ_R__ out,
+                                   int outcount,
+                                   const float *const BQ_R__ in,
+                                   int incount,
+                                   double ratio,
+                                   bool final)
+{
+    return m_resampler->resampleInterleaved(out, outcount,
+                                            in, incount,
+                                            ratio, final);
+}
+
+void
+D_BQResampler::reset()
+{
+    m_resampler->reset();
+}
+
+#endif /* USE_BQRESAMPLER */
+
+#ifdef USE_SPEEX
+    
+class D_Speex : public Resampler::Impl
+{
+public:
+    D_Speex(Resampler::Quality quality, Resampler::RatioChange,
+            int channels, double initialSampleRate,
+            int maxBufferSize, int debugLevel);
+    ~D_Speex();
+
+    int resample(float *const BQ_R__ *const BQ_R__ out,
+                 int outcount,
+                 const float *const BQ_R__ *const BQ_R__ in,
+                 int incount,
+                 double ratio,
+                 bool final);
+
+    int resampleInterleaved(float *const BQ_R__ out,
+                            int outcount,
+                            const float *const BQ_R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    int getChannelCount() const { return m_channels; }
+    double getEffectiveRatio(double ratio) const { return ratio; }
+
+    void reset();
+
+protected:
+    SpeexResamplerState *m_resampler;
+    double m_initialSampleRate;
+    float *m_iin;
+    float *m_iout;
+    int m_channels;
+    int m_iinsize;
+    int m_ioutsize;
+    double m_lastratio;
+    bool m_initial;
+    int m_debugLevel;
+
+    void setRatio(double);
+    void doResample(const float *in, unsigned int &incount,
+                    float *out, unsigned int &outcount,
+                    double ratio, bool final);
+};
+
+D_Speex::D_Speex(Resampler::Quality quality, Resampler::RatioChange,
+                 int channels, double initialSampleRate,
+                 int maxBufferSize, int debugLevel) :
+    m_resampler(0),
+    m_initialSampleRate(initialSampleRate),
+    m_iin(0),
+    m_iout(0),
+    m_channels(channels),
+    m_iinsize(0),
+    m_ioutsize(0),
+    m_lastratio(-1.0),
+    m_initial(true),
+    m_debugLevel(debugLevel)
+{
+    int q = (quality == Resampler::Best ? 10 :
+             quality == Resampler::Fastest ? 0 : 4);
+
+    if (m_debugLevel > 0) {
+        cerr << "Resampler::Resampler: using implementation: Speex with q = "
+             << q << endl;
+    }
+
+    int rrate = int(round(m_initialSampleRate));
+    
+    int err = 0;
+    m_resampler = speex_resampler_init_frac(m_channels,
+                                            1, 1,
+                                            rrate, rrate,
+                                            q,
+                                            &err);
+    
+
+    if (err) {
+        cerr << "Resampler::Resampler: failed to create Speex resampler" 
+             << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+
+    if (maxBufferSize > 0 && m_channels > 1) {
+        m_iinsize = maxBufferSize * m_channels;
+        m_ioutsize = maxBufferSize * m_channels * 2;
+        m_iin = allocate<float>(m_iinsize);
+        m_iout = allocate<float>(m_ioutsize);
+    }
+}
+
+D_Speex::~D_Speex()
+{
+    speex_resampler_destroy(m_resampler);
+    deallocate<float>(m_iin);
+    deallocate<float>(m_iout);
+}
+
+void
+D_Speex::setRatio(double ratio)
+{
+    // Speex wants a ratio of two unsigned integers, not a single
+    // float.  Let's do that.
+
+    unsigned int big = 272408136U; 
+    unsigned int denom = 1, num = 1;
+
+    if (ratio < 1.f) {
+        denom = big;
+        double dnum = double(big) * double(ratio);
+        num = (unsigned int)dnum;
+    } else if (ratio > 1.f) {
+        num = big;
+        double ddenom = double(big) / double(ratio);
+        denom = (unsigned int)ddenom;
+    }
+    
+    if (m_debugLevel > 1) {
+        cerr << "D_Speex: Desired ratio " << ratio << ", requesting ratio "
+             << num << "/" << denom << " = " << float(double(num)/double(denom))
+             << endl;
+    }
+
+    int fromRate = int(round(m_initialSampleRate));
+    int toRate = int(round(m_initialSampleRate * ratio));
+    
+    int err = speex_resampler_set_rate_frac
+        (m_resampler, denom, num, fromRate, toRate);
+
+    if (err) {
+        cerr << "Resampler::Resampler: failed to set rate on Speex resampler" 
+             << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+    
+    speex_resampler_get_ratio(m_resampler, &denom, &num);
+    
+    if (m_debugLevel > 1) {
+        cerr << "D_Speex: Desired ratio " << ratio << ", got ratio "
+             << num << "/" << denom << " = " << float(double(num)/double(denom))
+             << endl;
+    }
+    
+    m_lastratio = ratio;
+
+    if (m_initial) {
+        speex_resampler_skip_zeros(m_resampler);
+        m_initial = false;
+    }
+}
+
+int
+D_Speex::resample(float *const BQ_R__ *const BQ_R__ out,
+                  int outcount,
+                  const float *const BQ_R__ *const BQ_R__ in,
+                  int incount,
+                  double ratio,
+                  bool final)
+{
+    if (ratio != m_lastratio) {
+        setRatio(ratio);
+    }
+
+    unsigned int uincount = incount;
+    unsigned int uoutcount = outcount;
+
+    float *data_in, *data_out;
+
+    if (m_channels == 1) {
+        data_in = const_cast<float *>(*in);
+        data_out = *out;
+    } else {
+        if (int(incount * m_channels) > m_iinsize) {
+            m_iin = reallocate<float>(m_iin, m_iinsize, incount * m_channels);
+            m_iinsize = incount * m_channels;
+        }
+        if (int(outcount * m_channels) > m_ioutsize) {
+            m_iout = reallocate<float>(m_iout, m_ioutsize, outcount * m_channels);
+            m_ioutsize = outcount * m_channels;
+        }
+        v_interleave(m_iin, in, m_channels, incount);
+        data_in = m_iin;
+        data_out = m_iout;
+    }
+
+    doResample(data_in, uincount, data_out, uoutcount, ratio, final);
+
+    if (m_channels > 1) {
+        v_deinterleave(out, m_iout, m_channels, uoutcount);
+    }
+
+    return uoutcount;
+}
+
+int
+D_Speex::resampleInterleaved(float *const BQ_R__ out,
+                             int outcount,
+                             const float *const BQ_R__ in,
+                             int incount,
+                             double ratio,
+                             bool final)
+{
+    if (ratio != m_lastratio) {
+        setRatio(ratio);
+    }
+
+    unsigned int uincount = incount;
+    unsigned int uoutcount = outcount;
+
+    float *data_in = const_cast<float *>(in);
+    float *data_out = out;
+
+    doResample(data_in, uincount, data_out, uoutcount, ratio, final);
+    
+    return uoutcount;
+}
+
+void
+D_Speex::doResample(const float *data_in, unsigned int &uincount,
+                    float *data_out, unsigned int &uoutcount,
+                    double ratio, bool final)
+{
+    int initial_outcount = int(uoutcount);
+    
+    int err = speex_resampler_process_interleaved_float
+        (m_resampler,
+         data_in, &uincount,
+         data_out, &uoutcount);
+    
+    if (err) {
+        cerr << "Resampler::Resampler: Speex resampler returned error "
+             << err << endl;
+#ifndef NO_EXCEPTIONS
+        throw Resampler::ImplementationError;
+#endif
+    }
+
+    if (final) {
+        int actual = int(uoutcount);
+        int expected = std::min(initial_outcount, int(round(uincount * ratio)));
+        if (actual < expected) {
+            unsigned int final_out = expected - actual;
+            unsigned int final_in = (unsigned int)(round(final_out / ratio));
+            if (final_in > 0) {
+                float *pad = allocate_and_zero<float>(final_in * m_channels);
+                err = speex_resampler_process_interleaved_float
+                    (m_resampler,
+                     pad, &final_in,
+                     data_out + actual * m_channels, &final_out);
+                deallocate(pad);
+                uoutcount += final_out;
+                if (err) {
+                    cerr << "Resampler::Resampler: Speex resampler returned error "
+                         << err << endl;
+#ifndef NO_EXCEPTIONS
+                    throw Resampler::ImplementationError;
+#endif
+                }
+            }
+        }
+    }
+}
+
+void
+D_Speex::reset()
+{
+    m_lastratio = -1.0; // force reset of ratio
+    m_initial = true;
+    speex_resampler_reset_mem(m_resampler);
+}
+
+#endif
+
+} /* end namespace Resamplers */
+
+Resampler::Resampler(Resampler::Parameters params, int channels)
+{
+    m_method = -1;
+
+    if (params.initialSampleRate == 0) {
+        params.initialSampleRate = 44100;
+    }
+    
+    switch (params.quality) {
+
+    case Resampler::Best:
+#ifdef HAVE_IPP
+        m_method = 0;
+#endif
+#ifdef USE_SPEEX
+        m_method = 2;
+#endif
+#ifdef HAVE_LIBRESAMPLE
+        m_method = 3;
+#endif
+#ifdef USE_BQRESAMPLER
+        m_method = 4;
+#endif
+#ifdef HAVE_LIBSAMPLERATE
+        m_method = 1;
+#endif
+        break;
+
+    case Resampler::FastestTolerable:
+#ifdef HAVE_IPP
+        m_method = 0;
+#endif
+#ifdef HAVE_LIBRESAMPLE
+        m_method = 3;
+#endif
+#ifdef USE_SPEEX
+        m_method = 2;
+#endif
+#ifdef USE_BQRESAMPLER
+        m_method = 4;
+#endif
+#ifdef HAVE_LIBSAMPLERATE
+        m_method = 1;
+#endif
+        break;
+
+    case Resampler::Fastest:
+#ifdef HAVE_IPP
+        m_method = 0;
+#endif
+#ifdef HAVE_LIBRESAMPLE
+        m_method = 3;
+#endif
+#ifdef USE_SPEEX
+        m_method = 2;
+#endif
+#ifdef USE_BQRESAMPLER
+        m_method = 4;
+#endif
+#ifdef HAVE_LIBSAMPLERATE
+        m_method = 1;
+#endif
+        break;
+    }
+
+    if (m_method == -1) {
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+    }
+
+    switch (m_method) {
+    case 0:
+#ifdef HAVE_IPP
+        d = new Resamplers::D_IPP
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 1:
+#ifdef HAVE_LIBSAMPLERATE
+        d = new Resamplers::D_SRC
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 2:
+#ifdef USE_SPEEX
+        d = new Resamplers::D_Speex
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 3:
+#ifdef HAVE_LIBRESAMPLE
+        d = new Resamplers::D_Resample
+            (params.quality, params.ratioChange,
+             channels,
+             params.initialSampleRate, params.maxBufferSize, params.debugLevel);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+
+    case 4:
+#ifdef USE_BQRESAMPLER
+        d = new Resamplers::D_BQResampler(params, channels);
+#else
+        cerr << "Resampler::Resampler: No implementation available!" << endl;
+        abort();
+#endif
+        break;
+    }
+
+    if (!d) {
+        cerr << "Resampler::Resampler: Internal error: No implementation selected"
+             << endl;
+        abort();
+    }
+}
+
+Resampler::~Resampler()
+{
+    delete d;
+}
+
+int 
+Resampler::resample(float *const BQ_R__ *const BQ_R__ out,
+                    int outcount,
+                    const float *const BQ_R__ *const BQ_R__ in,
+                    int incount,
+                    double ratio,
+                    bool final)
+{
+    return d->resample(out, outcount, in, incount, ratio, final);
+}
+
+int 
+Resampler::resampleInterleaved(float *const BQ_R__ out,
+                               int outcount,
+                               const float *const BQ_R__ in,
+                               int incount,
+                               double ratio,
+                               bool final)
+{
+    return d->resampleInterleaved(out, outcount, in, incount, ratio, final);
+}
+
+int
+Resampler::getChannelCount() const
+{
+    return d->getChannelCount();
+}
+
+double
+Resampler::getEffectiveRatio(double ratio) const
+{
+    return d->getEffectiveRatio(ratio);
+}
+
+void
+Resampler::reset()
+{
+    d->reset();
+}
+
+}

--- a/pedalboard/vendors/rubberband/src/dsp/Resampler.h
+++ b/pedalboard/vendors/rubberband/src/dsp/Resampler.h
@@ -1,0 +1,179 @@
+//* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_RESAMPLER_H
+#define RUBBERBAND_RESAMPLER_H
+
+#include "../system/sysutils.h"
+
+namespace RubberBand {
+
+class Resampler
+{
+public:
+    enum Quality { Best, FastestTolerable, Fastest };
+    enum Dynamism { RatioOftenChanging, RatioMostlyFixed };
+    enum RatioChange { SmoothRatioChange, SuddenRatioChange };
+    
+    enum Exception { ImplementationError };
+
+    struct Parameters {
+
+        /**
+         * Resampler filter quality level.
+         */
+        Quality quality;
+
+        /**
+         * Performance hint indicating whether the ratio is expected
+         * to change regularly or not. If not, more work may happen on
+         * ratio changes to reduce work when ratio is unchanged.
+         */
+        Dynamism dynamism; 
+
+        /**
+         * Hint indicating whether to smooth transitions, via filter
+         * interpolation or some such method, at ratio change
+         * boundaries, or whether to make a precise switch to the new
+         * ratio without regard to audible artifacts. The actual
+         * effect of this depends on the implementation in use.
+         */
+        RatioChange ratioChange;
+        
+        /** 
+         * Rate of expected input prior to resampling: may be used to
+         * determine the filter bandwidth for the quality setting. If
+         * you don't know what this will be, you can provide an
+         * arbitrary rate (such as the default) and the resampler will
+         * work fine, but quality may not be as designed.
+         */
+        double initialSampleRate;
+
+        /** 
+         * Bound on the maximum incount size that may be passed to the
+         * resample function before the resampler needs to reallocate
+         * its internal buffers. Default is zero, so that buffer
+         * allocation will happen on the first call and any subsequent
+         * call with a greater incount.
+         */
+        int maxBufferSize;
+
+        /**
+         * Debug output level, from 0 to 3. Controls the amount of
+         * debug information printed to stderr.
+         */
+        int debugLevel;
+
+        Parameters() :
+            quality(FastestTolerable),
+            dynamism(RatioMostlyFixed),
+            ratioChange(SmoothRatioChange),
+            initialSampleRate(44100),
+            maxBufferSize(0),
+            debugLevel(0) { }
+    };
+    
+    /**
+     * Construct a resampler to process the given number of channels,
+     * with the given quality level, initial sample rate, and other
+     * parameters.
+     */
+    Resampler(Parameters parameters, int channels);
+    
+    ~Resampler();
+
+    /**
+     * Resample the given multi-channel buffers, where incount is the
+     * number of frames in the input buffers and outspace is the space
+     * available in the output buffers. Generally you want outspace to
+     * be at least ceil(incount * ratio).
+     *
+     * Returns the number of frames written to the output
+     * buffers. This may be smaller than outspace even where the ratio
+     * suggests otherwise, particularly at the start of processing
+     * where there may be a filter tail to allow for.
+     */
+#ifdef __GNUC__
+    __attribute__((warn_unused_result))
+#endif
+    int resample(float *const R__ *const R__ out,
+                 int outspace,
+                 const float *const R__ *const R__ in,
+                 int incount,
+                 double ratio,
+                 bool final = false);
+
+    /**
+     * Resample the given interleaved buffer, where incount is the
+     * number of frames in the input buffer (i.e. it has incount *
+     * getChannelCount() samples) and outspace is the space available
+     * in frames in the output buffer (i.e. it has space for at least
+     * outspace * getChannelCount() samples). Generally you want
+     * outspace to be at least ceil(incount * ratio).
+     *
+     * Returns the number of frames written to the output buffer. This
+     * may be smaller than outspace even where the ratio suggests
+     * otherwise, particularly at the start of processing where there
+     * may be a filter tail to allow for.
+     */
+#ifdef __GNUC__
+    __attribute__((warn_unused_result))
+#endif
+    int resampleInterleaved(float *const R__ out,
+                            int outspace,
+                            const float *const R__ in,
+                            int incount,
+                            double ratio,
+                            bool final = false);
+
+    /**
+     * Return the channel count provided on construction.
+     */
+    int getChannelCount() const;
+
+    /**
+     * Return the ratio that will be actually used when the given
+     * ratio is requested. For example, if the resampler internally
+     * uses a rational approximation of the given ratio, this will
+     * return the closest double to that approximation. Not all
+     * implementations support this; an implementation that does not
+     * will just return the given ratio.
+     */
+    double getEffectiveRatio(double ratio) const;
+    
+    /**
+     * Reset the internal processing state so that the next call
+     * behaves as if the resampler had just been constructed.
+     */
+    void reset();
+
+    class Impl;
+
+protected:
+    Impl *d;
+    int m_method;
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/dsp/SampleFilter.h
+++ b/pedalboard/vendors/rubberband/src/dsp/SampleFilter.h
@@ -1,0 +1,59 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SAMPLE_FILTER_H
+#define RUBBERBAND_SAMPLE_FILTER_H
+
+#include <cassert>
+
+namespace RubberBand
+{
+
+template <typename T>
+class SampleFilter
+{
+public:
+    SampleFilter(int size) : m_size(size) {
+	assert(m_size > 0);
+    }
+
+    virtual ~SampleFilter() { }
+
+    int getSize() const { return m_size; }
+
+    virtual void push(T) = 0;
+    virtual T get() const = 0;
+    virtual void reset() = 0;
+
+protected:
+    const int m_size;
+
+private:
+    SampleFilter(const SampleFilter &);
+    SampleFilter &operator=(const SampleFilter &);
+};
+
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/dsp/SincWindow.h
+++ b/pedalboard/vendors/rubberband/src/dsp/SincWindow.h
@@ -1,0 +1,155 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SINC_WINDOW_H
+#define RUBBERBAND_SINC_WINDOW_H
+
+#include <cmath>
+#include <iostream>
+#include <cstdlib>
+#include <map>
+
+#include "../system/sysutils.h"
+#include "../system/VectorOps.h"
+#include "../system/Allocators.h"
+
+namespace RubberBand {
+
+template <typename T>
+class SincWindow
+{
+public:
+    /**
+     * Construct a sinc windower which produces a window of size n
+     * containing the values of sinc(x) with x=0 at index n/2, such
+     * that the distance from -pi to pi (the point at which the sinc
+     * function first crosses zero, for negative and positive
+     * arguments respectively) is p samples.
+     */
+    SincWindow(int n, int p) : m_size(n), m_p(p), m_cache(0) {
+        encache();
+    }
+    SincWindow(const SincWindow &w) : m_size(w.m_size), m_p(w.m_p), m_cache(0) {
+        encache();
+    }
+    SincWindow &operator=(const SincWindow &w) {
+	if (&w == this) return *this;
+	m_size = w.m_size;
+	m_p = w.m_p;
+        m_cache = 0;
+	encache();
+	return *this;
+    }
+    virtual ~SincWindow() {
+        deallocate(m_cache);
+    }
+
+    /**
+     * Regenerate the sinc window with the same size, but a new scale
+     * (the p value is interpreted as for the argument of the same
+     * name to the constructor).  If p is unchanged from the previous
+     * value, do nothing (quickly).
+     */
+    inline void rewrite(int p) {
+        if (m_p == p) return;
+        m_p = p;
+        encache();
+    }
+    
+    inline void cut(T *const R__ dst) const {
+        v_multiply(dst, m_cache, m_size);
+    }
+
+    inline void cut(const T *const R__ src, T *const R__ dst) const {
+        v_multiply(dst, src, m_cache, m_size);
+    }
+
+    inline void add(T *const R__ dst, T scale) const {
+        v_add_with_gain(dst, m_cache, scale, m_size);
+    }
+
+    inline T getArea() const { return m_area; }
+    inline T getValue(int i) const { return m_cache[i]; }
+
+    inline int getSize() const { return m_size; }
+    inline int getP() const { return m_p; }
+
+    /**
+     * Write a sinc window of size n with scale p (the p value is
+     * interpreted as for the argument of the same name to the
+     * constructor).
+     */
+    static
+    void write(T *const R__ dst, const int n, const int p) {
+        const int half = n/2;
+        writeHalf(dst, n, p);
+        int target = half - 1;
+        for (int i = half + 1; i < n; ++i) {
+            dst[target--] = dst[i];
+        }
+        const T twopi = T(2. * M_PI);
+        T arg = T(half) * twopi / p;
+        dst[0] = sin(arg) / arg;
+    }
+
+protected:
+    int m_size;
+    int m_p;
+    T *R__ m_cache;
+    T m_area;
+
+    /**
+     * Write the positive half (i.e. n/2 to n-1) of a sinc window of
+     * size n with scale p (the p value is interpreted as for the
+     * argument of the same name to the constructor). The negative
+     * half (indices 0 to n/2-1) of dst is left unchanged.
+     */
+    static
+    void writeHalf(T *const R__ dst, const int n, const int p) {
+        const int half = n/2;
+        const T twopi = T(2. * M_PI);
+        dst[half] = T(1.0);
+        for (int i = 1; i < half; ++i) {
+            T arg = T(i) * twopi / p;
+            dst[half+i] = sin(arg) / arg;
+        }
+    }
+    
+    void encache() {
+        if (!m_cache) {
+            m_cache = allocate<T>(m_size);
+        }
+
+        write(m_cache, m_size, m_p);
+	
+        m_area = 0;
+        for (int i = 0; i < m_size; ++i) {
+            m_area += m_cache[i];
+        }
+        m_area /= m_size;
+    }
+};
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/dsp/Window.h
+++ b/pedalboard/vendors/rubberband/src/dsp/Window.h
@@ -1,0 +1,200 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_WINDOW_H
+#define RUBBERBAND_WINDOW_H
+
+#include <cmath>
+#include <cstdlib>
+#include <map>
+
+#include "../system/sysutils.h"
+#include "../system/VectorOps.h"
+#include "../system/Allocators.h"
+
+namespace RubberBand {
+
+enum WindowType {
+    RectangularWindow,
+    BartlettWindow,
+    HammingWindow,
+    HanningWindow,
+    BlackmanWindow,
+    GaussianWindow,
+    ParzenWindow,
+    NuttallWindow,
+    BlackmanHarrisWindow
+};
+
+template <typename T>
+class Window
+{
+public:
+    /**
+     * Construct a windower of the given type.
+     */
+    Window(WindowType type, int size) : m_type(type), m_size(size), m_cache(0) {
+        encache();
+    }
+    Window(const Window &w) : m_type(w.m_type), m_size(w.m_size), m_cache(0) {
+        encache();
+    }
+    Window &operator=(const Window &w) {
+	if (&w == this) return *this;
+	m_type = w.m_type;
+	m_size = w.m_size;
+        m_cache = 0;
+	encache();
+	return *this;
+    }
+    virtual ~Window() {
+        deallocate(m_cache);
+    }
+    
+    inline void cut(T *const R__ block) const {
+        v_multiply(block, m_cache, m_size);
+    }
+
+    inline void cut(const T *const R__ src, T *const R__ dst) const {
+        v_multiply(dst, src, m_cache, m_size);
+    }
+
+    inline void add(T *const R__ dst, T scale) const {
+        v_add_with_gain(dst, m_cache, scale, m_size);
+    }
+
+    inline T getRMS() const {
+        T total = 0;
+        for (int i = 0; i < m_size; ++i) {
+            total += m_cache[i] * m_cache[i];
+        }
+        T rms = sqrt(total / m_size);
+        return rms;
+    }
+
+    inline T getArea() const { return m_area; }
+    inline T getValue(int i) const { return m_cache[i]; }
+
+    inline WindowType getType() const { return m_type; }
+    inline int getSize() const { return m_size; }
+
+protected:
+    WindowType m_type;
+    int m_size;
+    T *R__ m_cache;
+    T m_area;
+    
+    void encache();
+    void cosinewin(T *, T, T, T, T);
+};
+
+template <typename T>
+void Window<T>::encache()
+{
+    if (!m_cache) m_cache = allocate<T>(m_size);
+
+    const int n = m_size;
+    v_set(m_cache, T(1.0), n);
+    int i;
+
+    switch (m_type) {
+		
+    case RectangularWindow:
+	for (i = 0; i < n; ++i) {
+	    m_cache[i] *= 0.5;
+	}
+	break;
+	    
+    case BartlettWindow:
+	for (i = 0; i < n/2; ++i) {
+	    m_cache[i] *= (i / T(n/2));
+	    m_cache[i + n/2] *= (1.0 - (i / T(n/2)));
+	}
+	break;
+	    
+    case HammingWindow:
+        cosinewin(m_cache, 0.54, 0.46, 0.0, 0.0);
+	break;
+	    
+    case HanningWindow:
+        cosinewin(m_cache, 0.50, 0.50, 0.0, 0.0);
+	break;
+	    
+    case BlackmanWindow:
+        cosinewin(m_cache, 0.42, 0.50, 0.08, 0.0);
+	break;
+	    
+    case GaussianWindow:
+	for (i = 0; i < n; ++i) {
+            m_cache[i] *= pow(2, - pow((i - (n-1)/2.0) / ((n-1)/2.0 / 3), 2));
+	}
+	break;
+	    
+    case ParzenWindow:
+    {
+        int N = n-1;
+        for (i = 0; i < N/4; ++i) {
+            T m = 2 * pow(1.0 - (T(N)/2 - i) / (T(N)/2), 3);
+            m_cache[i] *= m;
+            m_cache[N-i] *= m;
+        }
+        for (i = N/4; i <= N/2; ++i) {
+            int wn = i - N/2;
+            T m = 1.0 - 6 * pow(wn / (T(N)/2), 2) * (1.0 - abs(wn) / (T(N)/2));
+            m_cache[i] *= m;
+            m_cache[N-i] *= m;
+        }            
+        break;
+    }
+
+    case NuttallWindow:
+        cosinewin(m_cache, 0.3635819, 0.4891775, 0.1365995, 0.0106411);
+	break;
+
+    case BlackmanHarrisWindow:
+        cosinewin(m_cache, 0.35875, 0.48829, 0.14128, 0.01168);
+        break;
+    }
+	
+    m_area = 0;
+    for (i = 0; i < n; ++i) {
+        m_area += m_cache[i];
+    }
+    m_area /= n;
+}
+
+template <typename T>
+void Window<T>::cosinewin(T *mult, T a0, T a1, T a2, T a3)
+{
+    int n = int(m_size);
+    for (int i = 0; i < n; ++i) {
+        mult[i] *= (a0
+                    - a1 * cos(2 * M_PI * i / n)
+                    + a2 * cos(4 * M_PI * i / n)
+                    - a3 * cos(6 * M_PI * i / n));
+    }
+}
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/float_cast/float_cast.h
+++ b/pedalboard/vendors/rubberband/src/float_cast/float_cast.h
@@ -1,0 +1,81 @@
+#ifndef ERIKD_FLOATCAST_H
+#define ERIKD_FLOATCAST_H
+
+/*
+** Copyright (C) 2001 Erik de Castro Lopo <erikd AT mega-nerd DOT com>
+**
+** Permission to use, copy, modify, distribute, and sell this file for any 
+** purpose is hereby granted without fee, provided that the above copyright 
+** and this permission notice appear in all copies.  No representations are
+** made about the suitability of this software for any purpose.  It is 
+** provided "as is" without express or implied warranty.
+*/
+
+/* Version 1.1 */
+
+
+/*============================================================================ 
+**	On Intel Pentium processors (especially PIII and probably P4), converting
+**	from float to int is very slow. To meet the C specs, the code produced by 
+**	most C compilers targeting Pentium needs to change the FPU rounding mode 
+**	before the float to int conversion is performed. 
+**
+**	Changing the FPU rounding mode causes the FPU pipeline to be flushed. It 
+**	is this flushing of the pipeline which is so slow.
+**
+**	Fortunately the ISO C99 specifications define the functions lrint, lrintf,
+**	llrint and llrintf which fix this problem as a side effect. 
+**
+**	On Unix-like systems, the configure process should have detected the 
+**	presence of these functions. If they weren't found we have to replace them 
+**	here with a standard C cast.
+*/
+
+/*	
+**	The C99 prototypes for lrint and lrintf are as follows:
+**	
+**		long int lrintf (float x) ;
+**		long int lrint  (double x) ;
+*/
+
+#if (defined (_WIN64))
+
+#include <math.h>
+__inline long int lrint(double flt) { return (long int)flt; }
+__inline long int lrintf(float flt) { return (long int)flt; }
+
+#elif (defined (WIN32) || defined (_WIN32))
+
+	#include	<math.h>
+
+	/*	Win32 doesn't seem to have these functions. 
+	**	Therefore implement inline versions of these functions here.
+	*/
+	
+	__inline long int 
+	lrint (double flt) 
+	{	int intgr;
+
+		_asm
+		{	fld flt
+			fistp intgr
+			} ;
+			
+		return intgr ;
+	} 
+	
+	__inline long int 
+	lrintf (float flt)
+	{	int intgr;
+
+		_asm
+		{	fld flt
+			fistp intgr
+			} ;
+			
+		return intgr ;
+	}
+
+#endif
+
+#endif

--- a/pedalboard/vendors/rubberband/src/getopt/getopt.c
+++ b/pedalboard/vendors/rubberband/src/getopt/getopt.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 1987, 1993, 1994
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *	This product includes software developed by the University of
+ *	California, Berkeley and its contributors.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int	opterr = 1,		/* if error message should be printed */
+	optind = 1,		/* index into parent argv vector */
+	optopt,			/* character checked for validity */
+	optreset;		/* reset getopt */
+char	*optarg;		/* argument associated with option */
+
+#define	BADCH	(int)'?'
+#define	BADARG	(int)':'
+#define	EMSG	""
+
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt(nargc, nargv, ostr)
+	int nargc;
+	char * const *nargv;
+	const char *ostr;
+{
+	static char *place = EMSG;		/* option letter processing */
+	char *oli;				/* option letter list index */
+
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc || *(place = nargv[optind]) != '-') {
+			place = EMSG;
+			return (-1);
+		}
+		if (place[1] && *++place == '-') {	/* found "--" */
+			++optind;
+			place = EMSG;
+			return (-1);
+		}
+	}					/* option letter okay? */
+	if ((optopt = (int)*place++) == (int)':' ||
+	    !(oli = strchr(ostr, optopt))) {
+		/*
+		 * if the user didn't specify '-' as an option,
+		 * assume it means -1.
+		 */
+		if (optopt == (int)'-')
+			return (-1);
+		if (!*place)
+			++optind;
+		if (opterr && *ostr != ':' && optopt != BADCH)
+			(void)fprintf(stderr, "%s: illegal option -- %c\n",
+			    "progname", optopt);
+		return (BADCH);
+	}
+	if (*++oli != ':') {			/* don't need argument */
+		optarg = NULL;
+		if (!*place)
+			++optind;
+	}
+	else {					/* need an argument */
+		if (*place)			/* no white space */
+			optarg = place;
+		else if (nargc <= ++optind) {	/* no arg */
+			place = EMSG;
+			if (*ostr == ':')
+				return (BADARG);
+			if (opterr)
+				(void)fprintf(stderr,
+				    "%s: option requires an argument -- %c\n",
+				    "progname", optopt);
+			return (BADCH);
+		}
+	 	else				/* white space */
+			optarg = nargv[optind];
+		place = EMSG;
+		++optind;
+	}
+	return (optopt);			/* dump back option letter */
+}

--- a/pedalboard/vendors/rubberband/src/getopt/getopt.h
+++ b/pedalboard/vendors/rubberband/src/getopt/getopt.h
@@ -1,0 +1,110 @@
+/*      $NetBSD: getopt.h,v 1.4 2000/07/07 10:43:54 ad Exp $    */
+/*      $FreeBSD: src/include/getopt.h,v 1.1 2002/09/29 04:14:30 eric Exp $ */
+
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *        This product includes software developed by the NetBSD
+ *        Foundation, Inc. and its contributors.
+ * 4. Neither the name of The NetBSD Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _GETOPT_H_
+#define _GETOPT_H_
+
+#ifdef _WIN32
+/* from <sys/cdefs.h> */
+# ifdef  __cplusplus
+#  define __BEGIN_DECLS  extern "C" {
+#  define __END_DECLS    }
+# else
+#  define __BEGIN_DECLS
+#  define __END_DECLS
+# endif
+# define __P(args)      args
+#endif
+
+/*#ifndef _WIN32
+#include <sys/cdefs.h>
+#include <unistd.h>
+#endif*/
+
+#ifdef _WIN32
+# if !defined(GETOPT_API)
+#  define GETOPT_API __declspec(dllimport)
+# endif
+#endif
+
+/*
+ * Gnu like getopt_long() and BSD4.4 getsubopt()/optreset extensions
+ */
+#if !defined(_POSIX_SOURCE) && !defined(_XOPEN_SOURCE)
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+struct option {
+        /* name of long option */
+        const char *name;
+        /*
+         * one of no_argument, required_argument, and optional_argument:
+         * whether option takes an argument
+         */
+        int has_arg;
+        /* if not NULL, set *flag to val when option found */
+        int *flag;
+        /* if flag not NULL, value to set *flag to; else return value */
+        int val;
+};
+
+__BEGIN_DECLS
+GETOPT_API int getopt_long __P((int, char * const *, const char *,
+    const struct option *, int *));
+__END_DECLS
+#endif
+
+#ifdef _WIN32
+/* These are global getopt variables */
+__BEGIN_DECLS
+
+GETOPT_API extern int   opterr,   /* if error message should be printed */
+                        optind,   /* index into parent argv vector */
+                        optopt,   /* character checked for validity */
+                        optreset; /* reset getopt */
+GETOPT_API extern char* optarg;   /* argument associated with option */
+
+/* Original getopt */
+GETOPT_API int getopt __P((int, char * const *, const char *));
+
+__END_DECLS
+#endif
+ 
+#endif /* !_GETOPT_H_ */

--- a/pedalboard/vendors/rubberband/src/getopt/getopt_long.c
+++ b/pedalboard/vendors/rubberband/src/getopt/getopt_long.c
@@ -1,0 +1,547 @@
+/*	$NetBSD: getopt_long.c,v 1.15 2002/01/31 22:43:40 tv Exp $	*/
+/*	$FreeBSD: src/lib/libc/stdlib/getopt_long.c,v 1.2 2002/10/16 22:18:42 alfred Exp $ */
+
+/*-
+ * Copyright (c) 2000 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Dieter Baron and Thomas Klausner.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *        This product includes software developed by the NetBSD
+ *        Foundation, Inc. and its contributors.
+ * 4. Neither the name of The NetBSD Foundation nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+
+/* Windows needs warnx().  We change the definition though:
+ *  1. (another) global is defined, opterrmsg, which holds the error message
+ *  2. errors are always printed out on stderr w/o the program name
+ * Note that opterrmsg always gets set no matter what opterr is set to.  The
+ * error message will not be printed if opterr is 0 as usual.
+ */
+
+#include "getopt.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+GETOPT_API extern char opterrmsg[128];
+char opterrmsg[128]; /* last error message is stored here */
+
+static void warnx(int print_error, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	if (fmt != NULL)
+		_vsnprintf(opterrmsg, 128, fmt, ap);
+	else
+		opterrmsg[0]='\0';
+	va_end(ap);
+	if (print_error) {
+		fprintf(stderr, opterrmsg);
+		fprintf(stderr, "\n");
+	}
+}
+
+#endif /*_WIN32*/
+
+/* not part of the original file */
+#ifndef _DIAGASSERT
+#define _DIAGASSERT(X)
+#endif
+
+#if HAVE_CONFIG_H && !HAVE_GETOPT_LONG && !HAVE_DECL_OPTIND
+#define REPLACE_GETOPT
+#endif
+
+#ifdef REPLACE_GETOPT
+#ifdef __weak_alias
+__weak_alias(getopt,_getopt)
+#endif
+int	opterr = 1;		/* if error message should be printed */
+int	optind = 1;		/* index into parent argv vector */
+int	optopt = '?';		/* character checked for validity */
+int	optreset;		/* reset getopt */
+char    *optarg;		/* argument associated with option */
+#elif HAVE_CONFIG_H && !HAVE_DECL_OPTRESET
+static int optreset;
+#endif
+
+#ifdef __weak_alias
+__weak_alias(getopt_long,_getopt_long)
+#endif
+
+#if !HAVE_GETOPT_LONG
+#define IGNORE_FIRST	(*options == '-' || *options == '+')
+#define PRINT_ERROR	((opterr) && ((*options != ':') \
+				      || (IGNORE_FIRST && options[1] != ':')))
+#define IS_POSIXLY_CORRECT (getenv("POSIXLY_CORRECT") != NULL)
+#define PERMUTE         (!IS_POSIXLY_CORRECT && !IGNORE_FIRST)
+/* XXX: GNU ignores PC if *options == '-' */
+#define IN_ORDER        (!IS_POSIXLY_CORRECT && *options == '-')
+
+/* return values */
+#define	BADCH	(int)'?'
+#define	BADARG		((IGNORE_FIRST && options[1] == ':') \
+			 || (*options == ':') ? (int)':' : (int)'?')
+#define INORDER (int)1
+
+#define	EMSG	""
+
+static int getopt_internal(int, char * const *, const char *);
+static int gcd(int, int);
+static void permute_args(int, int, int, char * const *);
+
+static char *place = EMSG; /* option letter processing */
+
+/* XXX: set optreset to 1 rather than these two */
+static int nonopt_start = -1; /* first non option argument (for permute) */
+static int nonopt_end = -1;   /* first option after non options (for permute) */
+
+/* Error messages */
+static const char recargchar[] = "option requires an argument -- %c";
+static const char recargstring[] = "option requires an argument -- %s";
+static const char ambig[] = "ambiguous option -- %.*s";
+static const char noarg[] = "option doesn't take an argument -- %.*s";
+static const char illoptchar[] = "unknown option -- %c";
+static const char illoptstring[] = "unknown option -- %s";
+
+
+/*
+ * Compute the greatest common divisor of a and b.
+ */
+static int
+gcd(a, b)
+	int a;
+	int b;
+{
+	int c;
+
+	c = a % b;
+	while (c != 0) {
+		a = b;
+		b = c;
+		c = a % b;
+	}
+	   
+	return b;
+}
+
+/*
+ * Exchange the block from nonopt_start to nonopt_end with the block
+ * from nonopt_end to opt_end (keeping the same order of arguments
+ * in each block).
+ */
+static void
+permute_args(panonopt_start, panonopt_end, opt_end, nargv)
+	int panonopt_start;
+	int panonopt_end;
+	int opt_end;
+	char * const *nargv;
+{
+	int cstart, cyclelen, i, j, ncycle, nnonopts, nopts, pos;
+	char *swap;
+
+	_DIAGASSERT(nargv != NULL);
+
+	/*
+	 * compute lengths of blocks and number and size of cycles
+	 */
+	nnonopts = panonopt_end - panonopt_start;
+	nopts = opt_end - panonopt_end;
+	ncycle = gcd(nnonopts, nopts);
+	cyclelen = (opt_end - panonopt_start) / ncycle;
+
+	for (i = 0; i < ncycle; i++) {
+		cstart = panonopt_end+i;
+		pos = cstart;
+		for (j = 0; j < cyclelen; j++) {
+			if (pos >= panonopt_end)
+				pos -= nnonopts;
+			else
+				pos += nopts;
+			swap = nargv[pos];
+			/* LINTED const cast */
+			((char **) nargv)[pos] = nargv[cstart];
+			/* LINTED const cast */
+			((char **)nargv)[cstart] = swap;
+		}
+	}
+}
+
+/*
+ * getopt_internal --
+ *	Parse argc/argv argument vector.  Called by user level routines.
+ *  Returns -2 if -- is found (can be long option or end of options marker).
+ */
+static int
+getopt_internal(nargc, nargv, options)
+	int nargc;
+	char * const *nargv;
+	const char *options;
+{
+	char *oli;				/* option letter list index */
+	int optchar;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	optarg = NULL;
+
+	/*
+	 * XXX Some programs (like rsyncd) expect to be able to
+	 * XXX re-initialize optind to 0 and have getopt_long(3)
+	 * XXX properly function again.  Work around this braindamage.
+	 */
+	if (optind == 0)
+		optind = 1;
+
+	if (optreset)
+		nonopt_start = nonopt_end = -1;
+start:
+	if (optreset || !*place) {		/* update scanning pointer */
+		optreset = 0;
+		if (optind >= nargc) {          /* end of argument vector */
+			place = EMSG;
+			if (nonopt_end != -1) {
+				/* do permutation, if we have to */
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			else if (nonopt_start != -1) {
+				/*
+				 * If we skipped non-options, set optind
+				 * to the first of them.
+				 */
+				optind = nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((*(place = nargv[optind]) != '-')
+		    || (place[1] == '\0')) {    /* found non-option */
+			place = EMSG;
+			if (IN_ORDER) {
+				/*
+				 * GNU extension: 
+				 * return non-option as argument to option 1
+				 */
+				optarg = nargv[optind++];
+				return INORDER;
+			}
+			if (!PERMUTE) {
+				/*
+				 * if no permutation wanted, stop parsing
+				 * at first non-option
+				 */
+				return -1;
+			}
+			/* do permutation */
+			if (nonopt_start == -1)
+				nonopt_start = optind;
+			else if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				nonopt_start = optind -
+				    (nonopt_end - nonopt_start);
+				nonopt_end = -1;
+			}
+			optind++;
+			/* process next argument */
+			goto start;
+		}
+		if (nonopt_start != -1 && nonopt_end == -1)
+			nonopt_end = optind;
+		if (place[1] && *++place == '-') {	/* found "--" */
+			place++;
+			return -2;
+		}
+	}
+	if ((optchar = (int)*place++) == (int)':' ||
+	    (oli = strchr(options + (IGNORE_FIRST ? 1 : 0), optchar)) == NULL) {
+		/* option letter unknown or ':' */
+		if (!*place)
+			++optind;
+#ifndef _WIN32
+		if (PRINT_ERROR)
+			warnx(illoptchar, optchar);
+#else
+			warnx(PRINT_ERROR, illoptchar, optchar);
+#endif
+		optopt = optchar;
+		return BADCH;
+	}
+	if (optchar == 'W' && oli[1] == ';') {		/* -W long-option */
+		/* XXX: what if no long options provided (called by getopt)? */
+		if (*place) 
+			return -2;
+
+		if (++optind >= nargc) {	/* no arg */
+			place = EMSG;
+#ifndef _WIN32
+			if (PRINT_ERROR)
+				warnx(recargchar, optchar);
+#else
+				warnx(PRINT_ERROR, recargchar, optchar);
+#endif
+			optopt = optchar;
+			return BADARG;
+		} else				/* white space */
+			place = nargv[optind];
+		/*
+		 * Handle -W arg the same as --arg (which causes getopt to
+		 * stop parsing).
+		 */
+		return -2;
+	}
+	if (*++oli != ':') {			/* doesn't take argument */
+		if (!*place)
+			++optind;
+	} else {				/* takes (optional) argument */
+		optarg = NULL;
+		if (*place)			/* no white space */
+			optarg = place;
+		/* XXX: disable test for :: if PC? (GNU doesn't) */
+		else if (oli[1] != ':') {	/* arg not optional */
+			if (++optind >= nargc) {	/* no arg */
+				place = EMSG;
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(recargchar, optchar);
+#else
+					warnx(PRINT_ERROR, recargchar, optchar);
+#endif
+				optopt = optchar;
+				return BADARG;
+			} else
+				optarg = nargv[optind];
+		}
+		place = EMSG;
+		++optind;
+	}
+	/* dump back option letter */
+	return optchar;
+}
+
+#ifdef REPLACE_GETOPT
+/*
+ * getopt --
+ *	Parse argc/argv argument vector.
+ *
+ * [eventually this will replace the real getopt]
+ */
+int
+getopt(nargc, nargv, options)
+	int nargc;
+	char * const *nargv;
+	const char *options;
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+
+	if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
+		++optind;
+		/*
+		 * We found an option (--), so if we skipped non-options,
+		 * we have to permute.
+		 */
+		if (nonopt_end != -1) {
+			permute_args(nonopt_start, nonopt_end, optind,
+				       nargv);
+			optind -= nonopt_end - nonopt_start;
+		}
+		nonopt_start = nonopt_end = -1;
+		retval = -1;
+	}
+	return retval;
+}
+#endif
+
+/*
+ * getopt_long --
+ *	Parse argc/argv argument vector.
+ */
+int
+getopt_long(nargc, nargv, options, long_options, idx)
+	int nargc;
+	char * const *nargv;
+	const char *options;
+	const struct option *long_options;
+	int *idx;
+{
+	int retval;
+
+	_DIAGASSERT(nargv != NULL);
+	_DIAGASSERT(options != NULL);
+	_DIAGASSERT(long_options != NULL);
+	/* idx may be NULL */
+
+	if ((retval = getopt_internal(nargc, nargv, options)) == -2) {
+		char *current_argv, *has_equal;
+		size_t current_argv_len;
+		int i, match;
+
+		current_argv = place;
+		match = -1;
+
+		optind++;
+		place = EMSG;
+
+		if (*current_argv == '\0') {		/* found "--" */
+			/*
+			 * We found an option (--), so if we skipped
+			 * non-options, we have to permute.
+			 */
+			if (nonopt_end != -1) {
+				permute_args(nonopt_start, nonopt_end,
+				    optind, nargv);
+				optind -= nonopt_end - nonopt_start;
+			}
+			nonopt_start = nonopt_end = -1;
+			return -1;
+		}
+		if ((has_equal = strchr(current_argv, '=')) != NULL) {
+			/* argument found (--option=arg) */
+			current_argv_len = has_equal - current_argv;
+			has_equal++;
+		} else
+			current_argv_len = strlen(current_argv);
+	    
+		for (i = 0; long_options[i].name; i++) {
+			/* find matching long option */
+			if (strncmp(current_argv, long_options[i].name,
+			    current_argv_len))
+				continue;
+
+			if (strlen(long_options[i].name) ==
+			    (unsigned)current_argv_len) {
+				/* exact match */
+				match = i;
+				break;
+			}
+			if (match == -1)		/* partial match */
+				match = i;
+			else {
+				/* ambiguous abbreviation */
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(ambig, (int)current_argv_len,
+					     current_argv);
+#else
+					warnx(PRINT_ERROR, ambig, (int)current_argv_len,
+					     current_argv);
+#endif
+				optopt = 0;
+				return BADCH;
+			}
+		}
+		if (match != -1) {			/* option found */
+		        if (long_options[match].has_arg == no_argument
+			    && has_equal) {
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(noarg, (int)current_argv_len,
+					     current_argv);
+#else
+					warnx(PRINT_ERROR, noarg, (int)current_argv_len,
+					     current_argv);
+#endif
+				/*
+				 * XXX: GNU sets optopt to val regardless of
+				 * flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				return BADARG;
+			}
+			if (long_options[match].has_arg == required_argument ||
+			    long_options[match].has_arg == optional_argument) {
+				if (has_equal)
+					optarg = has_equal;
+				else if (long_options[match].has_arg ==
+				    required_argument) {
+					/*
+					 * optional argument doesn't use
+					 * next nargv
+					 */
+					optarg = nargv[optind++];
+				}
+			}
+			if ((long_options[match].has_arg == required_argument)
+			    && (optarg == NULL)) {
+				/*
+				 * Missing argument; leading ':'
+				 * indicates no error should be generated
+				 */
+#ifndef _WIN32
+				if (PRINT_ERROR)
+					warnx(recargstring, current_argv);
+#else
+					warnx(PRINT_ERROR, recargstring, current_argv);
+#endif
+				/*
+				 * XXX: GNU sets optopt to val regardless
+				 * of flag
+				 */
+				if (long_options[match].flag == NULL)
+					optopt = long_options[match].val;
+				else
+					optopt = 0;
+				--optind;
+				return BADARG;
+			}
+		} else {			/* unknown option */
+#ifndef _WIN32
+			if (PRINT_ERROR)
+				warnx(illoptstring, current_argv);
+#else
+				warnx(PRINT_ERROR, illoptstring, current_argv);
+#endif
+			optopt = 0;
+			return BADCH;
+		}
+		if (long_options[match].flag) {
+			*long_options[match].flag = long_options[match].val;
+			retval = 0;
+		} else 
+			retval = long_options[match].val;
+		if (idx)
+			*idx = match;
+	}
+	return retval;
+}
+#endif /* !GETOPT_LONG */

--- a/pedalboard/vendors/rubberband/src/kissfft/COPYING
+++ b/pedalboard/vendors/rubberband/src/kissfft/COPYING
@@ -1,0 +1,11 @@
+Copyright (c) 2003-2010 Mark Borgerding . All rights reserved.
+
+KISS FFT is provided under:
+
+  SPDX-License-Identifier: BSD-3-Clause
+
+Being under the terms of the BSD 3-clause "New" or "Revised" License,
+according with:
+
+  LICENSES/BSD-3-Clause
+

--- a/pedalboard/vendors/rubberband/src/kissfft/_kiss_fft_guts.h
+++ b/pedalboard/vendors/rubberband/src/kissfft/_kiss_fft_guts.h
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+/* kiss_fft.h
+   defines kiss_fft_scalar as either short or a float type
+   and defines
+   typedef struct { kiss_fft_scalar r; kiss_fft_scalar i; }kiss_fft_cpx; */
+
+#ifndef _kiss_fft_guts_h
+#define _kiss_fft_guts_h
+
+#include "kiss_fft.h"
+#include "kiss_fft_log.h"
+#include <limits.h>
+
+#define MAXFACTORS 32
+/* e.g. an fft of length 128 has 4 factors
+ as far as kissfft is concerned
+ 4*4*4*2
+ */
+
+struct kiss_fft_state{
+    int nfft;
+    int inverse;
+    int factors[2*MAXFACTORS];
+    kiss_fft_cpx twiddles[1];
+};
+
+/*
+  Explanation of macros dealing with complex math:
+
+   C_MUL(m,a,b)         : m = a*b
+   C_FIXDIV( c , div )  : if a fixed point impl., c /= div. noop otherwise
+   C_SUB( res, a,b)     : res = a - b
+   C_SUBFROM( res , a)  : res -= a
+   C_ADDTO( res , a)    : res += a
+ * */
+#ifdef FIXED_POINT
+#include <stdint.h>
+#if (FIXED_POINT==32)
+# define FRACBITS 31
+# define SAMPPROD int64_t
+#define SAMP_MAX INT32_MAX
+#define SAMP_MIN INT32_MIN
+#else
+# define FRACBITS 15
+# define SAMPPROD int32_t
+#define SAMP_MAX INT16_MAX
+#define SAMP_MIN INT16_MIN
+#endif
+
+#if defined(CHECK_OVERFLOW)
+#  define CHECK_OVERFLOW_OP(a,op,b)  \
+    if ( (SAMPPROD)(a) op (SAMPPROD)(b) > SAMP_MAX || (SAMPPROD)(a) op (SAMPPROD)(b) < SAMP_MIN ) { \
+        KISS_FFT_WARNING("overflow (%d " #op" %d) = %ld", (a),(b),(SAMPPROD)(a) op (SAMPPROD)(b)); }
+#endif
+
+
+#   define smul(a,b) ( (SAMPPROD)(a)*(b) )
+#   define sround( x )  (kiss_fft_scalar)( ( (x) + (1<<(FRACBITS-1)) ) >> FRACBITS )
+
+#   define S_MUL(a,b) sround( smul(a,b) )
+
+#   define C_MUL(m,a,b) \
+      do{ (m).r = sround( smul((a).r,(b).r) - smul((a).i,(b).i) ); \
+          (m).i = sround( smul((a).r,(b).i) + smul((a).i,(b).r) ); }while(0)
+
+#   define DIVSCALAR(x,k) \
+    (x) = sround( smul(  x, SAMP_MAX/k ) )
+
+#   define C_FIXDIV(c,div) \
+    do {    DIVSCALAR( (c).r , div);  \
+        DIVSCALAR( (c).i  , div); }while (0)
+
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r =  sround( smul( (c).r , s ) ) ;\
+        (c).i =  sround( smul( (c).i , s ) ) ; }while(0)
+
+#else  /* not FIXED_POINT*/
+
+#   define S_MUL(a,b) ( (a)*(b) )
+#define C_MUL(m,a,b) \
+    do{ (m).r = (a).r*(b).r - (a).i*(b).i;\
+        (m).i = (a).r*(b).i + (a).i*(b).r; }while(0)
+#   define C_FIXDIV(c,div) /* NOOP */
+#   define C_MULBYSCALAR( c, s ) \
+    do{ (c).r *= (s);\
+        (c).i *= (s); }while(0)
+#endif
+
+#ifndef CHECK_OVERFLOW_OP
+#  define CHECK_OVERFLOW_OP(a,op,b) /* noop */
+#endif
+
+#define  C_ADD( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,+,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,+,(b).i)\
+        (res).r=(a).r+(b).r;  (res).i=(a).i+(b).i; \
+    }while(0)
+#define  C_SUB( res, a,b)\
+    do { \
+        CHECK_OVERFLOW_OP((a).r,-,(b).r)\
+        CHECK_OVERFLOW_OP((a).i,-,(b).i)\
+        (res).r=(a).r-(b).r;  (res).i=(a).i-(b).i; \
+    }while(0)
+#define C_ADDTO( res , a)\
+    do { \
+        CHECK_OVERFLOW_OP((res).r,+,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,+,(a).i)\
+        (res).r += (a).r;  (res).i += (a).i;\
+    }while(0)
+
+#define C_SUBFROM( res , a)\
+    do {\
+        CHECK_OVERFLOW_OP((res).r,-,(a).r)\
+        CHECK_OVERFLOW_OP((res).i,-,(a).i)\
+        (res).r -= (a).r;  (res).i -= (a).i; \
+    }while(0)
+
+
+#ifdef FIXED_POINT
+#  define KISS_FFT_COS(phase)  floor(.5+SAMP_MAX * cos (phase))
+#  define KISS_FFT_SIN(phase)  floor(.5+SAMP_MAX * sin (phase))
+#  define HALF_OF(x) ((x)>>1)
+#elif defined(USE_SIMD)
+#  define KISS_FFT_COS(phase) _mm_set1_ps( cos(phase) )
+#  define KISS_FFT_SIN(phase) _mm_set1_ps( sin(phase) )
+#  define HALF_OF(x) ((x)*_mm_set1_ps(.5))
+#else
+#  define KISS_FFT_COS(phase) (kiss_fft_scalar) cos(phase)
+#  define KISS_FFT_SIN(phase) (kiss_fft_scalar) sin(phase)
+#  define HALF_OF(x) ((x)*((kiss_fft_scalar).5))
+#endif
+
+#define  kf_cexp(x,phase) \
+    do{ \
+        (x)->r = KISS_FFT_COS(phase);\
+        (x)->i = KISS_FFT_SIN(phase);\
+    }while(0)
+
+
+/* a debugging function */
+#define pcpx(c)\
+    KISS_FFT_DEBUG("%g + %gi\n",(double)((c)->r),(double)((c)->i))
+
+
+#ifdef KISS_FFT_USE_ALLOCA
+// define this to allow use of alloca instead of malloc for temporary buffers
+// Temporary buffers are used in two case:
+// 1. FFT sizes that have "bad" factors. i.e. not 2,3 and 5
+// 2. "in-place" FFTs.  Notice the quotes, since kissfft does not really do an in-place transform.
+#include <alloca.h>
+#define  KISS_FFT_TMP_ALLOC(nbytes) alloca(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr)
+#else
+#define  KISS_FFT_TMP_ALLOC(nbytes) KISS_FFT_MALLOC(nbytes)
+#define  KISS_FFT_TMP_FREE(ptr) KISS_FFT_FREE(ptr)
+#endif
+
+#endif /* _kiss_fft_guts_h */
+

--- a/pedalboard/vendors/rubberband/src/kissfft/kiss_fft.c
+++ b/pedalboard/vendors/rubberband/src/kissfft/kiss_fft.c
@@ -1,0 +1,420 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+
+#include "_kiss_fft_guts.h"
+/* The guts header contains all the multiplication and addition macros that are defined for
+ fixed or floating point complex numbers.  It also delares the kf_ internal functions.
+ */
+
+static void kf_bfly2(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx * Fout2;
+    kiss_fft_cpx * tw1 = st->twiddles;
+    kiss_fft_cpx t;
+    Fout2 = Fout + m;
+    do{
+        C_FIXDIV(*Fout,2); C_FIXDIV(*Fout2,2);
+
+        C_MUL (t,  *Fout2 , *tw1);
+        tw1 += fstride;
+        C_SUB( *Fout2 ,  *Fout , t );
+        C_ADDTO( *Fout ,  t );
+        ++Fout2;
+        ++Fout;
+    }while (--m);
+}
+
+static void kf_bfly4(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        const size_t m
+        )
+{
+    kiss_fft_cpx *tw1,*tw2,*tw3;
+    kiss_fft_cpx scratch[6];
+    size_t k=m;
+    const size_t m2=2*m;
+    const size_t m3=3*m;
+
+
+    tw3 = tw2 = tw1 = st->twiddles;
+
+    do {
+        C_FIXDIV(*Fout,4); C_FIXDIV(Fout[m],4); C_FIXDIV(Fout[m2],4); C_FIXDIV(Fout[m3],4);
+
+        C_MUL(scratch[0],Fout[m] , *tw1 );
+        C_MUL(scratch[1],Fout[m2] , *tw2 );
+        C_MUL(scratch[2],Fout[m3] , *tw3 );
+
+        C_SUB( scratch[5] , *Fout, scratch[1] );
+        C_ADDTO(*Fout, scratch[1]);
+        C_ADD( scratch[3] , scratch[0] , scratch[2] );
+        C_SUB( scratch[4] , scratch[0] , scratch[2] );
+        C_SUB( Fout[m2], *Fout, scratch[3] );
+        tw1 += fstride;
+        tw2 += fstride*2;
+        tw3 += fstride*3;
+        C_ADDTO( *Fout , scratch[3] );
+
+        if(st->inverse) {
+            Fout[m].r = scratch[5].r - scratch[4].i;
+            Fout[m].i = scratch[5].i + scratch[4].r;
+            Fout[m3].r = scratch[5].r + scratch[4].i;
+            Fout[m3].i = scratch[5].i - scratch[4].r;
+        }else{
+            Fout[m].r = scratch[5].r + scratch[4].i;
+            Fout[m].i = scratch[5].i - scratch[4].r;
+            Fout[m3].r = scratch[5].r - scratch[4].i;
+            Fout[m3].i = scratch[5].i + scratch[4].r;
+        }
+        ++Fout;
+    }while(--k);
+}
+
+static void kf_bfly3(
+         kiss_fft_cpx * Fout,
+         const size_t fstride,
+         const kiss_fft_cfg st,
+         size_t m
+         )
+{
+     size_t k=m;
+     const size_t m2 = 2*m;
+     kiss_fft_cpx *tw1,*tw2;
+     kiss_fft_cpx scratch[5];
+     kiss_fft_cpx epi3;
+     epi3 = st->twiddles[fstride*m];
+
+     tw1=tw2=st->twiddles;
+
+     do{
+         C_FIXDIV(*Fout,3); C_FIXDIV(Fout[m],3); C_FIXDIV(Fout[m2],3);
+
+         C_MUL(scratch[1],Fout[m] , *tw1);
+         C_MUL(scratch[2],Fout[m2] , *tw2);
+
+         C_ADD(scratch[3],scratch[1],scratch[2]);
+         C_SUB(scratch[0],scratch[1],scratch[2]);
+         tw1 += fstride;
+         tw2 += fstride*2;
+
+         Fout[m].r = Fout->r - HALF_OF(scratch[3].r);
+         Fout[m].i = Fout->i - HALF_OF(scratch[3].i);
+
+         C_MULBYSCALAR( scratch[0] , epi3.i );
+
+         C_ADDTO(*Fout,scratch[3]);
+
+         Fout[m2].r = Fout[m].r + scratch[0].i;
+         Fout[m2].i = Fout[m].i - scratch[0].r;
+
+         Fout[m].r -= scratch[0].i;
+         Fout[m].i += scratch[0].r;
+
+         ++Fout;
+     }while(--k);
+}
+
+static void kf_bfly5(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m
+        )
+{
+    kiss_fft_cpx *Fout0,*Fout1,*Fout2,*Fout3,*Fout4;
+    int u;
+    kiss_fft_cpx scratch[13];
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx *tw;
+    kiss_fft_cpx ya,yb;
+    ya = twiddles[fstride*m];
+    yb = twiddles[fstride*2*m];
+
+    Fout0=Fout;
+    Fout1=Fout0+m;
+    Fout2=Fout0+2*m;
+    Fout3=Fout0+3*m;
+    Fout4=Fout0+4*m;
+
+    tw=st->twiddles;
+    for ( u=0; u<m; ++u ) {
+        C_FIXDIV( *Fout0,5); C_FIXDIV( *Fout1,5); C_FIXDIV( *Fout2,5); C_FIXDIV( *Fout3,5); C_FIXDIV( *Fout4,5);
+        scratch[0] = *Fout0;
+
+        C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[2*u*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[3*u*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[4*u*fstride]);
+
+        C_ADD( scratch[7],scratch[1],scratch[4]);
+        C_SUB( scratch[10],scratch[1],scratch[4]);
+        C_ADD( scratch[8],scratch[2],scratch[3]);
+        C_SUB( scratch[9],scratch[2],scratch[3]);
+
+        Fout0->r += scratch[7].r + scratch[8].r;
+        Fout0->i += scratch[7].i + scratch[8].i;
+
+        scratch[5].r = scratch[0].r + S_MUL(scratch[7].r,ya.r) + S_MUL(scratch[8].r,yb.r);
+        scratch[5].i = scratch[0].i + S_MUL(scratch[7].i,ya.r) + S_MUL(scratch[8].i,yb.r);
+
+        scratch[6].r =  S_MUL(scratch[10].i,ya.i) + S_MUL(scratch[9].i,yb.i);
+        scratch[6].i = -S_MUL(scratch[10].r,ya.i) - S_MUL(scratch[9].r,yb.i);
+
+        C_SUB(*Fout1,scratch[5],scratch[6]);
+        C_ADD(*Fout4,scratch[5],scratch[6]);
+
+        scratch[11].r = scratch[0].r + S_MUL(scratch[7].r,yb.r) + S_MUL(scratch[8].r,ya.r);
+        scratch[11].i = scratch[0].i + S_MUL(scratch[7].i,yb.r) + S_MUL(scratch[8].i,ya.r);
+        scratch[12].r = - S_MUL(scratch[10].i,yb.i) + S_MUL(scratch[9].i,ya.i);
+        scratch[12].i = S_MUL(scratch[10].r,yb.i) - S_MUL(scratch[9].r,ya.i);
+
+        C_ADD(*Fout2,scratch[11],scratch[12]);
+        C_SUB(*Fout3,scratch[11],scratch[12]);
+
+        ++Fout0;++Fout1;++Fout2;++Fout3;++Fout4;
+    }
+}
+
+/* perform the butterfly for one stage of a mixed radix FFT */
+static void kf_bfly_generic(
+        kiss_fft_cpx * Fout,
+        const size_t fstride,
+        const kiss_fft_cfg st,
+        int m,
+        int p
+        )
+{
+    int u,k,q1,q;
+    kiss_fft_cpx * twiddles = st->twiddles;
+    kiss_fft_cpx t;
+    int Norig = st->nfft;
+
+    kiss_fft_cpx * scratch = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC(sizeof(kiss_fft_cpx)*p);
+    if (scratch == NULL){
+        KISS_FFT_ERROR("Memory allocation failed.");
+        return;
+    }
+
+    for ( u=0; u<m; ++u ) {
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            scratch[q1] = Fout[ k  ];
+            C_FIXDIV(scratch[q1],p);
+            k += m;
+        }
+
+        k=u;
+        for ( q1=0 ; q1<p ; ++q1 ) {
+            int twidx=0;
+            Fout[ k ] = scratch[0];
+            for (q=1;q<p;++q ) {
+                twidx += fstride * k;
+                if (twidx>=Norig) twidx-=Norig;
+                C_MUL(t,scratch[q] , twiddles[twidx] );
+                C_ADDTO( Fout[ k ] ,t);
+            }
+            k += m;
+        }
+    }
+    KISS_FFT_TMP_FREE(scratch);
+}
+
+static
+void kf_work(
+        kiss_fft_cpx * Fout,
+        const kiss_fft_cpx * f,
+        const size_t fstride,
+        int in_stride,
+        int * factors,
+        const kiss_fft_cfg st
+        )
+{
+    kiss_fft_cpx * Fout_beg=Fout;
+    const int p=*factors++; /* the radix  */
+    const int m=*factors++; /* stage's fft length/p */
+    const kiss_fft_cpx * Fout_end = Fout + p*m;
+
+#ifdef _OPENMP
+    // use openmp extensions at the
+    // top-level (not recursive)
+    if (fstride==1 && p<=5 && m!=1)
+    {
+        int k;
+
+        // execute the p different work units in different threads
+#       pragma omp parallel for
+        for (k=0;k<p;++k)
+            kf_work( Fout +k*m, f+ fstride*in_stride*k,fstride*p,in_stride,factors,st);
+        // all threads have joined by this point
+
+        switch (p) {
+            case 2: kf_bfly2(Fout,fstride,st,m); break;
+            case 3: kf_bfly3(Fout,fstride,st,m); break;
+            case 4: kf_bfly4(Fout,fstride,st,m); break;
+            case 5: kf_bfly5(Fout,fstride,st,m); break;
+            default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+        }
+        return;
+    }
+#endif
+
+    if (m==1) {
+        do{
+            *Fout = *f;
+            f += fstride*in_stride;
+        }while(++Fout != Fout_end );
+    }else{
+        do{
+            // recursive call:
+            // DFT of size m*p performed by doing
+            // p instances of smaller DFTs of size m,
+            // each one takes a decimated version of the input
+            kf_work( Fout , f, fstride*p, in_stride, factors,st);
+            f += fstride*in_stride;
+        }while( (Fout += m) != Fout_end );
+    }
+
+    Fout=Fout_beg;
+
+    // recombine the p smaller DFTs
+    switch (p) {
+        case 2: kf_bfly2(Fout,fstride,st,m); break;
+        case 3: kf_bfly3(Fout,fstride,st,m); break;
+        case 4: kf_bfly4(Fout,fstride,st,m); break;
+        case 5: kf_bfly5(Fout,fstride,st,m); break;
+        default: kf_bfly_generic(Fout,fstride,st,m,p); break;
+    }
+}
+
+/*  facbuf is populated by p1,m1,p2,m2, ...
+    where
+    p[i] * m[i] = m[i-1]
+    m0 = n                  */
+static
+void kf_factor(int n,int * facbuf)
+{
+    int p=4;
+    double floor_sqrt;
+    floor_sqrt = floor( sqrt((double)n) );
+
+    /*factor out powers of 4, powers of 2, then any remaining primes */
+    do {
+        while (n % p) {
+            switch (p) {
+                case 4: p = 2; break;
+                case 2: p = 3; break;
+                default: p += 2; break;
+            }
+            if (p > floor_sqrt)
+                p = n;          /* no more factors, skip to end */
+        }
+        n /= p;
+        *facbuf++ = p;
+        *facbuf++ = n;
+    } while (n > 1);
+}
+
+/*
+ *
+ * User-callable function to allocate all necessary storage space for the fft.
+ *
+ * The return value is a contiguous block of memory, allocated with malloc.  As such,
+ * It can be freed with free(), rather than a kiss_fft-specific function.
+ * */
+kiss_fft_cfg kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem )
+{
+    KISS_FFT_ALIGN_CHECK(mem)
+
+    kiss_fft_cfg st=NULL;
+    size_t memneeded = KISS_FFT_ALIGN_SIZE_UP(sizeof(struct kiss_fft_state)
+        + sizeof(kiss_fft_cpx)*(nfft-1)); /* twiddle factors*/
+
+    if ( lenmem==NULL ) {
+        st = ( kiss_fft_cfg)KISS_FFT_MALLOC( memneeded );
+    }else{
+        if (mem != NULL && *lenmem >= memneeded)
+            st = (kiss_fft_cfg)mem;
+        *lenmem = memneeded;
+    }
+    if (st) {
+        int i;
+        st->nfft=nfft;
+        st->inverse = inverse_fft;
+
+        for (i=0;i<nfft;++i) {
+            const double pi=3.141592653589793238462643383279502884197169399375105820974944;
+            double phase = -2*pi*i / nfft;
+            if (st->inverse)
+                phase *= -1;
+            kf_cexp(st->twiddles+i, phase );
+        }
+
+        kf_factor(nfft,st->factors);
+    }
+    return st;
+}
+
+
+void kiss_fft_stride(kiss_fft_cfg st,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int in_stride)
+{
+    if (fin == fout) {
+        //NOTE: this is not really an in-place FFT algorithm.
+        //It just performs an out-of-place FFT into a temp buffer
+        if (fout == NULL){
+            KISS_FFT_ERROR("fout buffer NULL.");
+        return;
+        }
+
+        kiss_fft_cpx * tmpbuf = (kiss_fft_cpx*)KISS_FFT_TMP_ALLOC( sizeof(kiss_fft_cpx)*st->nfft);
+        if (tmpbuf == NULL){
+            KISS_FFT_ERROR("Memory allocation error.");
+        return;
+        }
+
+
+
+        kf_work(tmpbuf,fin,1,in_stride, st->factors,st);
+        memcpy(fout,tmpbuf,sizeof(kiss_fft_cpx)*st->nfft);
+        KISS_FFT_TMP_FREE(tmpbuf);
+    }else{
+        kf_work( fout, fin, 1,in_stride, st->factors,st );
+    }
+}
+
+void kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout)
+{
+    kiss_fft_stride(cfg,fin,fout,1);
+}
+
+
+void kiss_fft_cleanup(void)
+{
+    // nothing needed any more
+}
+
+int kiss_fft_next_fast_size(int n)
+{
+    while(1) {
+        int m=n;
+        while ( (m%2) == 0 ) m/=2;
+        while ( (m%3) == 0 ) m/=3;
+        while ( (m%5) == 0 ) m/=5;
+        if (m<=1)
+            break; /* n is completely factorable by twos, threes, and fives */
+        n++;
+    }
+    return n;
+}

--- a/pedalboard/vendors/rubberband/src/kissfft/kiss_fft.h
+++ b/pedalboard/vendors/rubberband/src/kissfft/kiss_fft.h
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FFT_H
+#define KISS_FFT_H
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+// Define KISS_FFT_SHARED macro to properly export symbols
+#ifdef KISS_FFT_SHARED
+# ifdef _WIN32
+#  ifdef KISS_FFT_BUILD
+#   define KISS_FFT_API __declspec(dllexport)
+#  else
+#   define KISS_FFT_API __declspec(dllimport)
+#  endif
+# else
+#  define KISS_FFT_API __attribute__ ((visibility ("default")))
+# endif
+#else
+# define KISS_FFT_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ATTENTION!
+ If you would like a :
+ -- a utility that will handle the caching of fft objects
+ -- real-only (no imaginary time component ) FFT
+ -- a multi-dimensional FFT
+ -- a command-line utility to perform ffts
+ -- a command-line utility to perform fast-convolution filtering
+
+ Then see kfc.h kiss_fftr.h kiss_fftnd.h fftutil.c kiss_fastfir.c
+  in the tools/ directory.
+*/
+
+/* User may override KISS_FFT_MALLOC and/or KISS_FFT_FREE. */
+#ifdef USE_SIMD
+# include <xmmintrin.h>
+# define kiss_fft_scalar __m128
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC(nbytes) _mm_malloc(nbytes,16)
+#  define KISS_FFT_ALIGN_CHECK(ptr) 
+#  define KISS_FFT_ALIGN_SIZE_UP(size) ((size + 15UL) & ~0xFUL)
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE _mm_free
+# endif
+#else
+# define KISS_FFT_ALIGN_CHECK(ptr)
+# define KISS_FFT_ALIGN_SIZE_UP(size) (size)
+# ifndef KISS_FFT_MALLOC
+#  define KISS_FFT_MALLOC malloc
+# endif
+# ifndef KISS_FFT_FREE
+#  define KISS_FFT_FREE free
+# endif
+#endif
+
+
+#ifdef FIXED_POINT
+#include <stdint.h>
+# if (FIXED_POINT == 32)
+#  define kiss_fft_scalar int32_t
+# else	
+#  define kiss_fft_scalar int16_t
+# endif
+#else
+# ifndef kiss_fft_scalar
+/*  default is float */
+#   define kiss_fft_scalar float
+# endif
+#endif
+
+typedef struct {
+    kiss_fft_scalar r;
+    kiss_fft_scalar i;
+}kiss_fft_cpx;
+
+typedef struct kiss_fft_state* kiss_fft_cfg;
+
+/* 
+ *  kiss_fft_alloc
+ *  
+ *  Initialize a FFT (or IFFT) algorithm's cfg/state buffer.
+ *
+ *  typical usage:      kiss_fft_cfg mycfg=kiss_fft_alloc(1024,0,NULL,NULL);
+ *
+ *  The return value from fft_alloc is a cfg buffer used internally
+ *  by the fft routine or NULL.
+ *
+ *  If lenmem is NULL, then kiss_fft_alloc will allocate a cfg buffer using malloc.
+ *  The returned value should be free()d when done to avoid memory leaks.
+ *  
+ *  The state can be placed in a user supplied buffer 'mem':
+ *  If lenmem is not NULL and mem is not NULL and *lenmem is large enough,
+ *      then the function places the cfg in mem and the size used in *lenmem
+ *      and returns mem.
+ *  
+ *  If lenmem is not NULL and ( mem is NULL or *lenmem is not large enough),
+ *      then the function returns NULL and places the minimum cfg 
+ *      buffer size in *lenmem.
+ * */
+
+kiss_fft_cfg KISS_FFT_API kiss_fft_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem);
+
+/*
+ * kiss_fft(cfg,in_out_buf)
+ *
+ * Perform an FFT on a complex input buffer.
+ * for a forward FFT,
+ * fin should be  f[0] , f[1] , ... ,f[nfft-1]
+ * fout will be   F[0] , F[1] , ... ,F[nfft-1]
+ * Note that each element is complex and can be accessed like
+    f[k].r and f[k].i
+ * */
+void KISS_FFT_API kiss_fft(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout);
+
+/*
+ A more generic version of the above function. It reads its input from every Nth sample.
+ * */
+void KISS_FFT_API kiss_fft_stride(kiss_fft_cfg cfg,const kiss_fft_cpx *fin,kiss_fft_cpx *fout,int fin_stride);
+
+/* If kiss_fft_alloc allocated a buffer, it is one contiguous 
+   buffer and can be simply free()d when no longer needed*/
+#define kiss_fft_free KISS_FFT_FREE
+
+/*
+ Cleans up some memory that gets managed internally. Not necessary to call, but it might clean up 
+ your compiler output to call this before you exit.
+*/
+void KISS_FFT_API kiss_fft_cleanup(void);
+	
+
+/*
+ * Returns the smallest integer k, such that k>=n and k has only "fast" factors (2,3,5)
+ */
+int KISS_FFT_API kiss_fft_next_fast_size(int n);
+
+/* for real ffts, we need an even size */
+#define kiss_fftr_next_fast_size_real(n) \
+        (kiss_fft_next_fast_size( ((n)+1)>>1)<<1)
+
+#ifdef __cplusplus
+} 
+#endif
+
+#endif

--- a/pedalboard/vendors/rubberband/src/kissfft/kiss_fft_log.h
+++ b/pedalboard/vendors/rubberband/src/kissfft/kiss_fft_log.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef kiss_fft_log_h
+#define kiss_fft_log_h
+
+#define ERROR 1
+#define WARNING 2
+#define INFO 3
+#define DEBUG 4
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+
+#if defined(NDEBUG)
+# define KISS_FFT_LOG_MSG(severity, ...) ((void)0)
+#else
+# define KISS_FFT_LOG_MSG(severity, ...) \
+    fprintf(stderr, "[" #severity "] " __FILE__ ":" TOSTRING(__LINE__) " "); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n")
+#endif
+
+#define KISS_FFT_ERROR(...) KISS_FFT_LOG_MSG(ERROR, __VA_ARGS__)
+#define KISS_FFT_WARNING(...) KISS_FFT_LOG_MSG(WARNING, __VA_ARGS__)
+#define KISS_FFT_INFO(...) KISS_FFT_LOG_MSG(INFO, __VA_ARGS__)
+#define KISS_FFT_DEBUG(...) KISS_FFT_LOG_MSG(DEBUG, __VA_ARGS__)
+
+
+
+#endif /* kiss_fft_log_h */

--- a/pedalboard/vendors/rubberband/src/kissfft/kiss_fftr.c
+++ b/pedalboard/vendors/rubberband/src/kissfft/kiss_fftr.c
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2003-2004, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#include "kiss_fftr.h"
+#include "_kiss_fft_guts.h"
+
+struct kiss_fftr_state{
+    kiss_fft_cfg substate;
+    kiss_fft_cpx * tmpbuf;
+    kiss_fft_cpx * super_twiddles;
+#ifdef USE_SIMD
+    void * pad;
+#endif
+};
+
+kiss_fftr_cfg kiss_fftr_alloc(int nfft,int inverse_fft,void * mem,size_t * lenmem)
+{
+	KISS_FFT_ALIGN_CHECK(mem)
+
+    int i;
+    kiss_fftr_cfg st = NULL;
+    size_t subsize = 0, memneeded;
+
+    if (nfft & 1) {
+        KISS_FFT_ERROR("Real FFT optimization must be even.");
+        return NULL;
+    }
+    nfft >>= 1;
+
+    kiss_fft_alloc (nfft, inverse_fft, NULL, &subsize);
+    memneeded = sizeof(struct kiss_fftr_state) + subsize + sizeof(kiss_fft_cpx) * ( nfft * 3 / 2);
+
+    if (lenmem == NULL) {
+        st = (kiss_fftr_cfg) KISS_FFT_MALLOC (memneeded);
+    } else {
+        if (*lenmem >= memneeded)
+            st = (kiss_fftr_cfg) mem;
+        *lenmem = memneeded;
+    }
+    if (!st)
+        return NULL;
+
+    st->substate = (kiss_fft_cfg) (st + 1); /*just beyond kiss_fftr_state struct */
+    st->tmpbuf = (kiss_fft_cpx *) (((char *) st->substate) + subsize);
+    st->super_twiddles = st->tmpbuf + nfft;
+    kiss_fft_alloc(nfft, inverse_fft, st->substate, &subsize);
+
+    for (i = 0; i < nfft/2; ++i) {
+        double phase =
+            -3.14159265358979323846264338327 * ((double) (i+1) / nfft + .5);
+        if (inverse_fft)
+            phase *= -1;
+        kf_cexp (st->super_twiddles+i,phase);
+    }
+    return st;
+}
+
+void kiss_fftr(kiss_fftr_cfg st,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k,ncfft;
+    kiss_fft_cpx fpnk,fpk,f1k,f2k,tw,tdc;
+
+    if ( st->substate->inverse) {
+        KISS_FFT_ERROR("kiss fft usage error: improper alloc");
+        return;/* The caller did not call the correct function */
+    }
+
+    ncfft = st->substate->nfft;
+
+    /*perform the parallel fft of two real signals packed in real,imag*/
+    kiss_fft( st->substate , (const kiss_fft_cpx*)timedata, st->tmpbuf );
+    /* The real part of the DC element of the frequency spectrum in st->tmpbuf
+     * contains the sum of the even-numbered elements of the input time sequence
+     * The imag part is the sum of the odd-numbered elements
+     *
+     * The sum of tdc.r and tdc.i is the sum of the input time sequence.
+     *      yielding DC of input time sequence
+     * The difference of tdc.r - tdc.i is the sum of the input (dot product) [1,-1,1,-1...
+     *      yielding Nyquist bin of input time sequence
+     */
+
+    tdc.r = st->tmpbuf[0].r;
+    tdc.i = st->tmpbuf[0].i;
+    C_FIXDIV(tdc,2);
+    CHECK_OVERFLOW_OP(tdc.r ,+, tdc.i);
+    CHECK_OVERFLOW_OP(tdc.r ,-, tdc.i);
+    freqdata[0].r = tdc.r + tdc.i;
+    freqdata[ncfft].r = tdc.r - tdc.i;
+#ifdef USE_SIMD
+    freqdata[ncfft].i = freqdata[0].i = _mm_set1_ps(0);
+#else
+    freqdata[ncfft].i = freqdata[0].i = 0;
+#endif
+
+    for ( k=1;k <= ncfft/2 ; ++k ) {
+        fpk    = st->tmpbuf[k];
+        fpnk.r =   st->tmpbuf[ncfft-k].r;
+        fpnk.i = - st->tmpbuf[ncfft-k].i;
+        C_FIXDIV(fpk,2);
+        C_FIXDIV(fpnk,2);
+
+        C_ADD( f1k, fpk , fpnk );
+        C_SUB( f2k, fpk , fpnk );
+        C_MUL( tw , f2k , st->super_twiddles[k-1]);
+
+        freqdata[k].r = HALF_OF(f1k.r + tw.r);
+        freqdata[k].i = HALF_OF(f1k.i + tw.i);
+        freqdata[ncfft-k].r = HALF_OF(f1k.r - tw.r);
+        freqdata[ncfft-k].i = HALF_OF(tw.i - f1k.i);
+    }
+}
+
+void kiss_fftri(kiss_fftr_cfg st,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata)
+{
+    /* input buffer timedata is stored row-wise */
+    int k, ncfft;
+
+    if (st->substate->inverse == 0) {
+        KISS_FFT_ERROR("kiss fft usage error: improper alloc");
+        return;/* The caller did not call the correct function */
+    }
+
+    ncfft = st->substate->nfft;
+
+    st->tmpbuf[0].r = freqdata[0].r + freqdata[ncfft].r;
+    st->tmpbuf[0].i = freqdata[0].r - freqdata[ncfft].r;
+    C_FIXDIV(st->tmpbuf[0],2);
+
+    for (k = 1; k <= ncfft / 2; ++k) {
+        kiss_fft_cpx fk, fnkc, fek, fok, tmp;
+        fk = freqdata[k];
+        fnkc.r = freqdata[ncfft - k].r;
+        fnkc.i = -freqdata[ncfft - k].i;
+        C_FIXDIV( fk , 2 );
+        C_FIXDIV( fnkc , 2 );
+
+        C_ADD (fek, fk, fnkc);
+        C_SUB (tmp, fk, fnkc);
+        C_MUL (fok, tmp, st->super_twiddles[k-1]);
+        C_ADD (st->tmpbuf[k],     fek, fok);
+        C_SUB (st->tmpbuf[ncfft - k], fek, fok);
+#ifdef USE_SIMD
+        st->tmpbuf[ncfft - k].i *= _mm_set1_ps(-1.0);
+#else
+        st->tmpbuf[ncfft - k].i *= -1;
+#endif
+    }
+    kiss_fft (st->substate, st->tmpbuf, (kiss_fft_cpx *) timedata);
+}

--- a/pedalboard/vendors/rubberband/src/kissfft/kiss_fftr.h
+++ b/pedalboard/vendors/rubberband/src/kissfft/kiss_fftr.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2003-2004, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See COPYING file for more information.
+ */
+
+#ifndef KISS_FTR_H
+#define KISS_FTR_H
+
+#include "kiss_fft.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    
+/* 
+ 
+ Real optimized version can save about 45% cpu time vs. complex fft of a real seq.
+
+ 
+ 
+ */
+
+typedef struct kiss_fftr_state *kiss_fftr_cfg;
+
+
+kiss_fftr_cfg KISS_FFT_API kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);
+/*
+ nfft must be even
+
+ If you don't care to allocate space, use mem = lenmem = NULL 
+*/
+
+
+void KISS_FFT_API kiss_fftr(kiss_fftr_cfg cfg,const kiss_fft_scalar *timedata,kiss_fft_cpx *freqdata);
+/*
+ input timedata has nfft scalar points
+ output freqdata has nfft/2+1 complex points
+*/
+
+void KISS_FFT_API kiss_fftri(kiss_fftr_cfg cfg,const kiss_fft_cpx *freqdata,kiss_fft_scalar *timedata);
+/*
+ input freqdata has  nfft/2+1 complex points
+ output timedata has nfft scalar points
+*/
+
+#define kiss_fftr_free KISS_FFT_FREE
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/pedalboard/vendors/rubberband/src/pommier/neon_mathfun.h
+++ b/pedalboard/vendors/rubberband/src/pommier/neon_mathfun.h
@@ -1,0 +1,301 @@
+/* NEON implementation of sin, cos, exp and log
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library
+*/
+
+/* Copyright (C) 2011  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#include <arm_neon.h>
+
+typedef float32x4_t v4sf;  // vector of 4 float
+typedef uint32x4_t v4su;  // vector of 4 uint32
+typedef int32x4_t v4si;  // vector of 4 uint32
+
+#define c_inv_mant_mask ~0x7f800000u
+#define c_cephes_SQRTHF 0.707106781186547524
+#define c_cephes_log_p0 7.0376836292E-2
+#define c_cephes_log_p1 - 1.1514610310E-1
+#define c_cephes_log_p2 1.1676998740E-1
+#define c_cephes_log_p3 - 1.2420140846E-1
+#define c_cephes_log_p4 + 1.4249322787E-1
+#define c_cephes_log_p5 - 1.6668057665E-1
+#define c_cephes_log_p6 + 2.0000714765E-1
+#define c_cephes_log_p7 - 2.4999993993E-1
+#define c_cephes_log_p8 + 3.3333331174E-1
+#define c_cephes_log_q1 -2.12194440e-4
+#define c_cephes_log_q2 0.693359375
+
+/* natural logarithm computed for 4 simultaneous float 
+   return NaN for x <= 0
+*/
+v4sf log_ps(v4sf x) {
+  v4sf one = vdupq_n_f32(1);
+
+  x = vmaxq_f32(x, vdupq_n_f32(0)); /* force flush to zero on denormal values */
+  v4su invalid_mask = vcleq_f32(x, vdupq_n_f32(0));
+
+  v4si ux = vreinterpretq_s32_f32(x);
+  
+  v4si emm0 = vshrq_n_s32(ux, 23);
+
+  /* keep only the fractional part */
+  ux = vandq_s32(ux, vdupq_n_s32(c_inv_mant_mask));
+  ux = vorrq_s32(ux, vreinterpretq_s32_f32(vdupq_n_f32(0.5f)));
+  x = vreinterpretq_f32_s32(ux);
+
+  emm0 = vsubq_s32(emm0, vdupq_n_s32(0x7f));
+  v4sf e = vcvtq_f32_s32(emm0);
+
+  e = vaddq_f32(e, one);
+
+  /* part2: 
+     if( x < SQRTHF ) {
+       e -= 1;
+       x = x + x - 1.0;
+     } else { x = x - 1.0; }
+  */
+  v4su mask = vcltq_f32(x, vdupq_n_f32(c_cephes_SQRTHF));
+  v4sf tmp = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(x), mask));
+  x = vsubq_f32(x, one);
+  e = vsubq_f32(e, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(one), mask)));
+  x = vaddq_f32(x, tmp);
+
+  v4sf z = vmulq_f32(x,x);
+
+  v4sf y = vdupq_n_f32(c_cephes_log_p0);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p1));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p2));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p3));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p4));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p5));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p6));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p7));
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, vdupq_n_f32(c_cephes_log_p8));
+  y = vmulq_f32(y, x);
+
+  y = vmulq_f32(y, z);
+  
+
+  tmp = vmulq_f32(e, vdupq_n_f32(c_cephes_log_q1));
+  y = vaddq_f32(y, tmp);
+
+
+  tmp = vmulq_f32(z, vdupq_n_f32(0.5f));
+  y = vsubq_f32(y, tmp);
+
+  tmp = vmulq_f32(e, vdupq_n_f32(c_cephes_log_q2));
+  x = vaddq_f32(x, y);
+  x = vaddq_f32(x, tmp);
+  x = vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(x), invalid_mask)); // negative arg will be NAN
+  return x;
+}
+
+#define c_exp_hi 88.3762626647949f
+#define c_exp_lo -88.3762626647949f
+
+#define c_cephes_LOG2EF 1.44269504088896341
+#define c_cephes_exp_C1 0.693359375
+#define c_cephes_exp_C2 -2.12194440e-4
+
+#define c_cephes_exp_p0 1.9875691500E-4
+#define c_cephes_exp_p1 1.3981999507E-3
+#define c_cephes_exp_p2 8.3334519073E-3
+#define c_cephes_exp_p3 4.1665795894E-2
+#define c_cephes_exp_p4 1.6666665459E-1
+#define c_cephes_exp_p5 5.0000001201E-1
+
+/* exp() computed for 4 float at once */
+v4sf exp_ps(v4sf x) {
+  v4sf tmp, fx;
+
+  v4sf one = vdupq_n_f32(1);
+  x = vminq_f32(x, vdupq_n_f32(c_exp_hi));
+  x = vmaxq_f32(x, vdupq_n_f32(c_exp_lo));
+
+  /* express exp(x) as exp(g + n*log(2)) */
+  fx = vmlaq_f32(vdupq_n_f32(0.5f), x, vdupq_n_f32(c_cephes_LOG2EF));
+
+  /* perform a floorf */
+  tmp = vcvtq_f32_s32(vcvtq_s32_f32(fx));
+
+  /* if greater, substract 1 */
+  v4su mask = vcgtq_f32(tmp, fx);    
+  mask = vandq_u32(mask, vreinterpretq_u32_f32(one));
+
+
+  fx = vsubq_f32(tmp, vreinterpretq_f32_u32(mask));
+
+  tmp = vmulq_f32(fx, vdupq_n_f32(c_cephes_exp_C1));
+  v4sf z = vmulq_f32(fx, vdupq_n_f32(c_cephes_exp_C2));
+  x = vsubq_f32(x, tmp);
+  x = vsubq_f32(x, z);
+
+  static const float32_t cephes_exp_p[6] = { c_cephes_exp_p0, c_cephes_exp_p1, c_cephes_exp_p2, c_cephes_exp_p3, c_cephes_exp_p4, c_cephes_exp_p5 };
+  v4sf y = vld1q_dup_f32(cephes_exp_p+0);
+  v4sf c1 = vld1q_dup_f32(cephes_exp_p+1); 
+  v4sf c2 = vld1q_dup_f32(cephes_exp_p+2); 
+  v4sf c3 = vld1q_dup_f32(cephes_exp_p+3); 
+  v4sf c4 = vld1q_dup_f32(cephes_exp_p+4); 
+  v4sf c5 = vld1q_dup_f32(cephes_exp_p+5);
+
+  y = vmulq_f32(y, x);
+  z = vmulq_f32(x,x);
+  y = vaddq_f32(y, c1);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c2);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c3);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c4);
+  y = vmulq_f32(y, x);
+  y = vaddq_f32(y, c5);
+  
+  y = vmulq_f32(y, z);
+  y = vaddq_f32(y, x);
+  y = vaddq_f32(y, one);
+
+  /* build 2^n */
+  int32x4_t mm;
+  mm = vcvtq_s32_f32(fx);
+  mm = vaddq_s32(mm, vdupq_n_s32(0x7f));
+  mm = vshlq_n_s32(mm, 23);
+  v4sf pow2n = vreinterpretq_f32_s32(mm);
+
+  y = vmulq_f32(y, pow2n);
+  return y;
+}
+
+#define c_minus_cephes_DP1 -0.78515625
+#define c_minus_cephes_DP2 -2.4187564849853515625e-4
+#define c_minus_cephes_DP3 -3.77489497744594108e-8
+#define c_sincof_p0 -1.9515295891E-4
+#define c_sincof_p1  8.3321608736E-3
+#define c_sincof_p2 -1.6666654611E-1
+#define c_coscof_p0  2.443315711809948E-005
+#define c_coscof_p1 -1.388731625493765E-003
+#define c_coscof_p2  4.166664568298827E-002
+#define c_cephes_FOPI 1.27323954473516 // 4 / M_PI
+
+/* evaluation of 4 sines & cosines at once.
+
+   The code is the exact rewriting of the cephes sinf function.
+   Precision is excellent as long as x < 8192 (I did not bother to
+   take into account the special handling they have for greater values
+   -- it does not return garbage for arguments over 8192, though, but
+   the extra precision is missing).
+
+   Note that it is such that sinf((float)M_PI) = 8.74e-8, which is the
+   surprising but correct result.
+
+   Note also that when you compute sin(x), cos(x) is available at
+   almost no extra price so both sin_ps and cos_ps make use of
+   sincos_ps..
+  */
+void sincos_ps(v4sf x, v4sf *ysin, v4sf *ycos) { // any x
+  v4sf xmm1, xmm2, xmm3, y;
+
+  v4su emm2;
+  
+  v4su sign_mask_sin, sign_mask_cos;
+  sign_mask_sin = vcltq_f32(x, vdupq_n_f32(0));
+  x = vabsq_f32(x);
+
+  /* scale by 4/Pi */
+  y = vmulq_f32(x, vdupq_n_f32(c_cephes_FOPI));
+
+  /* store the integer part of y in mm0 */
+  emm2 = vcvtq_u32_f32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = vaddq_u32(emm2, vdupq_n_u32(1));
+  emm2 = vandq_u32(emm2, vdupq_n_u32(~1));
+  y = vcvtq_f32_u32(emm2);
+
+  /* get the polynom selection mask 
+     there is one polynom for 0 <= x <= Pi/4
+     and another one for Pi/4<x<=Pi/2
+
+     Both branches will be computed.
+  */
+  v4su poly_mask = vtstq_u32(emm2, vdupq_n_u32(2));
+  
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = vmulq_n_f32(y, c_minus_cephes_DP1);
+  xmm2 = vmulq_n_f32(y, c_minus_cephes_DP2);
+  xmm3 = vmulq_n_f32(y, c_minus_cephes_DP3);
+  x = vaddq_f32(x, xmm1);
+  x = vaddq_f32(x, xmm2);
+  x = vaddq_f32(x, xmm3);
+
+  sign_mask_sin = veorq_u32(sign_mask_sin, vtstq_u32(emm2, vdupq_n_u32(4)));
+  sign_mask_cos = vtstq_u32(vsubq_u32(emm2, vdupq_n_u32(2)), vdupq_n_u32(4));
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) in y1, 
+     and the second polynom      (Pi/4 <= x <= 0) in y2 */
+  v4sf z = vmulq_f32(x,x);
+  v4sf y1, y2;
+
+  y1 = vmulq_n_f32(z, c_coscof_p0);
+  y2 = vmulq_n_f32(z, c_sincof_p0);
+  y1 = vaddq_f32(y1, vdupq_n_f32(c_coscof_p1));
+  y2 = vaddq_f32(y2, vdupq_n_f32(c_sincof_p1));
+  y1 = vmulq_f32(y1, z);
+  y2 = vmulq_f32(y2, z);
+  y1 = vaddq_f32(y1, vdupq_n_f32(c_coscof_p2));
+  y2 = vaddq_f32(y2, vdupq_n_f32(c_sincof_p2));
+  y1 = vmulq_f32(y1, z);
+  y2 = vmulq_f32(y2, z);
+  y1 = vmulq_f32(y1, z);
+  y2 = vmulq_f32(y2, x);
+  y1 = vsubq_f32(y1, vmulq_f32(z, vdupq_n_f32(0.5f)));
+  y2 = vaddq_f32(y2, x);
+  y1 = vaddq_f32(y1, vdupq_n_f32(1));
+
+  /* select the correct result from the two polynoms */  
+  v4sf ys = vbslq_f32(poly_mask, y1, y2);
+  v4sf yc = vbslq_f32(poly_mask, y2, y1);
+  *ysin = vbslq_f32(sign_mask_sin, vnegq_f32(ys), ys);
+  *ycos = vbslq_f32(sign_mask_cos, yc, vnegq_f32(yc));
+}
+
+v4sf sin_ps(v4sf x) {
+  v4sf ysin, ycos; 
+  sincos_ps(x, &ysin, &ycos); 
+  return ysin;
+}
+
+v4sf cos_ps(v4sf x) {
+  v4sf ysin, ycos; 
+  sincos_ps(x, &ysin, &ycos); 
+  return ycos;
+}
+
+

--- a/pedalboard/vendors/rubberband/src/pommier/sse_mathfun.h
+++ b/pedalboard/vendors/rubberband/src/pommier/sse_mathfun.h
@@ -1,0 +1,766 @@
+
+#ifndef POMMIER_SSE_MATHFUN_H
+#define POMMIER_SSE_MATHFUN_H
+
+/* SIMD (SSE1+MMX or SSE2) implementation of sin, cos, exp and log
+
+   Inspired by Intel Approximate Math library, and based on the
+   corresponding algorithms of the cephes math library
+
+   The default is to use the SSE1 version. If you define USE_SSE2 the
+   the SSE2 intrinsics will be used in place of the MMX intrinsics. Do
+   not expect any significant performance improvement with SSE2.
+*/
+
+/* Copyright (C) 2007  Julien Pommier
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  (this is the zlib license)
+*/
+
+#include <xmmintrin.h>
+
+/* yes I know, the top of this file is quite ugly */
+
+#ifdef _MSC_VER /* visual c++ */
+# define ALIGN16_BEG __declspec(align(16))
+# define ALIGN16_END 
+#else /* gcc or icc */
+# define ALIGN16_BEG
+# define ALIGN16_END __attribute__((aligned(16)))
+#endif
+
+/* __m128 is ugly to write */
+typedef __m128 v4sf;  // vector of 4 float (sse1)
+
+#ifdef USE_SSE2
+# include <emmintrin.h>
+typedef __m128i v4si; // vector of 4 int (sse2)
+#else
+typedef __m64 v2si;   // vector of 2 int (mmx)
+#endif
+
+/* declare some SSE constants -- why can't I figure a better way to do that? */
+#define _PS_CONST(Name, Val)                                            \
+  static const ALIGN16_BEG float _ps_##Name[4] ALIGN16_END = { Val, Val, Val, Val }
+#define _PI32_CONST(Name, Val)                                            \
+  static const ALIGN16_BEG int _pi32_##Name[4] ALIGN16_END = { Val, Val, Val, Val }
+#define _PS_CONST_TYPE(Name, Type, Val)                                 \
+  static const ALIGN16_BEG Type _ps_##Name[4] ALIGN16_END = { Val, Val, Val, Val }
+
+_PS_CONST(1  , 1.0f);
+_PS_CONST(0p5, 0.5f);
+/* the smallest non denormalized float number */
+_PS_CONST_TYPE(min_norm_pos, int, 0x00800000);
+_PS_CONST_TYPE(mant_mask, int, 0x7f800000);
+_PS_CONST_TYPE(inv_mant_mask, int, ~0x7f800000);
+
+_PS_CONST_TYPE(sign_mask, int, (int)0x80000000);
+_PS_CONST_TYPE(inv_sign_mask, int, ~0x80000000);
+
+_PI32_CONST(1, 1);
+_PI32_CONST(inv1, ~1);
+_PI32_CONST(2, 2);
+_PI32_CONST(4, 4);
+_PI32_CONST(0x7f, 0x7f);
+
+_PS_CONST(cephes_SQRTHF, 0.707106781186547524);
+_PS_CONST(cephes_log_p0, 7.0376836292E-2);
+_PS_CONST(cephes_log_p1, - 1.1514610310E-1);
+_PS_CONST(cephes_log_p2, 1.1676998740E-1);
+_PS_CONST(cephes_log_p3, - 1.2420140846E-1);
+_PS_CONST(cephes_log_p4, + 1.4249322787E-1);
+_PS_CONST(cephes_log_p5, - 1.6668057665E-1);
+_PS_CONST(cephes_log_p6, + 2.0000714765E-1);
+_PS_CONST(cephes_log_p7, - 2.4999993993E-1);
+_PS_CONST(cephes_log_p8, + 3.3333331174E-1);
+_PS_CONST(cephes_log_q1, -2.12194440e-4);
+_PS_CONST(cephes_log_q2, 0.693359375);
+
+#if defined (__MINGW32__)
+
+/* the ugly part below: many versions of gcc used to be completely buggy with respect to some intrinsics
+   The movehl_ps is fixed in mingw 3.4.5, but I found out that all the _mm_cmp* intrinsics were completely
+   broken on my mingw gcc 3.4.5 ...
+
+   Note that the bug on _mm_cmp* does occur only at -O0 optimization level
+*/
+
+inline __m128 my_movehl_ps(__m128 a, const __m128 b) {
+	asm (
+			"movhlps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;                                 }
+#warning "redefined _mm_movehl_ps (see gcc bug 21179)"
+#define _mm_movehl_ps my_movehl_ps
+
+inline __m128 my_cmplt_ps(__m128 a, const __m128 b) {
+	asm (
+			"cmpltps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;               
+                  }
+inline __m128 my_cmpgt_ps(__m128 a, const __m128 b) {
+	asm (
+			"cmpnleps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;               
+}
+inline __m128 my_cmpeq_ps(__m128 a, const __m128 b) {
+	asm (
+			"cmpeqps %2,%0\n\t"
+			: "=x" (a)
+			: "0" (a), "x"(b)
+	    );
+	return a;               
+}
+#warning "redefined _mm_cmpxx_ps functions..."
+#define _mm_cmplt_ps my_cmplt_ps
+#define _mm_cmpgt_ps my_cmpgt_ps
+#define _mm_cmpeq_ps my_cmpeq_ps
+#endif
+
+#ifndef USE_SSE2
+typedef union xmm_mm_union {
+  __m128 xmm;
+  __m64 mm[2];
+} xmm_mm_union;
+
+#define COPY_XMM_TO_MM(xmm_, mm0_, mm1_) {          \
+    xmm_mm_union u; u.xmm = xmm_;                   \
+    mm0_ = u.mm[0];                                 \
+    mm1_ = u.mm[1];                                 \
+}
+
+#define COPY_MM_TO_XMM(mm0_, mm1_, xmm_) {                         \
+    xmm_mm_union u; u.mm[0]=mm0_; u.mm[1]=mm1_; xmm_ = u.xmm;      \
+  }
+
+#endif // USE_SSE2
+
+/* natural logarithm computed for 4 simultaneous float 
+   return NaN for x <= 0
+*/
+v4sf log_ps(v4sf x) {
+#ifdef USE_SSE2
+  v4si emm0;
+#else
+  v2si mm0, mm1;
+#endif
+  v4sf one = *(v4sf*)_ps_1;
+
+  v4sf invalid_mask = _mm_cmple_ps(x, _mm_setzero_ps());
+
+  x = _mm_max_ps(x, *(v4sf*)_ps_min_norm_pos);  /* cut off denormalized stuff */
+
+#ifndef USE_SSE2
+  /* part 1: x = frexpf(x, &e); */
+  COPY_XMM_TO_MM(x, mm0, mm1);
+  mm0 = _mm_srli_pi32(mm0, 23);
+  mm1 = _mm_srli_pi32(mm1, 23);
+#else
+  emm0 = _mm_srli_epi32(_mm_castps_si128(x), 23);
+#endif
+  /* keep only the fractional part */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_mant_mask);
+  x = _mm_or_ps(x, *(v4sf*)_ps_0p5);
+
+#ifndef USE_SSE2
+  /* now e=mm0:mm1 contain the really base-2 exponent */
+  mm0 = _mm_sub_pi32(mm0, *(v2si*)_pi32_0x7f);
+  mm1 = _mm_sub_pi32(mm1, *(v2si*)_pi32_0x7f);
+  v4sf e = _mm_cvtpi32x2_ps(mm0, mm1);
+  _mm_empty(); /* bye bye mmx */
+#else
+  emm0 = _mm_sub_epi32(emm0, *(v4si*)_pi32_0x7f);
+  v4sf e = _mm_cvtepi32_ps(emm0);
+#endif
+
+  e = _mm_add_ps(e, one);
+
+  /* part2: 
+     if( x < SQRTHF ) {
+       e -= 1;
+       x = x + x - 1.0;
+     } else { x = x - 1.0; }
+  */
+  v4sf mask = _mm_cmplt_ps(x, *(v4sf*)_ps_cephes_SQRTHF);
+  v4sf tmp = _mm_and_ps(x, mask);
+  x = _mm_sub_ps(x, one);
+  e = _mm_sub_ps(e, _mm_and_ps(one, mask));
+  x = _mm_add_ps(x, tmp);
+
+
+  v4sf z = _mm_mul_ps(x,x);
+
+  v4sf y = *(v4sf*)_ps_cephes_log_p0;
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p1);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p2);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p3);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p4);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p5);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p6);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p7);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_log_p8);
+  y = _mm_mul_ps(y, x);
+
+  y = _mm_mul_ps(y, z);
+  
+
+  tmp = _mm_mul_ps(e, *(v4sf*)_ps_cephes_log_q1);
+  y = _mm_add_ps(y, tmp);
+
+
+  tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+
+  tmp = _mm_mul_ps(e, *(v4sf*)_ps_cephes_log_q2);
+  x = _mm_add_ps(x, y);
+  x = _mm_add_ps(x, tmp);
+  x = _mm_or_ps(x, invalid_mask); // negative arg will be NAN
+  return x;
+}
+
+_PS_CONST(exp_hi,	88.3762626647949f);
+_PS_CONST(exp_lo,	-88.3762626647949f);
+
+_PS_CONST(cephes_LOG2EF, 1.44269504088896341);
+_PS_CONST(cephes_exp_C1, 0.693359375);
+_PS_CONST(cephes_exp_C2, -2.12194440e-4);
+
+_PS_CONST(cephes_exp_p0, 1.9875691500E-4);
+_PS_CONST(cephes_exp_p1, 1.3981999507E-3);
+_PS_CONST(cephes_exp_p2, 8.3334519073E-3);
+_PS_CONST(cephes_exp_p3, 4.1665795894E-2);
+_PS_CONST(cephes_exp_p4, 1.6666665459E-1);
+_PS_CONST(cephes_exp_p5, 5.0000001201E-1);
+
+v4sf exp_ps(v4sf x) {
+  v4sf tmp = _mm_setzero_ps(), fx;
+#ifdef USE_SSE2
+  v4si emm0;
+#else
+  v2si mm0, mm1;
+#endif
+  v4sf one = *(v4sf*)_ps_1;
+
+  x = _mm_min_ps(x, *(v4sf*)_ps_exp_hi);
+  x = _mm_max_ps(x, *(v4sf*)_ps_exp_lo);
+
+  /* express exp(x) as exp(g + n*log(2)) */
+  fx = _mm_mul_ps(x, *(v4sf*)_ps_cephes_LOG2EF);
+  fx = _mm_add_ps(fx, *(v4sf*)_ps_0p5);
+
+  /* how to perform a floorf with SSE: just below */
+#ifndef USE_SSE2
+  /* step 1 : cast to int */
+  tmp = _mm_movehl_ps(tmp, fx);
+  mm0 = _mm_cvttps_pi32(fx);
+  mm1 = _mm_cvttps_pi32(tmp);
+  /* step 2 : cast back to float */
+  tmp = _mm_cvtpi32x2_ps(mm0, mm1);
+#else
+  emm0 = _mm_cvttps_epi32(fx);
+  tmp  = _mm_cvtepi32_ps(emm0);
+#endif
+  /* if greater, substract 1 */
+  v4sf mask = _mm_cmpgt_ps(tmp, fx);    
+  mask = _mm_and_ps(mask, one);
+  fx = _mm_sub_ps(tmp, mask);
+
+  tmp = _mm_mul_ps(fx, *(v4sf*)_ps_cephes_exp_C1);
+  v4sf z = _mm_mul_ps(fx, *(v4sf*)_ps_cephes_exp_C2);
+  x = _mm_sub_ps(x, tmp);
+  x = _mm_sub_ps(x, z);
+
+  z = _mm_mul_ps(x,x);
+  
+  v4sf y = *(v4sf*)_ps_cephes_exp_p0;
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p1);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p2);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p3);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p4);
+  y = _mm_mul_ps(y, x);
+  y = _mm_add_ps(y, *(v4sf*)_ps_cephes_exp_p5);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, x);
+  y = _mm_add_ps(y, one);
+
+  /* build 2^n */
+#ifndef USE_SSE2
+  z = _mm_movehl_ps(z, fx);
+  mm0 = _mm_cvttps_pi32(fx);
+  mm1 = _mm_cvttps_pi32(z);
+  mm0 = _mm_add_pi32(mm0, *(v2si*)_pi32_0x7f);
+  mm1 = _mm_add_pi32(mm1, *(v2si*)_pi32_0x7f);
+  mm0 = _mm_slli_pi32(mm0, 23); 
+  mm1 = _mm_slli_pi32(mm1, 23);
+  
+  v4sf pow2n; 
+  COPY_MM_TO_XMM(mm0, mm1, pow2n);
+  _mm_empty();
+#else
+  emm0 = _mm_cvttps_epi32(fx);
+  emm0 = _mm_add_epi32(emm0, *(v4si*)_pi32_0x7f);
+  emm0 = _mm_slli_epi32(emm0, 23);
+  v4sf pow2n = _mm_castsi128_ps(emm0);
+#endif
+  y = _mm_mul_ps(y, pow2n);
+  return y;
+}
+
+_PS_CONST(minus_cephes_DP1, -0.78515625);
+_PS_CONST(minus_cephes_DP2, -2.4187564849853515625e-4);
+_PS_CONST(minus_cephes_DP3, -3.77489497744594108e-8);
+_PS_CONST(sincof_p0, -1.9515295891E-4);
+_PS_CONST(sincof_p1,  8.3321608736E-3);
+_PS_CONST(sincof_p2, -1.6666654611E-1);
+_PS_CONST(coscof_p0,  2.443315711809948E-005);
+_PS_CONST(coscof_p1, -1.388731625493765E-003);
+_PS_CONST(coscof_p2,  4.166664568298827E-002);
+_PS_CONST(cephes_FOPI, 1.27323954473516); // 4 / M_PI
+
+
+/* evaluation of 4 sines at onces, using only SSE1+MMX intrinsics so
+   it runs also on old athlons XPs and the pentium III of your grand
+   mother.
+
+   The code is the exact rewriting of the cephes sinf function.
+   Precision is excellent as long as x < 8192 (I did not bother to
+   take into account the special handling they have for greater values
+   -- it does not return garbage for arguments over 8192, though, but
+   the extra precision is missing).
+
+   Note that it is such that sinf((float)M_PI) = 8.74e-8, which is the
+   surprising but correct result.
+
+   Performance is also surprisingly good, 1.33 times faster than the
+   macos vsinf SSE2 function, and 1.5 times faster than the
+   __vrs4_sinf of amd's ACML (which is only available in 64 bits). Not
+   too bad for an SSE1 function (with no special tuning) !
+   However the latter libraries probably have a much better handling of NaN,
+   Inf, denormalized and other special arguments..
+
+   On my core 1 duo, the execution of this function takes approximately 95 cycles.
+
+   From what I have observed on the experiments with Intel AMath lib, switching to an
+   SSE2 version would improve the perf by only 10%.
+
+   Since it is based on SSE intrinsics, it has to be compiled at -O2 to
+   deliver full speed.
+*/
+v4sf sin_ps(v4sf x) { // any x
+  v4sf xmm1, xmm2 = _mm_setzero_ps(), xmm3, sign_bit, y;
+
+#ifdef USE_SSE2
+  v4si emm0, emm2;
+#else
+  v2si mm0, mm1, mm2, mm3;
+#endif
+  sign_bit = x;
+  /* take the absolute value */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_sign_mask);
+  /* extract the sign bit (upper one) */
+  sign_bit = _mm_and_ps(sign_bit, *(v4sf*)_ps_sign_mask);
+  
+  /* scale by 4/Pi */
+  y = _mm_mul_ps(x, *(v4sf*)_ps_cephes_FOPI);
+
+  //printf("plop:"); print4(y); 
+#ifdef USE_SSE2
+  /* store the integer part of y in mm0 */
+  emm2 = _mm_cvttps_epi32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm_add_epi32(emm2, *(v4si*)_pi32_1);
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+  /* get the swap sign flag */
+  emm0 = _mm_and_si128(emm2, *(v4si*)_pi32_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  /* get the polynom selection mask 
+     there is one polynom for 0 <= x <= Pi/4
+     and another one for Pi/4<x<=Pi/2
+
+     Both branches will be computed.
+  */
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  
+  v4sf swap_sign_bit = _mm_castsi128_ps(emm0);
+  v4sf poly_mask = _mm_castsi128_ps(emm2);
+  sign_bit = _mm_xor_ps(sign_bit, swap_sign_bit);
+#else
+  /* store the integer part of y in mm0:mm1 */
+  xmm2 = _mm_movehl_ps(xmm2, y);
+  mm2 = _mm_cvttps_pi32(y);
+  mm3 = _mm_cvttps_pi32(xmm2);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  mm2 = _mm_add_pi32(mm2, *(v2si*)_pi32_1);
+  mm3 = _mm_add_pi32(mm3, *(v2si*)_pi32_1);
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_inv1);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_inv1);
+  y = _mm_cvtpi32x2_ps(mm2, mm3);
+  /* get the swap sign flag */
+  mm0 = _mm_and_si64(mm2, *(v2si*)_pi32_4);
+  mm1 = _mm_and_si64(mm3, *(v2si*)_pi32_4);
+  mm0 = _mm_slli_pi32(mm0, 29);
+  mm1 = _mm_slli_pi32(mm1, 29);
+  /* get the polynom selection mask */
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_2);
+  mm2 = _mm_cmpeq_pi32(mm2, _mm_setzero_si64());
+  mm3 = _mm_cmpeq_pi32(mm3, _mm_setzero_si64());
+  v4sf swap_sign_bit, poly_mask;
+  COPY_MM_TO_XMM(mm0, mm1, swap_sign_bit);
+  COPY_MM_TO_XMM(mm2, mm3, poly_mask);
+  sign_bit = _mm_xor_ps(sign_bit, swap_sign_bit);
+  _mm_empty(); /* good-bye mmx */
+#endif
+  
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = *(v4sf*)_ps_minus_cephes_DP1;
+  xmm2 = *(v4sf*)_ps_minus_cephes_DP2;
+  xmm3 = *(v4sf*)_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  y = *(v4sf*)_ps_coscof_p0;
+  v4sf z = _mm_mul_ps(x,x);
+
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  v4sf tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *(v4sf*)_ps_1);
+  
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+
+  v4sf y2 = *(v4sf*)_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+
+  /* select the correct result from the two polynoms */  
+  xmm3 = poly_mask;
+  y2 = _mm_and_ps(xmm3, y2); //, xmm3);
+  y = _mm_andnot_ps(xmm3, y);
+  y = _mm_add_ps(y,y2);
+  /* update the sign */
+  y = _mm_xor_ps(y, sign_bit);
+
+  return y;
+}
+
+/* almost the same as sin_ps */
+v4sf cos_ps(v4sf x) { // any x
+  v4sf xmm1, xmm2 = _mm_setzero_ps(), xmm3, y;
+#ifdef USE_SSE2
+  v4si emm0, emm2;
+#else
+  v2si mm0, mm1, mm2, mm3;
+#endif
+  /* take the absolute value */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_sign_mask);
+  
+  /* scale by 4/Pi */
+  y = _mm_mul_ps(x, *(v4sf*)_ps_cephes_FOPI);
+  
+#ifdef USE_SSE2
+  /* store the integer part of y in mm0 */
+  emm2 = _mm_cvttps_epi32(y);
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm_add_epi32(emm2, *(v4si*)_pi32_1);
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+
+  emm2 = _mm_sub_epi32(emm2, *(v4si*)_pi32_2);
+  
+  /* get the swap sign flag */
+  emm0 = _mm_andnot_si128(emm2, *(v4si*)_pi32_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  /* get the polynom selection mask */
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  
+  v4sf sign_bit = _mm_castsi128_ps(emm0);
+  v4sf poly_mask = _mm_castsi128_ps(emm2);
+#else
+  /* store the integer part of y in mm0:mm1 */
+  xmm2 = _mm_movehl_ps(xmm2, y);
+  mm2 = _mm_cvttps_pi32(y);
+  mm3 = _mm_cvttps_pi32(xmm2);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  mm2 = _mm_add_pi32(mm2, *(v2si*)_pi32_1);
+  mm3 = _mm_add_pi32(mm3, *(v2si*)_pi32_1);
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_inv1);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_inv1);
+
+  y = _mm_cvtpi32x2_ps(mm2, mm3);
+
+
+  mm2 = _mm_sub_pi32(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_sub_pi32(mm3, *(v2si*)_pi32_2);
+
+  /* get the swap sign flag in mm0:mm1 and the 
+     polynom selection mask in mm2:mm3 */
+
+  mm0 = _mm_andnot_si64(mm2, *(v2si*)_pi32_4);
+  mm1 = _mm_andnot_si64(mm3, *(v2si*)_pi32_4);
+  mm0 = _mm_slli_pi32(mm0, 29);
+  mm1 = _mm_slli_pi32(mm1, 29);
+
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_2);
+
+  mm2 = _mm_cmpeq_pi32(mm2, _mm_setzero_si64());
+  mm3 = _mm_cmpeq_pi32(mm3, _mm_setzero_si64());
+
+  v4sf sign_bit, poly_mask;
+  COPY_MM_TO_XMM(mm0, mm1, sign_bit);
+  COPY_MM_TO_XMM(mm2, mm3, poly_mask);
+  _mm_empty(); /* good-bye mmx */
+#endif
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = *(v4sf*)_ps_minus_cephes_DP1;
+  xmm2 = *(v4sf*)_ps_minus_cephes_DP2;
+  xmm3 = *(v4sf*)_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+  
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  y = *(v4sf*)_ps_coscof_p0;
+  v4sf z = _mm_mul_ps(x,x);
+
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  v4sf tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *(v4sf*)_ps_1);
+  
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+
+  v4sf y2 = *(v4sf*)_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+
+  /* select the correct result from the two polynoms */  
+  xmm3 = poly_mask;
+  y2 = _mm_and_ps(xmm3, y2); //, xmm3);
+  y = _mm_andnot_ps(xmm3, y);
+  y = _mm_add_ps(y,y2);
+  /* update the sign */
+  y = _mm_xor_ps(y, sign_bit);
+
+  return y;
+}
+
+/* since sin_ps and cos_ps are almost identical, sincos_ps could replace both of them..
+   it is almost as fast, and gives you a free cosine with your sine */
+void sincos_ps(v4sf x, v4sf *s, v4sf *c) {
+  v4sf xmm1, xmm2, xmm3 = _mm_setzero_ps(), sign_bit_sin, y;
+#ifdef USE_SSE2
+  v4si emm0, emm2, emm4;
+#else
+  v2si mm0, mm1, mm2, mm3, mm4, mm5;
+#endif
+  sign_bit_sin = x;
+  /* take the absolute value */
+  x = _mm_and_ps(x, *(v4sf*)_ps_inv_sign_mask);
+  /* extract the sign bit (upper one) */
+  sign_bit_sin = _mm_and_ps(sign_bit_sin, *(v4sf*)_ps_sign_mask);
+  
+  /* scale by 4/Pi */
+  y = _mm_mul_ps(x, *(v4sf*)_ps_cephes_FOPI);
+    
+#ifdef USE_SSE2
+  /* store the integer part of y in emm2 */
+  emm2 = _mm_cvttps_epi32(y);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  emm2 = _mm_add_epi32(emm2, *(v4si*)_pi32_1);
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_inv1);
+  y = _mm_cvtepi32_ps(emm2);
+
+  emm4 = emm2;
+
+  /* get the swap sign flag for the sine */
+  emm0 = _mm_and_si128(emm2, *(v4si*)_pi32_4);
+  emm0 = _mm_slli_epi32(emm0, 29);
+  v4sf swap_sign_bit_sin = _mm_castsi128_ps(emm0);
+
+  /* get the polynom selection mask for the sine*/
+  emm2 = _mm_and_si128(emm2, *(v4si*)_pi32_2);
+  emm2 = _mm_cmpeq_epi32(emm2, _mm_setzero_si128());
+  v4sf poly_mask = _mm_castsi128_ps(emm2);
+#else
+  /* store the integer part of y in mm2:mm3 */
+  xmm3 = _mm_movehl_ps(xmm3, y);
+  mm2 = _mm_cvttps_pi32(y);
+  mm3 = _mm_cvttps_pi32(xmm3);
+
+  /* j=(j+1) & (~1) (see the cephes sources) */
+  mm2 = _mm_add_pi32(mm2, *(v2si*)_pi32_1);
+  mm3 = _mm_add_pi32(mm3, *(v2si*)_pi32_1);
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_inv1);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_inv1);
+
+  y = _mm_cvtpi32x2_ps(mm2, mm3);
+
+  mm4 = mm2;
+  mm5 = mm3;
+
+  /* get the swap sign flag for the sine */
+  mm0 = _mm_and_si64(mm2, *(v2si*)_pi32_4);
+  mm1 = _mm_and_si64(mm3, *(v2si*)_pi32_4);
+  mm0 = _mm_slli_pi32(mm0, 29);
+  mm1 = _mm_slli_pi32(mm1, 29);
+  v4sf swap_sign_bit_sin;
+  COPY_MM_TO_XMM(mm0, mm1, swap_sign_bit_sin);
+
+  /* get the polynom selection mask for the sine */
+
+  mm2 = _mm_and_si64(mm2, *(v2si*)_pi32_2);
+  mm3 = _mm_and_si64(mm3, *(v2si*)_pi32_2);
+  mm2 = _mm_cmpeq_pi32(mm2, _mm_setzero_si64());
+  mm3 = _mm_cmpeq_pi32(mm3, _mm_setzero_si64());
+  v4sf poly_mask;
+  COPY_MM_TO_XMM(mm2, mm3, poly_mask);
+#endif
+
+  /* The magic pass: "Extended precision modular arithmetic" 
+     x = ((x - y * DP1) - y * DP2) - y * DP3; */
+  xmm1 = *(v4sf*)_ps_minus_cephes_DP1;
+  xmm2 = *(v4sf*)_ps_minus_cephes_DP2;
+  xmm3 = *(v4sf*)_ps_minus_cephes_DP3;
+  xmm1 = _mm_mul_ps(y, xmm1);
+  xmm2 = _mm_mul_ps(y, xmm2);
+  xmm3 = _mm_mul_ps(y, xmm3);
+  x = _mm_add_ps(x, xmm1);
+  x = _mm_add_ps(x, xmm2);
+  x = _mm_add_ps(x, xmm3);
+
+#ifdef USE_SSE2
+  emm4 = _mm_sub_epi32(emm4, *(v4si*)_pi32_2);
+  emm4 = _mm_andnot_si128(emm4, *(v4si*)_pi32_4);
+  emm4 = _mm_slli_epi32(emm4, 29);
+  v4sf sign_bit_cos = _mm_castsi128_ps(emm4);
+#else
+  /* get the sign flag for the cosine */
+  mm4 = _mm_sub_pi32(mm4, *(v2si*)_pi32_2);
+  mm5 = _mm_sub_pi32(mm5, *(v2si*)_pi32_2);
+  mm4 = _mm_andnot_si64(mm4, *(v2si*)_pi32_4);
+  mm5 = _mm_andnot_si64(mm5, *(v2si*)_pi32_4);
+  mm4 = _mm_slli_pi32(mm4, 29);
+  mm5 = _mm_slli_pi32(mm5, 29);
+  v4sf sign_bit_cos;
+  COPY_MM_TO_XMM(mm4, mm5, sign_bit_cos);
+  _mm_empty(); /* good-bye mmx */
+#endif
+
+  sign_bit_sin = _mm_xor_ps(sign_bit_sin, swap_sign_bit_sin);
+
+  
+  /* Evaluate the first polynom  (0 <= x <= Pi/4) */
+  v4sf z = _mm_mul_ps(x,x);
+  y = *(v4sf*)_ps_coscof_p0;
+
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p1);
+  y = _mm_mul_ps(y, z);
+  y = _mm_add_ps(y, *(v4sf*)_ps_coscof_p2);
+  y = _mm_mul_ps(y, z);
+  y = _mm_mul_ps(y, z);
+  v4sf tmp = _mm_mul_ps(z, *(v4sf*)_ps_0p5);
+  y = _mm_sub_ps(y, tmp);
+  y = _mm_add_ps(y, *(v4sf*)_ps_1);
+  
+  /* Evaluate the second polynom  (Pi/4 <= x <= 0) */
+
+  v4sf y2 = *(v4sf*)_ps_sincof_p0;
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p1);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_add_ps(y2, *(v4sf*)_ps_sincof_p2);
+  y2 = _mm_mul_ps(y2, z);
+  y2 = _mm_mul_ps(y2, x);
+  y2 = _mm_add_ps(y2, x);
+
+  /* select the correct result from the two polynoms */  
+  xmm3 = poly_mask;
+  v4sf ysin2 = _mm_and_ps(xmm3, y2);
+  v4sf ysin1 = _mm_andnot_ps(xmm3, y);
+  y2 = _mm_sub_ps(y2,ysin2);
+  y = _mm_sub_ps(y, ysin1);
+
+  xmm1 = _mm_add_ps(ysin1,ysin2);
+  xmm2 = _mm_add_ps(y,y2);
+ 
+  /* update the sign */
+  *s = _mm_xor_ps(xmm1, sign_bit_sin);
+  *c = _mm_xor_ps(xmm2, sign_bit_cos);
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/rubberband-c.cpp
+++ b/pedalboard/vendors/rubberband/src/rubberband-c.cpp
@@ -1,0 +1,169 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "../rubberband/rubberband-c.h"
+#include "../rubberband/RubberBandStretcher.h"
+
+struct RubberBandState_
+{
+    RubberBand::RubberBandStretcher *m_s;
+};
+
+RubberBandState rubberband_new(unsigned int sampleRate,
+                               unsigned int channels,
+                               RubberBandOptions options,
+                               double initialTimeRatio,
+                               double initialPitchScale)
+{
+    RubberBandState_ *state = new RubberBandState_();
+    state->m_s = new RubberBand::RubberBandStretcher
+        (sampleRate, channels, options,
+         initialTimeRatio, initialPitchScale);
+    return state;
+}
+
+void rubberband_delete(RubberBandState state)
+{
+    delete state->m_s;
+    delete state;
+}
+
+void rubberband_reset(RubberBandState state)
+{
+    state->m_s->reset();
+}
+
+void rubberband_set_time_ratio(RubberBandState state, double ratio)
+{
+    state->m_s->setTimeRatio(ratio);
+}
+
+void rubberband_set_pitch_scale(RubberBandState state, double scale)
+{
+    state->m_s->setPitchScale(scale);
+}
+
+double rubberband_get_time_ratio(const RubberBandState state) 
+{
+    return state->m_s->getTimeRatio();
+}
+
+double rubberband_get_pitch_scale(const RubberBandState state)
+{
+    return state->m_s->getPitchScale();
+}
+
+unsigned int rubberband_get_latency(const RubberBandState state) 
+{
+    return state->m_s->getLatency();
+}
+
+void rubberband_set_transients_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setTransientsOption(options);
+}
+
+void rubberband_set_detector_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setDetectorOption(options);
+}
+
+void rubberband_set_phase_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setPhaseOption(options);
+}
+
+void rubberband_set_formant_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setFormantOption(options);
+}
+
+void rubberband_set_pitch_option(RubberBandState state, RubberBandOptions options)
+{
+    state->m_s->setPitchOption(options);
+}
+
+void rubberband_set_expected_input_duration(RubberBandState state, unsigned int samples)
+{
+    state->m_s->setExpectedInputDuration(samples);
+}
+
+unsigned int rubberband_get_samples_required(const RubberBandState state)
+{
+    return state->m_s->getSamplesRequired();
+}
+
+void rubberband_set_max_process_size(RubberBandState state, unsigned int samples)
+{
+    state->m_s->setMaxProcessSize(samples);
+}
+
+void rubberband_set_key_frame_map(RubberBandState state, unsigned int keyframecount, unsigned int *from, unsigned int *to)
+{
+    std::map<size_t, size_t> kfm;
+    for (unsigned int i = 0; i < keyframecount; ++i) {
+        kfm[from[i]] = to[i];
+    }
+    state->m_s->setKeyFrameMap(kfm);
+}
+
+void rubberband_study(RubberBandState state, const float *const *input, unsigned int samples, int final)
+{
+    state->m_s->study(input, samples, final != 0);
+}
+
+void rubberband_process(RubberBandState state, const float *const *input, unsigned int samples, int final)
+{
+    state->m_s->process(input, samples, final != 0);
+}
+
+int rubberband_available(const RubberBandState state)
+{
+    return state->m_s->available();
+}
+
+unsigned int rubberband_retrieve(const RubberBandState state, float *const *output, unsigned int samples)
+{
+    return state->m_s->retrieve(output, samples);
+}
+
+unsigned int rubberband_get_channel_count(const RubberBandState state)
+{
+    return state->m_s->getChannelCount();
+}
+
+void rubberband_calculate_stretch(RubberBandState state)
+{
+    state->m_s->calculateStretch();
+}
+
+void rubberband_set_debug_level(RubberBandState state, int level)
+{
+    state->m_s->setDebugLevel(level);
+}
+
+void rubberband_set_default_debug_level(int level)
+{
+    RubberBand::RubberBandStretcher::setDefaultDebugLevel(level);
+}
+

--- a/pedalboard/vendors/rubberband/src/speex/COPYING
+++ b/pedalboard/vendors/rubberband/src/speex/COPYING
@@ -1,0 +1,35 @@
+Copyright 2002-2007 	Xiph.org Foundation
+Copyright 2002-2007 	Jean-Marc Valin
+Copyright 2005-2007	Analog Devices Inc.
+Copyright 2005-2007	Commonwealth Scientific and Industrial Research 
+                        Organisation (CSIRO)
+Copyright 1993, 2002, 2006 David Rowe
+Copyright 2003 		EpicGames
+Copyright 1992-1994	Jutta Degener, Carsten Bormann
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.org Foundation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pedalboard/vendors/rubberband/src/speex/resample.c
+++ b/pedalboard/vendors/rubberband/src/speex/resample.c
@@ -1,0 +1,1265 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*- vi:set ts=8 sts=4 sw=4: */
+
+/* Copyright (C) 2007 Jean-Marc Valin
+
+   File: resample.c
+   Arbitrary resampling code
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*
+   The design goals of this code are:
+      - Very fast algorithm
+      - SIMD-friendly algorithm
+      - Low memory requirement
+      - Good *perceptual* quality (and not best SNR)
+
+   Warning: This resampler is relatively new. Although I think I got rid of
+   all the major bugs and I don't expect the API to change anymore, there
+   may be something I've missed. So use with caution.
+
+   This algorithm is based on this original resampling algorithm:
+   Smith, Julius O. Digital Audio Resampling Home Page
+   Center for Computer Research in Music and Acoustics (CCRMA),
+   Stanford University, 2007.
+   Web published at http://www-ccrma.stanford.edu/~jos/resample/.
+
+   There is one main difference, though. This resampler uses cubic
+   interpolation instead of linear interpolation in the above paper. This
+   makes the table much smaller and makes it possible to compute that table
+   on a per-stream basis. In turn, being able to tweak the table for each
+   stream makes it possible to both reduce complexity on simple ratios
+   (e.g. 2/3), and get rid of the rounding operations in the inner loop.
+   The latter both reduces CPU time and makes the algorithm more SIMD-friendly.
+*/
+
+/*
+   NOTE: This code has been cut down and reformatted by Chris Cannam
+   for personal reading preference, and for use in the Rubber Band
+   time stretching and pitch shifting library.  If you have problems
+   with this code, cast suspicion on the butchering it has undergone;
+   it's probably my fault.  If you want a properly functioning
+   version, please go for the original Speex code first.  I haven't
+   made any substantial changes to this code, I've just made it less
+   generally useful.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <string.h>
+
+#ifdef HAVE_IPP
+#include <ipps.h>
+#endif
+
+// Simple allocators with a fixed minimum, to avoid reallocation if
+// the size changes but remains smaller than that.  The system alloc
+// functions no doubt do exactly the same thing for some value
+// probably not too distant from ours, but we want the certainty.
+
+#define ALLOC_MINIMUM 4096
+
+static void *speex_alloc (int count, int size)
+{
+#ifdef HAVE_IPP
+    void *rv;
+#endif
+    if (count * size < ALLOC_MINIMUM) {
+        count = ALLOC_MINIMUM / size;
+    }
+
+#ifdef HAVE_IPP
+    if (size == sizeof(float) && size == 4) { // or sizeof(int32) or whatever, doesn't matter
+        rv = ippsMalloc_32f(count);
+    } else if (size == sizeof(double) && size == 8) {
+        rv = ippsMalloc_64f(count);
+    } else {
+        rv = ippsMalloc_8u(count * size);
+    }
+    memset(rv, 0, count * size);
+    return rv;
+#else
+    return calloc(count, size);
+#endif
+}
+
+static void speex_free (void *ptr) 
+{
+//	fprintf(stderr,"speex_free(%p)\n", ptr);
+#ifdef HAVE_IPP
+  	ippsFree(ptr);
+#else
+    free(ptr);
+#endif
+}
+
+static void *speex_realloc (void *ptr, int oldcount, int newcount, int size)
+{
+#ifdef HAVE_IPP
+	void *newptr;
+#endif
+
+//	fprintf(stderr,"speex_realloc(%p,%d,%d,%d)\n", ptr, oldcount, newcount, size);
+
+    if (newcount * size < ALLOC_MINIMUM) {
+//		fprintf(stderr,"returning %p\n",ptr);
+        return ptr;
+    }
+//    fprintf(stderr, "NOTE: speex_realloc: actual reallocation happening (newcount = %d, size = %d)\n", newcount, size);
+
+#ifdef HAVE_IPP
+    newptr = speex_alloc(newcount, size);
+    if (ptr && oldcount > 0) {
+        int copy = newcount;
+        if (oldcount < copy) copy = oldcount;
+        memcpy(newptr, ptr, copy * size);
+    }
+    speex_free(ptr);
+//	fprintf(stderr,"returning %p\n", ptr);
+    return newptr;
+#else
+    return realloc(ptr, newcount * size);
+#endif
+}
+
+#include "speex_resampler.h"
+
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159263
+#endif
+
+#define FILTER_SIZE 64
+#define OVERSAMPLE 8
+
+#define IMAX(a,b) ((a) > (b) ? (a) : (b))
+#define IMIN(a,b) ((a) < (b) ? (a) : (b))
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+
+typedef int (*resampler_basic_func)(SpeexResamplerState *, spx_uint32_t , const float *, spx_uint32_t *, float *, spx_uint32_t *);
+
+struct SpeexResamplerState_ {
+    spx_uint32_t in_rate;
+    spx_uint32_t out_rate;
+    spx_uint32_t num_rate;
+    spx_uint32_t den_rate;
+
+    int    quality;
+    spx_uint32_t nb_channels;
+    spx_uint32_t filt_len;
+    spx_uint32_t mem_alloc_size;
+    int          int_advance;
+    int          frac_advance;
+    float  cutoff;
+    spx_uint32_t oversample;
+    int          initialised;
+    int          started;
+
+    /* These are per-channel */
+    spx_int32_t  *last_sample;
+    spx_uint32_t *samp_frac_num;
+    spx_uint32_t *magic_samples;
+
+    float *mem;
+    float *sinc_table;
+    spx_uint32_t sinc_table_length;
+    spx_uint32_t sinc_table_alloc;
+    resampler_basic_func resampler_ptr;
+
+    int    in_stride;
+    int    out_stride;
+} ;
+
+static double kaiser12_table[68] = {
+    0.99859849, 1.00000000, 0.99859849, 0.99440475, 0.98745105, 0.97779076,
+    0.96549770, 0.95066529, 0.93340547, 0.91384741, 0.89213598, 0.86843014,
+    0.84290116, 0.81573067, 0.78710866, 0.75723148, 0.72629970, 0.69451601,
+    0.66208321, 0.62920216, 0.59606986, 0.56287762, 0.52980938, 0.49704014,
+    0.46473455, 0.43304576, 0.40211431, 0.37206735, 0.34301800, 0.31506490,
+    0.28829195, 0.26276832, 0.23854851, 0.21567274, 0.19416736, 0.17404546,
+    0.15530766, 0.13794294, 0.12192957, 0.10723616, 0.09382272, 0.08164178,
+    0.07063950, 0.06075685, 0.05193064, 0.04409466, 0.03718069, 0.03111947,
+    0.02584161, 0.02127838, 0.01736250, 0.01402878, 0.01121463, 0.00886058,
+    0.00691064, 0.00531256, 0.00401805, 0.00298291, 0.00216702, 0.00153438,
+    0.00105297, 0.00069463, 0.00043489, 0.00025272, 0.00013031, 0.0000527734,
+    0.00001000, 0.00000000
+};
+
+static double kaiser10_table[36] = {
+    0.99537781, 1.00000000, 0.99537781, 0.98162644, 0.95908712, 0.92831446,
+    0.89005583, 0.84522401, 0.79486424, 0.74011713, 0.68217934, 0.62226347,
+    0.56155915, 0.50119680, 0.44221549, 0.38553619, 0.33194107, 0.28205962,
+    0.23636152, 0.19515633, 0.15859932, 0.12670280, 0.09935205, 0.07632451,
+    0.05731132, 0.04193980, 0.02979584, 0.02044510, 0.01345224, 0.00839739,
+    0.00488951, 0.00257636, 0.00115101, 0.00035515, 0.00000000, 0.00000000
+};
+
+static double kaiser8_table[36] = {
+    0.99635258, 1.00000000, 0.99635258, 0.98548012, 0.96759014, 0.94302200,
+    0.91223751, 0.87580811, 0.83439927, 0.78875245, 0.73966538, 0.68797126,
+    0.63451750, 0.58014482, 0.52566725, 0.47185369, 0.41941150, 0.36897272,
+    0.32108304, 0.27619388, 0.23465776, 0.19672670, 0.16255380, 0.13219758,
+    0.10562887, 0.08273982, 0.06335451, 0.04724088, 0.03412321, 0.02369490,
+    0.01563093, 0.00959968, 0.00527363, 0.00233883, 0.00050000, 0.00000000
+};
+
+static double kaiser6_table[36] = {
+    0.99733006, 1.00000000, 0.99733006, 0.98935595, 0.97618418, 0.95799003,
+    0.93501423, 0.90755855, 0.87598009, 0.84068475, 0.80211977, 0.76076565,
+    0.71712752, 0.67172623, 0.62508937, 0.57774224, 0.53019925, 0.48295561,
+    0.43647969, 0.39120616, 0.34752997, 0.30580127, 0.26632152, 0.22934058,
+    0.19505503, 0.16360756, 0.13508755, 0.10953262, 0.08693120, 0.06722600,
+    0.05031820, 0.03607231, 0.02432151, 0.01487334, 0.00752000, 0.00000000
+};
+
+struct FuncDef {
+    double *table;
+    int oversample;
+};
+
+static struct FuncDef _KAISER12 = {kaiser12_table, 64};
+#define KAISER12 (&_KAISER12)
+static struct FuncDef _KAISER10 = {kaiser10_table, 32};
+#define KAISER10 (&_KAISER10)
+static struct FuncDef _KAISER8 = {kaiser8_table, 32};
+#define KAISER8 (&_KAISER8)
+static struct FuncDef _KAISER6 = {kaiser6_table, 32};
+#define KAISER6 (&_KAISER6)
+
+struct QualityMapping {
+    int base_length;
+    int oversample;
+    float downsample_bandwidth;
+    float upsample_bandwidth;
+
+    struct FuncDef *window_func;
+};
+
+
+/* This table maps conversion quality to internal parameters. There are two
+   reasons that explain why the up-sampling bandwidth is larger than the
+   down-sampling bandwidth:
+   1) When up-sampling, we can assume that the spectrum is already attenuated
+      close to the Nyquist rate (from an A/D or a previous resampling filter)
+   2) Any aliasing that occurs very close to the Nyquist rate will be masked
+      by the sinusoids/noise just below the Nyquist rate (guaranteed only for
+      up-sampling).
+*/
+
+static const struct QualityMapping quality_map[11] = {
+   {  8,  4, 0.830f, 0.860f, KAISER6 }, /* Q0 */
+   { 16,  4, 0.850f, 0.880f, KAISER6 }, /* Q1 */
+   { 32,  4, 0.882f, 0.910f, KAISER6 }, /* Q2 */  /* 82.3% cutoff ( ~60 dB stop) 6  */
+   { 48,  8, 0.895f, 0.917f, KAISER8 }, /* Q3 */  /* 84.9% cutoff ( ~80 dB stop) 8  */
+   { 64,  8, 0.921f, 0.940f, KAISER8 }, /* Q4 */  /* 88.7% cutoff ( ~80 dB stop) 8  */
+   { 80, 16, 0.922f, 0.940f, KAISER10}, /* Q5 */  /* 89.1% cutoff (~100 dB stop) 10 */
+   { 96, 16, 0.940f, 0.945f, KAISER10}, /* Q6 */  /* 91.5% cutoff (~100 dB stop) 10 */
+   {128, 16, 0.950f, 0.950f, KAISER10}, /* Q7 */  /* 93.1% cutoff (~100 dB stop) 10 */
+   {160, 16, 0.960f, 0.960f, KAISER10}, /* Q8 */  /* 94.5% cutoff (~100 dB stop) 10 */
+   {192, 32, 0.968f, 0.968f, KAISER12}, /* Q9 */  /* 95.5% cutoff (~100 dB stop) 10 */
+   {256, 32, 0.975f, 0.975f, KAISER12}, /* Q10 */ /* 96.6% cutoff (~100 dB stop) 10 */
+};
+/*8,24,40,56,80,104,128,160,200,256,320*/
+
+static double compute_func(float x, struct FuncDef *func)
+{
+    float y, frac;
+    double interp[4];
+    int ind;
+
+    y = x * func->oversample;
+    ind = (int)floor(y);
+    frac = (y - ind);
+
+    /* CSE with handle the repeated powers */
+    interp[3] =  -0.1666666667 * frac + 0.1666666667 * (frac * frac * frac);
+    interp[2] = frac + 0.5 * (frac * frac) - 0.5 * (frac * frac * frac);
+    interp[0] = -0.3333333333 * frac + 0.5 * (frac * frac) - 0.1666666667 * (frac * frac * frac);
+
+    /* Just to make sure we don't have rounding problems */
+    interp[1] = 1.f - interp[3] - interp[2] - interp[0];
+
+    /*sum = frac*accum[1] + (1-frac)*accum[2];*/
+    return 
+	interp[0]*func->table[ind] + interp[1]*func->table[ind+1] +
+	interp[2]*func->table[ind+2] + interp[3]*func->table[ind+3];
+}
+
+/* The slow way of computing a sinc for the table. Should improve that some day */
+static float sinc(float cutoff, float x, int N, struct FuncDef *window_func)
+{
+    float xx = x * cutoff;
+
+    if (fabsf(x) < 1e-6)
+        return cutoff;
+    else if (fabsf(x) > .5*N)
+        return 0;
+
+    /*FIXME: Can it really be any slower than this? */
+    return cutoff*sin(M_PI*xx) / (M_PI*xx)
+	* compute_func(fabs(2.*x / N), window_func);
+}
+
+static void cubic_coef(float frac, float interp[4])
+{
+    /* Compute interpolation coefficients. I'm not sure whether this
+    corresponds to cubic interpolation but I know it's MMSE-optimal on
+    a sinc */
+
+    interp[0] =  -0.16667f * frac + 0.16667f * frac * frac * frac;
+    interp[1] = frac + 0.5f * frac * frac - 0.5f * frac * frac * frac;
+    interp[3] = -0.33333f * frac + 0.5f * frac * frac - 0.16667f * frac * frac * frac;
+
+    /* Just to make sure we don't have rounding problems */
+    interp[2] = 1. - interp[0] - interp[1] - interp[3];
+}
+
+static int resampler_basic_direct_single(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        float sum = 0;
+
+        /* We already have all the filter coefficients pre-computed in the table */
+        const float *ptr;
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+            sum += ((float)(mem[last_sample+j]) *
+		    (float)(st->sinc_table[samp_frac_num*st->filt_len+j]));
+        }
+
+        /* Do the new part */
+        if (in != NULL) {
+
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            for (; j < N; j++) {
+                sum += ((float)(*ptr) *
+			(float)(st->sinc_table[samp_frac_num*st->filt_len+j]));
+                ptr += st->in_stride;
+            }
+        }
+
+        *out = (sum);
+
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+
+    st->samp_frac_num[channel_index] = samp_frac_num;
+    return out_sample;
+}
+
+/* This is the same as the previous function, except with a double-precision accumulator */
+static int resampler_basic_direct_double(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        double sum = 0;
+
+        /* We already have all the filter coefficients pre-computed in
+         * the table */
+        const float *ptr;
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+            sum += ((float)(mem[last_sample+j]) *
+		    (float)((double)st->sinc_table[samp_frac_num*st->filt_len+j]));
+        }
+
+        /* Do the new part */
+        if (in != NULL) {
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            for (; j < N; j++) {
+                sum += ((float)(*ptr) *
+			(float)((double)st->sinc_table[samp_frac_num*st->filt_len+j]));
+                ptr += st->in_stride;
+            }
+        }
+
+        *out = sum;
+
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+
+    st->samp_frac_num[channel_index] = samp_frac_num;
+    return out_sample;
+}
+
+static int resampler_basic_interpolate_single(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        float sum = 0;
+
+        /* We need to interpolate the sinc filter */
+        float accum[4] = {0.f, 0.f, 0.f, 0.f};
+        float interp[4];
+        const float *ptr;
+        int offset;
+        float frac;
+
+        offset = samp_frac_num * st->oversample / st->den_rate;
+
+        frac = ((float)((samp_frac_num * st->oversample) % st->den_rate))
+	    / st->den_rate;
+
+        /* This code is written like this to make it easy to optimise
+	 * with SIMD.  For most DSPs, it would be best to split the
+	 * loops in two because most DSPs have only two
+	 * accumulators */
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+
+            float curr_mem = mem[last_sample+j];
+
+            accum[0] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 2]));
+            accum[1] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 1]));
+            accum[2] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset]));
+            accum[3] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset + 1]));
+        }
+
+        if (in != NULL) {
+
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            /* Do the new part */
+            for (; j < N; j++) {
+
+                float curr_in = *ptr;
+                ptr += st->in_stride;
+
+                accum[0] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 2]));
+                accum[1] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 1]));
+                accum[2] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset]));
+                accum[3] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset + 1]));
+            }
+        }
+
+        cubic_coef(frac, interp);
+
+        sum =
+	    ((interp[0]) * (accum[0])) +
+	    ((interp[1]) * (accum[1])) +
+	    ((interp[2]) * (accum[2])) +
+	    ((interp[3]) * (accum[3]));
+
+        *out = (sum);
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+    st->samp_frac_num[channel_index] = samp_frac_num;
+    return out_sample;
+}
+
+/* This is the same as the previous function, except with a
+ * double-precision accumulator */
+static int resampler_basic_interpolate_double(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len) 
+{
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    int last_sample = st->last_sample[channel_index];
+    unsigned int samp_frac_num = st->samp_frac_num[channel_index];
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+
+    while (!(last_sample >= (int)*in_len || out_sample >= (int)*out_len)) {
+
+        int j;
+        float sum = 0;
+
+        /* We need to interpolate the sinc filter */
+        double accum[4] = {0.f, 0.f, 0.f, 0.f};
+        float interp[4];
+        const float *ptr;
+        float alpha = ((float)samp_frac_num) / st->den_rate;
+        int offset = samp_frac_num * st->oversample / st->den_rate;
+        float frac = alpha * st->oversample - offset;
+
+        /* This code is written like this to make it easy to optimise
+	 * with SIMD.  For most DSPs, it would be best to split the
+	 * loops in two because most DSPs have only two
+	 * accumulators */
+
+        for (j = 0; last_sample - N + 1 + j < 0; j++) {
+
+            double curr_mem = mem[last_sample + j];
+
+            accum[0] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 2]));
+            accum[1] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset - 1]));
+            accum[2] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset]));
+            accum[3] += ((float)(curr_mem) *
+                         (float)(st->sinc_table
+                                 [4 + (j+1)*st->oversample - offset + 1]));
+        }
+
+        if (in != NULL) {
+
+            ptr = in + st->in_stride * (last_sample - N + 1 + j);
+
+            /* Do the new part */
+            for (; j < N; j++) {
+
+                double curr_in = *ptr;
+                ptr += st->in_stride;
+
+                accum[0] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 2]));
+                accum[1] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset - 1]));
+                accum[2] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset]));
+                accum[3] += ((float)(curr_in) *
+                             (float)(st->sinc_table
+                                     [4 + (j+1)*st->oversample - offset + 1]));
+            }
+        }
+
+        cubic_coef(frac, interp);
+
+        sum =
+	    interp[0] * accum[0] +
+	    interp[1] * accum[1] +
+	    interp[2] * accum[2] +
+	    interp[3] * accum[3];
+
+        *out = (sum);
+        out += st->out_stride;
+        out_sample++;
+        last_sample += st->int_advance;
+        samp_frac_num += st->frac_advance;
+
+        if (samp_frac_num >= st->den_rate) {
+            samp_frac_num -= st->den_rate;
+            last_sample++;
+        }
+    }
+
+    st->last_sample[channel_index] = last_sample;
+    st->samp_frac_num[channel_index] = samp_frac_num;
+
+    return out_sample;
+}
+
+static void update_filter(SpeexResamplerState *st)
+{
+    unsigned int old_length;
+
+    /*   fprintf(stderr, "update_filter\n"); */
+
+    old_length = st->filt_len;
+    st->oversample = quality_map[st->quality].oversample;
+    st->filt_len = quality_map[st->quality].base_length;
+
+    if (st->num_rate > st->den_rate) {
+
+        /* down-sampling */
+        st->cutoff = quality_map[st->quality].downsample_bandwidth
+            * st->den_rate / st->num_rate;
+
+        st->filt_len = (unsigned int)
+            ceil(st->filt_len * ((double)st->num_rate / (double)st->den_rate));
+
+        /* Round down to make sure we have a multiple of 4 */
+        st->filt_len &= (~0x3);
+
+        if (2*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (4*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (8*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (16*st->den_rate < st->num_rate)
+            st->oversample >>= 1;
+
+        if (st->oversample < 1)
+            st->oversample = 1;
+
+    } else {
+
+        /* up-sampling */
+        st->cutoff = quality_map[st->quality].upsample_bandwidth;
+    }
+
+    /* Choose the resampling type that requires the least amount of memory */
+
+    if (st->den_rate <= st->oversample) {
+
+        unsigned int i;
+
+        if (!st->sinc_table) {
+
+            st->sinc_table = (float *)speex_alloc
+                (st->filt_len * st->den_rate, sizeof(float));
+
+	} else if (st->sinc_table_alloc < st->filt_len*st->den_rate) {
+
+//		fprintf(stderr,"sinc_table=%p\n",st->sinc_table);
+            st->sinc_table = (float *)speex_realloc
+                (st->sinc_table, st->sinc_table_alloc,
+                 st->filt_len * st->den_rate, sizeof(float));
+            st->sinc_table_alloc = st->filt_len * st->den_rate;
+        }
+
+        for (i = 0; i < st->den_rate; i++) {
+
+            int j;
+
+            for (j = 0; j < st->filt_len; j++) {
+                st->sinc_table[i*st->filt_len+j] = sinc
+                    (st->cutoff,
+                     ((j - (int)st->filt_len / 2 + 1) - ((float)i) / st->den_rate), 
+                     st->filt_len,
+                     quality_map[st->quality].window_func);
+            }
+        }
+
+        if (st->quality > 8) {
+            st->resampler_ptr = resampler_basic_direct_double;
+        } else {
+            st->resampler_ptr = resampler_basic_direct_single;
+        }
+
+        /*      fprintf (stderr, "resampler uses direct sinc table and normalised cutoff %f\n", st->cutoff); */
+
+    } else {
+
+        int i;
+
+        if (!st->sinc_table) {
+
+            st->sinc_table = (float *)speex_alloc
+                ((st->filt_len * st->oversample + 8),  sizeof(float));
+
+	} else if (st->sinc_table_alloc < st->filt_len*st->oversample + 8) {
+
+		//fprintf(stderr,"sinc_table=%p\n",st->sinc_table);
+            st->sinc_table = (float *)speex_realloc
+                (st->sinc_table, st->sinc_table_alloc,
+                 (st->filt_len * st->oversample + 8), sizeof(float));
+            st->sinc_table_alloc = st->filt_len * st->oversample + 8;
+        }
+
+        for (i = -4; i < (int)(st->oversample * st->filt_len + 4); i++) {
+            st->sinc_table[i+4] = sinc
+                (st->cutoff,
+                 (i / (float)st->oversample - st->filt_len / 2),
+                 st->filt_len,
+                 quality_map[st->quality].window_func);
+	}
+
+        if (st->quality > 8)
+            st->resampler_ptr = resampler_basic_interpolate_double;
+        else
+            st->resampler_ptr = resampler_basic_interpolate_single;
+
+        /* fprintf (stderr, "resampler uses interpolated sinc table and normalised cutoff %f\n", st->cutoff); */
+
+        /* fprintf (stderr, "table length %d, filt len %d\n", st->sinc_table_length, st->filt_len); */
+    }
+
+    st->int_advance = st->num_rate / st->den_rate;
+    st->frac_advance = st->num_rate % st->den_rate;
+
+    /* Here's the place where we update the filter memory to take into
+       account the change in filter length. It's probably the messiest
+       part of the code due to handling of lots of corner cases. */
+
+    if (!st->mem) {
+
+        unsigned int i;
+        st->mem = (float*)speex_alloc
+            (st->nb_channels * (st->filt_len - 1), sizeof(float));
+
+        for (i = 0; i < st->nb_channels * (st->filt_len - 1); i++)
+            st->mem[i] = 0;
+
+        st->mem_alloc_size = st->filt_len - 1;
+
+    } else if (!st->started) {
+
+        unsigned int i;
+
+		//fprintf(stderr,"mem=%p\n",st->mem);
+		st->mem = (float*)speex_realloc
+            (st->mem, 0, st->nb_channels * (st->filt_len - 1), sizeof(float));
+
+        for (i = 0; i < st->nb_channels * (st->filt_len - 1); i++)
+            st->mem[i] = 0;
+
+        st->mem_alloc_size = st->filt_len - 1;
+
+    } else if (st->filt_len > old_length) {
+
+        int i;
+
+        /* Increase the filter length */
+
+        int old_alloc_size = st->mem_alloc_size;
+
+        if (st->filt_len - 1 > st->mem_alloc_size) {
+			
+		//fprintf(stderr,"mem=%p\n",st->mem);
+
+            st->mem = (float*)speex_realloc
+                (st->mem, st->nb_channels * (old_length - 1),
+                 st->nb_channels * (st->filt_len - 1), sizeof(float));
+            st->mem_alloc_size = st->filt_len - 1;
+        }
+
+        for (i = st->nb_channels - 1; i >= 0; i--) {
+
+            int j;
+            unsigned int olen = old_length;
+
+	    /*if (st->magic_samples[i])*/
+            {
+
+                /* Try and remove the magic samples as if nothing had happened */
+
+                /* FIXME: This is wrong but for now we need it to
+                 * avoid going over the array bounds */
+
+                olen = old_length + 2 * st->magic_samples[i];
+
+                for (j = old_length - 2 + st->magic_samples[i]; j >= 0; j--) {
+                    st->mem[i*st->mem_alloc_size+j+st->magic_samples[i]] =
+                        st->mem[i*old_alloc_size+j];
+                }
+
+                for (j = 0; j < st->magic_samples[i]; j++) {
+                    st->mem[i*st->mem_alloc_size+j] = 0;
+                }
+
+                st->magic_samples[i] = 0;
+            }
+
+            if (st->filt_len > olen) {
+
+                /* If the new filter length is still bigger than the
+                 * "augmented" length */
+
+                /* Copy data going backward */
+
+                for (j = 0; j < olen - 1; j++) {
+                    st->mem[i*st->mem_alloc_size+(st->filt_len-2-j)] =
+                        st->mem[i*st->mem_alloc_size+(olen-2-j)];
+                }
+
+                /* Then put zeros for lack of anything better */
+                for (; j < st->filt_len - 1; j++) {
+                    st->mem[i*st->mem_alloc_size+(st->filt_len-2-j)] = 0;
+                }
+
+                /* Adjust last_sample */
+                st->last_sample[i] += (st->filt_len - olen) / 2;
+
+            } else {
+
+                /* Put back some of the magic! */
+                st->magic_samples[i] = (olen - st->filt_len) / 2;
+
+                for (j = 0; j < st->filt_len - 1 + st->magic_samples[i]; j++) {
+                    st->mem[i*st->mem_alloc_size+j] =
+                        st->mem[i*st->mem_alloc_size+j+st->magic_samples[i]];
+                }
+            }
+        }
+    } else if (st->filt_len < old_length) {
+
+        unsigned int i;
+
+        /* Reduce filter length, this a bit tricky. We need to store
+           some of the memory as "magic" samples so they can be used
+           directly as input the next time(s) */
+
+        for (i = 0; i < st->nb_channels; i++) {
+
+            unsigned int j;
+            unsigned int old_magic = st->magic_samples[i];
+            st->magic_samples[i] = (old_length - st->filt_len) / 2;
+
+            /* We must copy some of the memory that's no longer used */
+            /* Copy data going backward */
+
+            for (j = 0; j < st->filt_len - 1 + st->magic_samples[i] + old_magic; j++) {
+                st->mem[i*st->mem_alloc_size+j] =
+                    st->mem[i*st->mem_alloc_size+j+st->magic_samples[i]];
+	    }
+
+            st->magic_samples[i] += old_magic;
+        }
+    }
+}
+
+SpeexResamplerState *speex_resampler_init(unsigned int nb_channels, unsigned int in_rate, unsigned int out_rate, int quality, int *err)
+{
+    return speex_resampler_init_frac(nb_channels, in_rate, out_rate,
+				     in_rate, out_rate, quality, err);
+}
+
+SpeexResamplerState *speex_resampler_init_frac(unsigned int nb_channels, unsigned int ratio_num, unsigned int ratio_den, unsigned int in_rate, unsigned int out_rate, int quality, int *err)
+{
+    unsigned int i;
+    SpeexResamplerState *st;
+
+    if (quality > 10 || quality < 0) {
+        if (err) *err = RESAMPLER_ERR_INVALID_ARG;
+        return NULL;
+    }
+
+    st = (SpeexResamplerState *)speex_alloc(1, sizeof(SpeexResamplerState));
+
+    st->initialised = 0;
+    st->started = 0;
+    st->in_rate = 0;
+    st->out_rate = 0;
+    st->num_rate = 0;
+    st->den_rate = 0;
+    st->quality = -1;
+	st->sinc_table = 0;
+    st->sinc_table_length = 0;
+    st->sinc_table_alloc = 0;
+    st->mem_alloc_size = 0;
+    st->filt_len = 0;
+    st->mem = 0;
+    st->resampler_ptr = 0;
+
+    st->cutoff = 1.f;
+    st->nb_channels = nb_channels;
+    st->in_stride = 1;
+    st->out_stride = 1;
+
+    /* Per channel data */
+    st->last_sample = (int*)speex_alloc(nb_channels, sizeof(int));
+    st->magic_samples = (unsigned int*)speex_alloc(nb_channels, sizeof(int));
+    st->samp_frac_num = (unsigned int*)speex_alloc(nb_channels, sizeof(int));
+
+    for (i = 0; i < nb_channels; i++) {
+        st->last_sample[i] = 0;
+        st->magic_samples[i] = 0;
+        st->samp_frac_num[i] = 0;
+    }
+
+    speex_resampler_set_quality(st, quality);
+    speex_resampler_set_rate_frac(st, ratio_num, ratio_den, in_rate, out_rate);
+
+    update_filter(st);
+
+    st->initialised = 1;
+
+    if (err) *err = RESAMPLER_ERR_SUCCESS;
+
+    return st;
+}
+
+void speex_resampler_destroy(SpeexResamplerState *st)
+{
+    speex_free(st->mem);
+    speex_free(st->sinc_table);
+    speex_free(st->last_sample);
+    speex_free(st->magic_samples);
+    speex_free(st->samp_frac_num);
+    speex_free(st);
+}
+
+static int speex_resampler_process_native(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    int j = 0;
+    int N = st->filt_len;
+    int out_sample = 0;
+    float *mem;
+    unsigned int tmp_out_len = 0;
+
+    mem = st->mem + channel_index * st->mem_alloc_size;
+    st->started = 1;
+
+    /* Handle the case where we have samples left from a reduction in
+     * filter length */
+
+    if (st->magic_samples[channel_index]) {
+
+        int istride_save;
+        unsigned int tmp_in_len;
+        unsigned int tmp_magic;
+
+        istride_save = st->in_stride;
+        tmp_in_len = st->magic_samples[channel_index];
+        tmp_out_len = *out_len;
+
+        /* magic_samples needs to be set to zero to avoid infinite recursion */
+        tmp_magic = st->magic_samples[channel_index];
+        st->magic_samples[channel_index] = 0;
+        st->in_stride = 1;
+        speex_resampler_process_native(st, channel_index, mem + N-1,
+                                       &tmp_in_len, out, &tmp_out_len);
+        st->in_stride = istride_save;
+
+        /* If we couldn't process all "magic" input samples, save the
+         * rest for next time */
+
+        if (tmp_in_len < tmp_magic) {
+
+            unsigned int i;
+
+            st->magic_samples[channel_index] = tmp_magic - tmp_in_len;
+
+            for (i = 0; i < st->magic_samples[channel_index]; i++) {
+                mem[N-1+i] = mem[N-1+i+tmp_in_len];
+            }
+        }
+
+        out += tmp_out_len * st->out_stride;
+        *out_len -= tmp_out_len;
+    }
+
+    /* Call the right resampler through the function ptr */
+    out_sample = st->resampler_ptr(st, channel_index,
+                                   in, in_len, out, out_len);
+
+    if (st->last_sample[channel_index] < (int)*in_len) {
+        *in_len = st->last_sample[channel_index];
+    }
+
+    *out_len = out_sample + tmp_out_len;
+
+    st->last_sample[channel_index] -= *in_len;
+
+    for (j = 0; j < N-1 - (int)*in_len; j++) {
+        mem[j] = mem[j+*in_len];
+    }
+
+    if (in != NULL) {
+        for ( ; j < N-1; j++) mem[j] = in[st->in_stride*(j+*in_len-N+1)];
+    } else {
+        for ( ; j < N-1; j++) mem[j] = 0;
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+int speex_resampler_process_float(SpeexResamplerState *st, unsigned int channel_index, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    return speex_resampler_process_native(st, channel_index, in, in_len, out, out_len);
+}
+
+int speex_resampler_process_interleaved_float(SpeexResamplerState *st, const float *in, unsigned int *in_len, float *out, unsigned int *out_len)
+{
+    unsigned int i;
+    int istride_save, ostride_save;
+    unsigned int bak_len = *out_len;
+
+    istride_save = st->in_stride;
+    ostride_save = st->out_stride;
+    st->in_stride = st->out_stride = st->nb_channels;
+
+    for (i = 0; i < st->nb_channels; i++) {
+
+        *out_len = bak_len;
+
+        if (in != NULL) {
+            speex_resampler_process_float(st, i, in + i, in_len, out + i, out_len);
+        } else {
+            speex_resampler_process_float(st, i, NULL, in_len, out + i, out_len);
+        }
+    }
+
+    st->in_stride = istride_save;
+    st->out_stride = ostride_save;
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+int speex_resampler_set_rate(SpeexResamplerState *st, unsigned int in_rate, unsigned int out_rate)
+{
+    return speex_resampler_set_rate_frac(st, in_rate, out_rate, in_rate, out_rate);
+}
+
+void speex_resampler_get_rate(SpeexResamplerState *st, unsigned int *in_rate, unsigned int *out_rate)
+{
+    *in_rate = st->in_rate;
+    *out_rate = st->out_rate;
+}
+
+static unsigned int gcd(unsigned int a, unsigned int b)
+{
+    /* Euclid */
+
+    while (b) {
+        unsigned int tmp = b;
+        b = a % b;
+        a = tmp;
+    }
+
+    return a;
+}
+
+int speex_resampler_set_rate_frac(SpeexResamplerState *st, unsigned int ratio_num, unsigned int ratio_den, unsigned int in_rate, unsigned int out_rate)
+{
+    unsigned int old_den;
+    unsigned int i;
+	unsigned int g;
+
+    if (st->in_rate == in_rate && st->out_rate == out_rate &&
+	st->num_rate == ratio_num && st->den_rate == ratio_den) {
+        return RESAMPLER_ERR_SUCCESS;
+    }
+
+    old_den = st->den_rate;
+
+    st->in_rate = in_rate;
+    st->out_rate = out_rate;
+
+    st->num_rate = ratio_num;
+    st->den_rate = ratio_den;
+
+    g = gcd(st->num_rate, st->den_rate);
+
+    st->num_rate /= g;
+    st->den_rate /= g;
+
+    if (old_den > 0) {
+
+        for (i = 0; i < st->nb_channels; i++) {
+
+            st->samp_frac_num[i] = st->samp_frac_num[i] * st->den_rate / old_den;
+
+            if (st->samp_frac_num[i] >= st->den_rate) {
+                st->samp_frac_num[i] = st->den_rate - 1;
+	    }
+        }
+    }
+
+    if (st->initialised) {
+        update_filter(st);
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+void speex_resampler_get_ratio(SpeexResamplerState *st, unsigned int *ratio_num, unsigned int *ratio_den)
+{
+    *ratio_num = st->num_rate;
+    *ratio_den = st->den_rate;
+}
+
+int speex_resampler_set_quality(SpeexResamplerState *st, int quality)
+{
+    if (quality > 10 || quality < 0) {
+        return RESAMPLER_ERR_INVALID_ARG;
+    }
+
+    if (st->quality == quality) {
+        return RESAMPLER_ERR_SUCCESS;
+    }
+
+    st->quality = quality;
+
+    if (st->initialised) {
+        update_filter(st); 
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+void speex_resampler_get_quality(SpeexResamplerState *st, int *quality)
+{
+    *quality = st->quality;
+}
+
+void speex_resampler_set_input_stride(SpeexResamplerState *st, unsigned int stride)
+{
+    st->in_stride = stride;
+}
+
+void speex_resampler_get_input_stride(SpeexResamplerState *st, unsigned int *stride)
+{
+    *stride = st->in_stride;
+}
+
+void speex_resampler_set_output_stride(SpeexResamplerState *st, unsigned int stride)
+{
+    st->out_stride = stride;
+}
+
+void speex_resampler_get_output_stride(SpeexResamplerState *st, unsigned int *stride)
+{
+    *stride = st->out_stride;
+}
+
+int speex_resampler_get_input_latency(SpeexResamplerState *st)
+{
+    return st->filt_len / 2;
+}
+
+int speex_resampler_get_output_latency(SpeexResamplerState *st) 
+{
+    return ((st->filt_len / 2) * st->den_rate + (st->num_rate >> 1)) / st->num_rate;
+}
+
+int speex_resampler_skip_zeros(SpeexResamplerState *st)
+{
+    unsigned int i;
+
+    for (i = 0; i < st->nb_channels; i++) {
+        st->last_sample[i] = st->filt_len / 2;
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+int speex_resampler_reset_mem(SpeexResamplerState *st)
+{
+    unsigned int i;
+
+    for (i = 0; i < st->nb_channels*(st->filt_len - 1); i++) {
+        st->mem[i] = 0;
+    }
+
+    for (i = 0; i < st->nb_channels; i++) {
+        st->last_sample[i] = 0;
+        st->magic_samples[i] = 0;
+        st->samp_frac_num[i] = 0;
+    }
+
+    return RESAMPLER_ERR_SUCCESS;
+}
+
+const char *speex_resampler_strerror(int err)
+{
+    switch (err) {
+
+    case RESAMPLER_ERR_SUCCESS:
+        return "Success.";
+
+    case RESAMPLER_ERR_ALLOC_FAILED:
+        return "Memory allocation failed.";
+
+    case RESAMPLER_ERR_BAD_STATE:
+        return "Bad resampler state.";
+
+    case RESAMPLER_ERR_INVALID_ARG:
+        return "Invalid argument.";
+
+    case RESAMPLER_ERR_PTR_OVERLAP:
+        return "Input and output buffers overlap.";
+
+    default:
+        return "Unknown error. Bad error code or strange version mismatch.";
+    }
+}

--- a/pedalboard/vendors/rubberband/src/speex/speex_resampler.h
+++ b/pedalboard/vendors/rubberband/src/speex/speex_resampler.h
@@ -1,0 +1,301 @@
+/* Copyright (C) 2007 Jean-Marc Valin
+      
+   File: speex_resampler.h
+   Resampling code
+      
+   The design goals of this code are:
+      - Very fast algorithm
+      - Low memory requirement
+      - Good *perceptual* quality (and not best SNR)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+   ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef SPEEX_RESAMPLER_H
+#define SPEEX_RESAMPLER_H
+
+/********* WARNING: MENTAL SANITY ENDS HERE *************/
+
+/* If the resampler is defined outside of Speex, we change the symbol
+   names so that there won't be any clash if linking with Speex later
+   on. */
+
+#define RANDOM_PREFIX rubberband
+
+#ifndef RANDOM_PREFIX
+#error "Please define RANDOM_PREFIX (above) to something specific to your project to prevent symbol name clashes"
+#endif
+
+#define CAT_PREFIX2(a,b) a ## b
+#define CAT_PREFIX(a,b) CAT_PREFIX2(a, b)
+      
+#define speex_resampler_init CAT_PREFIX(RANDOM_PREFIX,_resampler_init)
+#define speex_resampler_init_frac CAT_PREFIX(RANDOM_PREFIX,_resampler_init_frac)
+#define speex_resampler_destroy CAT_PREFIX(RANDOM_PREFIX,_resampler_destroy)
+#define speex_resampler_process_float CAT_PREFIX(RANDOM_PREFIX,_resampler_process_float)
+#define speex_resampler_process_int CAT_PREFIX(RANDOM_PREFIX,_resampler_process_int)
+#define speex_resampler_process_interleaved_float CAT_PREFIX(RANDOM_PREFIX,_resampler_process_interleaved_float)
+#define speex_resampler_process_interleaved_int CAT_PREFIX(RANDOM_PREFIX,_resampler_process_interleaved_int)
+#define speex_resampler_set_rate CAT_PREFIX(RANDOM_PREFIX,_resampler_set_rate)
+#define speex_resampler_get_rate CAT_PREFIX(RANDOM_PREFIX,_resampler_get_rate)
+#define speex_resampler_set_rate_frac CAT_PREFIX(RANDOM_PREFIX,_resampler_set_rate_frac)
+#define speex_resampler_get_ratio CAT_PREFIX(RANDOM_PREFIX,_resampler_get_ratio)
+#define speex_resampler_set_quality CAT_PREFIX(RANDOM_PREFIX,_resampler_set_quality)
+#define speex_resampler_get_quality CAT_PREFIX(RANDOM_PREFIX,_resampler_get_quality)
+#define speex_resampler_set_input_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_set_input_stride)
+#define speex_resampler_get_input_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_get_input_stride)
+#define speex_resampler_set_output_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_set_output_stride)
+#define speex_resampler_get_output_stride CAT_PREFIX(RANDOM_PREFIX,_resampler_get_output_stride)
+#define speex_resampler_get_input_latency CAT_PREFIX(RANDOM_PREFIX,_resampler_get_input_latency)
+#define speex_resampler_get_output_latency CAT_PREFIX(RANDOM_PREFIX,_resampler_get_output_latency)
+#define speex_resampler_skip_zeros CAT_PREFIX(RANDOM_PREFIX,_resampler_skip_zeros)
+#define speex_resampler_reset_mem CAT_PREFIX(RANDOM_PREFIX,_resampler_reset_mem)
+#define speex_resampler_strerror CAT_PREFIX(RANDOM_PREFIX,_resampler_strerror)
+
+#define spx_int16_t short
+#define spx_int32_t int
+#define spx_uint16_t unsigned short
+#define spx_uint32_t unsigned int
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SPEEX_RESAMPLER_QUALITY_MAX 10
+#define SPEEX_RESAMPLER_QUALITY_MIN 0
+#define SPEEX_RESAMPLER_QUALITY_DEFAULT 4
+#define SPEEX_RESAMPLER_QUALITY_VOIP 3
+#define SPEEX_RESAMPLER_QUALITY_DESKTOP 5
+
+enum {
+   RESAMPLER_ERR_SUCCESS         = 0,
+   RESAMPLER_ERR_ALLOC_FAILED    = 1,
+   RESAMPLER_ERR_BAD_STATE       = 2,
+   RESAMPLER_ERR_INVALID_ARG     = 3,
+   RESAMPLER_ERR_PTR_OVERLAP     = 4,
+   
+   RESAMPLER_ERR_MAX_ERROR
+};
+
+struct SpeexResamplerState_;
+typedef struct SpeexResamplerState_ SpeexResamplerState;
+
+/** Create a new resampler with integer input and output rates.
+ * @param nb_channels Number of channels to be processed
+ * @param in_rate Input sampling rate (integer number of Hz).
+ * @param out_rate Output sampling rate (integer number of Hz).
+ * @param quality Resampling quality between 0 and 10, where 0 has poor quality
+ * and 10 has very high quality.
+ * @return Newly created resampler state
+ * @retval NULL Error: not enough memory
+ */
+SpeexResamplerState *speex_resampler_init(spx_uint32_t nb_channels, 
+                                          spx_uint32_t in_rate, 
+                                          spx_uint32_t out_rate, 
+                                          int quality,
+                                          int *err);
+
+/** Create a new resampler with fractional input/output rates. The sampling 
+ * rate ratio is an arbitrary rational number with both the numerator and 
+ * denominator being 32-bit integers.
+ * @param nb_channels Number of channels to be processed
+ * @param ratio_num Numerator of the sampling rate ratio
+ * @param ratio_den Denominator of the sampling rate ratio
+ * @param in_rate Input sampling rate rounded to the nearest integer (in Hz).
+ * @param out_rate Output sampling rate rounded to the nearest integer (in Hz).
+ * @param quality Resampling quality between 0 and 10, where 0 has poor quality
+ * and 10 has very high quality.
+ * @return Newly created resampler state
+ * @retval NULL Error: not enough memory
+ */
+SpeexResamplerState *speex_resampler_init_frac(spx_uint32_t nb_channels, 
+                                               spx_uint32_t ratio_num, 
+                                               spx_uint32_t ratio_den, 
+                                               spx_uint32_t in_rate, 
+                                               spx_uint32_t out_rate, 
+                                               int quality,
+                                               int *err);
+
+/** Destroy a resampler state.
+ * @param st Resampler state
+ */
+void speex_resampler_destroy(SpeexResamplerState *st);
+
+/** Resample a float array. The input and output buffers must *not* overlap.
+ * @param st Resampler state
+ * @param channel_index Index of the channel to process for the multi-channel 
+ * base (0 otherwise)
+ * @param in Input buffer
+ * @param in_len Number of input samples in the input buffer. Returns the 
+ * number of samples processed
+ * @param out Output buffer
+ * @param out_len Size of the output buffer. Returns the number of samples written
+ */
+int speex_resampler_process_float(SpeexResamplerState *st, 
+                                   spx_uint32_t channel_index, 
+                                   const float *in, 
+                                   spx_uint32_t *in_len, 
+                                   float *out, 
+                                   spx_uint32_t *out_len);
+
+/** Resample an interleaved float array. The input and output buffers must *not* overlap.
+ * @param st Resampler state
+ * @param in Input buffer
+ * @param in_len Number of input samples in the input buffer. Returns the number
+ * of samples processed. This is all per-channel.
+ * @param out Output buffer
+ * @param out_len Size of the output buffer. Returns the number of samples written.
+ * This is all per-channel.
+ */
+int speex_resampler_process_interleaved_float(SpeexResamplerState *st, 
+                                               const float *in, 
+                                               spx_uint32_t *in_len, 
+                                               float *out, 
+                                               spx_uint32_t *out_len);
+
+/** Set (change) the input/output sampling rates (integer value).
+ * @param st Resampler state
+ * @param in_rate Input sampling rate (integer number of Hz).
+ * @param out_rate Output sampling rate (integer number of Hz).
+ */
+int speex_resampler_set_rate(SpeexResamplerState *st, 
+                              spx_uint32_t in_rate, 
+                              spx_uint32_t out_rate);
+
+/** Get the current input/output sampling rates (integer value).
+ * @param st Resampler state
+ * @param in_rate Input sampling rate (integer number of Hz) copied.
+ * @param out_rate Output sampling rate (integer number of Hz) copied.
+ */
+void speex_resampler_get_rate(SpeexResamplerState *st, 
+                              spx_uint32_t *in_rate, 
+                              spx_uint32_t *out_rate);
+
+/** Set (change) the input/output sampling rates and resampling ratio 
+ * (fractional values in Hz supported).
+ * @param st Resampler state
+ * @param ratio_num Numerator of the sampling rate ratio
+ * @param ratio_den Denominator of the sampling rate ratio
+ * @param in_rate Input sampling rate rounded to the nearest integer (in Hz).
+ * @param out_rate Output sampling rate rounded to the nearest integer (in Hz).
+ */
+int speex_resampler_set_rate_frac(SpeexResamplerState *st, 
+                                   spx_uint32_t ratio_num, 
+                                   spx_uint32_t ratio_den, 
+                                   spx_uint32_t in_rate, 
+                                   spx_uint32_t out_rate);
+
+/** Get the current resampling ratio. This will be reduced to the least
+ * common denominator.
+ * @param st Resampler state
+ * @param ratio_num Numerator of the sampling rate ratio copied
+ * @param ratio_den Denominator of the sampling rate ratio copied
+ */
+void speex_resampler_get_ratio(SpeexResamplerState *st, 
+                               spx_uint32_t *ratio_num, 
+                               spx_uint32_t *ratio_den);
+
+/** Set (change) the conversion quality.
+ * @param st Resampler state
+ * @param quality Resampling quality between 0 and 10, where 0 has poor 
+ * quality and 10 has very high quality.
+ */
+int speex_resampler_set_quality(SpeexResamplerState *st, 
+                                 int quality);
+
+/** Get the conversion quality.
+ * @param st Resampler state
+ * @param quality Resampling quality between 0 and 10, where 0 has poor 
+ * quality and 10 has very high quality.
+ */
+void speex_resampler_get_quality(SpeexResamplerState *st, 
+                                 int *quality);
+
+/** Set (change) the input stride.
+ * @param st Resampler state
+ * @param stride Input stride
+ */
+void speex_resampler_set_input_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t stride);
+
+/** Get the input stride.
+ * @param st Resampler state
+ * @param stride Input stride copied
+ */
+void speex_resampler_get_input_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t *stride);
+
+/** Set (change) the output stride.
+ * @param st Resampler state
+ * @param stride Output stride
+ */
+void speex_resampler_set_output_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t stride);
+
+/** Get the output stride.
+ * @param st Resampler state copied
+ * @param stride Output stride
+ */
+void speex_resampler_get_output_stride(SpeexResamplerState *st, 
+                                      spx_uint32_t *stride);
+
+/** Get the latency in input samples introduced by the resampler.
+ * @param st Resampler state
+ */
+int speex_resampler_get_input_latency(SpeexResamplerState *st);
+
+/** Get the latency in output samples introduced by the resampler.
+ * @param st Resampler state
+ */
+int speex_resampler_get_output_latency(SpeexResamplerState *st);
+
+/** Make sure that the first samples to go out of the resamplers don't have 
+ * leading zeros. This is only useful before starting to use a newly created 
+ * resampler. It is recommended to use that when resampling an audio file, as
+ * it will generate a file with the same length. For real-time processing,
+ * it is probably easier not to use this call (so that the output duration
+ * is the same for the first frame).
+ * @param st Resampler state
+ */
+int speex_resampler_skip_zeros(SpeexResamplerState *st);
+
+/** Reset a resampler so a new (unrelated) stream can be processed.
+ * @param st Resampler state
+ */
+int speex_resampler_reset_mem(SpeexResamplerState *st);
+
+/** Returns the English meaning for an error code
+ * @param err Error code
+ * @return English string
+ */
+const char *speex_resampler_strerror(int err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/pedalboard/vendors/rubberband/src/system/Allocators.cpp
+++ b/pedalboard/vendors/rubberband/src/system/Allocators.cpp
@@ -1,0 +1,69 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "Allocators.h"
+
+#ifdef HAVE_IPP
+#include <ipps.h>
+#endif
+
+#include <iostream>
+using std::cerr;
+using std::endl;
+
+namespace RubberBand {
+
+#ifdef HAVE_IPP
+
+template <>
+float *allocate(size_t count)
+{
+    float *ptr = ippsMalloc_32f(count);
+    if (!ptr) throw (std::bad_alloc());
+    return ptr;
+}
+
+template <>
+double *allocate(size_t count)
+{
+    double *ptr = ippsMalloc_64f(count);
+    if (!ptr) throw (std::bad_alloc());
+    return ptr;
+}
+
+template <>
+void deallocate(float *ptr)
+{
+    if (ptr) ippsFree((void *)ptr);
+}
+
+template <>
+void deallocate(double *ptr)
+{
+    if (ptr) ippsFree((void *)ptr);
+}
+
+#endif
+
+}
+

--- a/pedalboard/vendors/rubberband/src/system/Allocators.h
+++ b/pedalboard/vendors/rubberband/src/system/Allocators.h
@@ -1,0 +1,407 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_ALLOCATORS_H
+#define RUBBERBAND_ALLOCATORS_H
+
+#include "VectorOps.h"
+
+#include <new> // for std::bad_alloc
+#include <stdlib.h>
+
+#include <stdexcept>
+
+#ifndef HAVE_POSIX_MEMALIGN
+#ifndef _WIN32
+#ifndef __APPLE__
+#ifndef LACK_POSIX_MEMALIGN
+#define HAVE_POSIX_MEMALIGN
+#endif
+#endif
+#endif
+#endif
+
+#ifndef MALLOC_IS_ALIGNED
+#ifndef MALLOC_IS_NOT_ALIGNED
+#ifdef __APPLE__
+#define MALLOC_IS_ALIGNED
+#endif
+#endif
+#endif
+
+#ifndef HAVE__ALIGNED_MALLOC
+#ifndef LACK__ALIGNED_MALLOC
+#ifdef _WIN32
+#define HAVE__ALIGNED_MALLOC
+#endif
+#endif
+#endif
+
+#ifdef HAVE_POSIX_MEMALIGN
+#include <sys/mman.h>
+#include <errno.h>
+#endif
+
+#ifdef LACK_BAD_ALLOC
+namespace std { struct bad_alloc { }; }
+#endif
+
+namespace RubberBand {
+
+template <typename T>
+T *allocate(size_t count)
+{
+    void *ptr = 0;
+
+    // We'd like to check HAVE_IPP first and, if it's defined, call
+    // ippsMalloc_8u(count * sizeof(T)). But that isn't a general
+    // replacement for malloc() because it only takes an int
+    // argument. So we save it for the specialisations of
+    // allocate<float> and allocate<double> below, where we're more
+    // likely to get away with it.
+
+#ifdef MALLOC_IS_ALIGNED
+    ptr = malloc(count * sizeof(T));
+#else /* !MALLOC_IS_ALIGNED */
+
+    // That's the "sufficiently aligned" functions dealt with, the
+    // rest need a specific alignment provided to the call. 32-byte
+    // alignment is required for at least OpenMAX
+    static const int alignment = 32;
+
+#ifdef HAVE__ALIGNED_MALLOC
+    ptr = _aligned_malloc(count * sizeof(T), alignment);
+#else /* !HAVE__ALIGNED_MALLOC */
+
+#ifdef HAVE_POSIX_MEMALIGN
+    int rv = posix_memalign(&ptr, alignment, count * sizeof(T));
+    if (rv) {
+#ifndef NO_EXCEPTIONS
+        if (rv == EINVAL) {
+            throw "Internal error: invalid alignment";
+        } else {
+            throw std::bad_alloc();
+        }
+#else
+        abort();
+#endif
+    }
+#else /* !HAVE_POSIX_MEMALIGN */
+    
+#ifdef USE_OWN_ALIGNED_MALLOC
+#pragma message("Rolling own aligned malloc: this is unlikely to perform as well as the alternatives")
+
+    // Alignment must be a power of two, bigger than the pointer
+    // size. Stuff the actual malloc'd pointer in just before the
+    // returned value.  This is the least desirable way to do this --
+    // the other options below are all better
+    size_t allocd = count * sizeof(T) + alignment;
+    void *buf = malloc(allocd);
+    if (buf) {
+        char *adj = (char *)buf;
+        while ((unsigned long long)adj & (alignment-1)) --adj;
+        ptr = ((char *)adj) + alignment;
+        new (((void **)ptr)[-1]) (void *);
+        ((void **)ptr)[-1] = buf;
+    }
+
+#else /* !USE_OWN_ALIGNED_MALLOC */
+
+#error "No aligned malloc available: define MALLOC_IS_ALIGNED to use system malloc, HAVE_POSIX_MEMALIGN if posix_memalign is available, HAVE__ALIGNED_MALLOC if _aligned_malloc is available, or USE_OWN_ALIGNED_MALLOC to roll our own"
+
+#endif /* !USE_OWN_ALIGNED_MALLOC */
+#endif /* !HAVE_POSIX_MEMALIGN */
+#endif /* !HAVE__ALIGNED_MALLOC */
+#endif /* !MALLOC_IS_ALIGNED */
+
+    if (!ptr) {
+#ifndef NO_EXCEPTIONS
+        throw std::bad_alloc();
+#else
+        abort();
+#endif
+    }
+
+    T *typed_ptr = static_cast<T *>(ptr);
+    for (size_t i = 0; i < count; ++i) {
+        new (typed_ptr + i) T;
+    }
+    return typed_ptr;
+}
+
+#ifdef HAVE_IPP
+
+template <>
+float *allocate(size_t count);
+
+template <>
+double *allocate(size_t count);
+
+#endif
+	
+template <typename T>
+T *allocate_and_zero(size_t count)
+{
+    T *ptr = allocate<T>(count);
+    v_zero(ptr, count);
+    return ptr;
+}
+
+template <typename T>
+void deallocate(T *ptr)
+{
+    if (!ptr) return;
+    
+#ifdef MALLOC_IS_ALIGNED
+    free((void *)ptr);
+#else /* !MALLOC_IS_ALIGNED */
+
+#ifdef HAVE__ALIGNED_MALLOC
+    _aligned_free((void *)ptr);
+#else /* !HAVE__ALIGNED_MALLOC */
+
+#ifdef HAVE_POSIX_MEMALIGN
+    free((void *)ptr);
+#else /* !HAVE_POSIX_MEMALIGN */
+    
+#ifdef USE_OWN_ALIGNED_MALLOC
+    free(((void **)ptr)[-1]);
+#else /* !USE_OWN_ALIGNED_MALLOC */
+
+#error "No aligned malloc available: define MALLOC_IS_ALIGNED to use system malloc, HAVE_POSIX_MEMALIGN if posix_memalign is available, or USE_OWN_ALIGNED_MALLOC to roll our own"
+
+#endif /* !USE_OWN_ALIGNED_MALLOC */
+#endif /* !HAVE_POSIX_MEMALIGN */
+#endif /* !HAVE__ALIGNED_MALLOC */
+#endif /* !MALLOC_IS_ALIGNED */
+}
+
+#ifdef HAVE_IPP
+
+template <>
+void deallocate(float *);
+
+template <>
+void deallocate(double *);
+
+#endif
+
+/// Reallocate preserving contents but leaving additional memory uninitialised	
+template <typename T>
+T *reallocate(T *ptr, size_t oldcount, size_t count)
+{
+    T *newptr = allocate<T>(count);
+    if (oldcount && ptr) {
+        v_copy(newptr, ptr, oldcount < count ? oldcount : count);
+    }
+    if (ptr) deallocate<T>(ptr);
+    return newptr;
+}
+
+/// Reallocate, zeroing all contents
+template <typename T>
+T *reallocate_and_zero(T *ptr, size_t oldcount, size_t count)
+{
+    ptr = reallocate(ptr, oldcount, count);
+    v_zero(ptr, count);
+    return ptr;
+}
+	
+/// Reallocate preserving contents and zeroing any additional memory	
+template <typename T>
+T *reallocate_and_zero_extension(T *ptr, size_t oldcount, size_t count)
+{
+    ptr = reallocate(ptr, oldcount, count);
+    if (count > oldcount) v_zero(ptr + oldcount, count - oldcount);
+    return ptr;
+}
+
+template <typename T>
+T **allocate_channels(size_t channels, size_t count)
+{
+    T **ptr = allocate<T *>(channels);
+    for (size_t c = 0; c < channels; ++c) {
+        ptr[c] = allocate<T>(count);
+    }
+    return ptr;
+}
+	
+template <typename T>
+T **allocate_and_zero_channels(size_t channels, size_t count)
+{
+    T **ptr = allocate<T *>(channels);
+    for (size_t c = 0; c < channels; ++c) {
+        ptr[c] = allocate_and_zero<T>(count);
+    }
+    return ptr;
+}
+
+template <typename T>
+void deallocate_channels(T **ptr, size_t channels)
+{
+    if (!ptr) return;
+    for (size_t c = 0; c < channels; ++c) {
+        deallocate<T>(ptr[c]);
+    }
+    deallocate<T *>(ptr);
+}
+	
+template <typename T>
+T **reallocate_channels(T **ptr,
+                        size_t oldchannels, size_t oldcount,
+                        size_t channels, size_t count)
+{
+    T **newptr = allocate_channels<T>(channels, count);
+    if (oldcount && ptr) {
+        for (size_t c = 0; c < oldchannels && c < channels; ++c) {
+            for (size_t i = 0; i < oldcount && i < count; ++i) {
+                newptr[c][i] = ptr[c][i];
+            }
+        }
+    } 
+    if (ptr) deallocate_channels<T>(ptr, oldchannels);
+    return newptr;
+}
+	
+template <typename T>
+T **reallocate_and_zero_extend_channels(T **ptr,
+                                        size_t oldchannels, size_t oldcount,
+                                        size_t channels, size_t count)
+{
+    T **newptr = allocate_and_zero_channels<T>(channels, count);
+    if (oldcount && ptr) {
+        for (size_t c = 0; c < oldchannels && c < channels; ++c) {
+            for (size_t i = 0; i < oldcount && i < count; ++i) {
+                newptr[c][i] = ptr[c][i];
+            }
+        }
+    } 
+    if (ptr) deallocate_channels<T>(ptr, oldchannels);
+    return newptr;
+}
+
+/// RAII class to call deallocate() on destruction
+template <typename T>
+class Deallocator
+{
+public:
+    Deallocator(T *t) : m_t(t) { }
+    ~Deallocator() { deallocate<T>(m_t); }
+private:
+    T *m_t;
+};
+
+/** Allocator for use with STL classes, e.g. vector, to ensure
+ *  alignment.  Based on example code by Stephan T. Lavavej.
+ *
+ *  e.g. std::vector<float, StlAllocator<float> > v;
+ */
+template <typename T>
+class StlAllocator
+{
+public:
+    typedef T *pointer;
+    typedef const T *const_pointer;
+    typedef T &reference;
+    typedef const T &const_reference;
+    typedef T value_type;
+    typedef size_t size_type;
+    typedef ptrdiff_t difference_type;
+
+    StlAllocator() { }
+    StlAllocator(const StlAllocator&) { }
+    template <typename U> StlAllocator(const StlAllocator<U>&) { }
+    ~StlAllocator() { }
+
+    T *
+    allocate(const size_t n) const {
+        if (n == 0) return 0;
+        if (n > max_size()) {
+#ifndef NO_EXCEPTIONS
+            throw std::length_error("Size overflow in StlAllocator::allocate()");
+#else
+            abort();
+#endif
+        }
+        return RubberBand::allocate<T>(n);
+    }
+
+    void
+    deallocate(T *const p, const size_t) const {
+        RubberBand::deallocate(p);
+    }
+
+    template <typename U>
+    T *
+    allocate(const size_t n, const U *) const {
+        return allocate(n);
+    }
+
+    T *
+    address(T &r) const {
+        return &r;
+    }
+
+    const T *
+    address(const T &s) const {
+        return &s;
+    }
+
+    size_t
+    max_size() const {
+        return (static_cast<size_t>(0) - static_cast<size_t>(1)) / sizeof(T);
+    }
+
+    template <typename U> struct rebind {
+        typedef StlAllocator<U> other;
+    };
+    
+    bool
+    operator==(const StlAllocator &) const {
+        return true;
+    }
+
+    bool
+    operator!=(const StlAllocator &) const {
+        return false;
+    }
+
+    void
+    construct(T *const p, const T &t) const {
+        void *const pv = static_cast<void *>(p);
+        new (pv) T(t);
+    }
+
+    void
+    destroy(T *const p) const {
+        p->~T();
+    }
+
+private:
+    StlAllocator& operator=(const StlAllocator&);
+};
+
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/system/Thread.cpp
+++ b/pedalboard/vendors/rubberband/src/system/Thread.cpp
@@ -1,0 +1,671 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef NO_THREADING
+
+#include "Thread.h"
+
+#include <iostream>
+#include <cstdlib>
+
+#ifdef USE_PTHREADS
+#include <sys/time.h>
+#include <time.h>
+#endif
+
+using std::cerr;
+using std::endl;
+using std::string;
+
+namespace RubberBand
+{
+
+#ifdef _WIN32
+
+Thread::Thread() :
+    m_id(0),
+    m_extant(false)
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Created thread object " << this << endl;
+#endif
+}
+
+Thread::~Thread()
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroying thread object " << this << ", id " << m_id << endl;
+#endif
+    if (m_extant) {
+        WaitForSingleObject(m_id, INFINITE);
+    }
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroyed thread object " << this << endl;
+#endif
+}
+
+void
+Thread::start()
+{
+    m_id = CreateThread(NULL, 0, staticRun, this, 0, 0);
+    if (!m_id) {
+        cerr << "ERROR: thread creation failed" << endl;
+        exit(1);
+    } else {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Created thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = true;
+    }
+}    
+
+void 
+Thread::wait()
+{
+    if (m_extant) {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waiting on thread " << m_id << " for thread object " << this << endl;
+#endif
+        WaitForSingleObject(m_id, INFINITE);
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waited on thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = false;
+    }
+}
+
+Thread::Id
+Thread::id()
+{
+    return m_id;
+}
+
+bool
+Thread::threadingAvailable()
+{
+    return true;
+}
+
+DWORD
+Thread::staticRun(LPVOID arg)
+{
+    Thread *thread = static_cast<Thread *>(arg);
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: " << (void *)GetCurrentThreadId() << ": Running thread " << thread->m_id << " for thread object " << thread << endl;
+#endif
+    thread->run();
+    return 0;
+}
+
+Mutex::Mutex()
+#ifndef NO_THREAD_CHECKS
+    :
+    m_lockedBy(-1)
+#endif
+{
+    m_mutex = CreateMutex(NULL, FALSE, NULL);
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)GetCurrentThreadId() << ": Initialised mutex " << &m_mutex << endl;
+#endif
+}
+
+Mutex::~Mutex()
+{
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)GetCurrentThreadId() << ": Destroying mutex " << &m_mutex << endl;
+#endif
+    CloseHandle(m_mutex);
+}
+
+void
+Mutex::lock()
+{
+#ifndef NO_THREAD_CHECKS
+    DWORD tid = GetCurrentThreadId();
+    if (m_lockedBy == tid) {
+        cerr << "ERROR: Deadlock on mutex " << &m_mutex << endl;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Want to lock mutex " << &m_mutex << endl;
+#endif
+    WaitForSingleObject(m_mutex, INFINITE);
+#ifndef NO_THREAD_CHECKS
+    m_lockedBy = tid;
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << endl;
+#endif
+}
+
+void
+Mutex::unlock()
+{
+#ifndef NO_THREAD_CHECKS
+    DWORD tid = GetCurrentThreadId();
+    if (m_lockedBy != tid) {
+        cerr << "ERROR: Mutex " << &m_mutex << " not owned by unlocking thread" << endl;
+        return;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Unlocking mutex " << &m_mutex << endl;
+#endif
+#ifndef NO_THREAD_CHECKS
+    m_lockedBy = -1;
+#endif
+    ReleaseMutex(m_mutex);
+}
+
+bool
+Mutex::trylock()
+{
+#ifndef NO_THREAD_CHECKS
+    DWORD tid = GetCurrentThreadId();
+#endif
+    DWORD result = WaitForSingleObject(m_mutex, 0);
+    if (result == WAIT_TIMEOUT || result == WAIT_FAILED) {
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Mutex " << &m_mutex << " unavailable" << endl;
+#endif
+        return false;
+    } else {
+#ifndef NO_THREAD_CHECKS
+        m_lockedBy = tid;
+#endif
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << " (from trylock)" << endl;
+#endif
+        return true;
+    }
+}
+
+Condition::Condition(string
+#ifdef DEBUG_CONDITION
+                     name
+#endif
+    ) :
+    m_locked(false)
+#ifdef DEBUG_CONDITION
+    , m_name(name)
+#endif
+{
+    m_mutex = CreateMutex(NULL, FALSE, NULL);
+    m_condition = CreateEvent(NULL, FALSE, FALSE, NULL);
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Initialised condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+Condition::~Condition()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Destroying condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    if (m_locked) ReleaseMutex(m_mutex);
+    CloseHandle(m_condition);
+    CloseHandle(m_mutex);
+}
+
+void
+Condition::lock()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Want to lock " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    WaitForSingleObject(m_mutex, INFINITE);
+    m_locked = true;
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+void
+Condition::unlock()
+{
+    if (!m_locked) {
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Not locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        return;
+    }
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Unlocking " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = false;
+    ReleaseMutex(m_mutex);
+}
+
+void 
+Condition::wait(int us)
+{
+    if (us == 0) {
+
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        SignalObjectAndWait(m_mutex, m_condition, INFINITE, FALSE);
+        WaitForSingleObject(m_mutex, INFINITE);
+
+    } else {
+
+        DWORD ms = us / 1000;
+        if (us > 0 && ms == 0) ms = 1;
+    
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Timed waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        SignalObjectAndWait(m_mutex, m_condition, ms, FALSE);
+        WaitForSingleObject(m_mutex, INFINITE);
+    }
+
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Wait done on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = true;
+}
+
+void
+Condition::signal()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)GetCurrentThreadId() << ": Signalling " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    SetEvent(m_condition);
+}
+
+#else /* !_WIN32 */
+
+#ifdef USE_PTHREADS
+
+Thread::Thread() :
+    m_id(0),
+    m_extant(false)
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Created thread object " << this << endl;
+#endif
+}
+
+Thread::~Thread()
+{
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroying thread object " << this << ", id " << m_id << endl;
+#endif
+    if (m_extant) {
+        pthread_join(m_id, 0);
+    }
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: Destroyed thread object " << this << endl;
+#endif
+}
+
+void
+Thread::start()
+{
+    if (pthread_create(&m_id, 0, staticRun, this)) {
+        cerr << "ERROR: thread creation failed" << endl;
+        exit(1);
+    } else {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Created thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = true;
+    }
+}    
+
+void 
+Thread::wait()
+{
+    if (m_extant) {
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waiting on thread " << m_id << " for thread object " << this << endl;
+#endif
+        pthread_join(m_id, 0);
+#ifdef DEBUG_THREAD
+        cerr << "THREAD DEBUG: Waited on thread " << m_id << " for thread object " << this << endl;
+#endif
+        m_extant = false;
+    }
+}
+
+Thread::Id
+Thread::id()
+{
+    return m_id;
+}
+
+bool
+Thread::threadingAvailable()
+{
+    return true;
+}
+
+void *
+Thread::staticRun(void *arg)
+{
+    Thread *thread = static_cast<Thread *>(arg);
+#ifdef DEBUG_THREAD
+    cerr << "THREAD DEBUG: " << (void *)pthread_self() << ": Running thread " << thread->m_id << " for thread object " << thread << endl;
+#endif
+    thread->run();
+    return 0;
+}
+
+Mutex::Mutex()
+#ifndef NO_THREAD_CHECKS
+    :
+    m_lockedBy(0),
+    m_locked(false)
+#endif
+{
+    pthread_mutex_init(&m_mutex, 0);
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)pthread_self() << ": Initialised mutex " << &m_mutex << endl;
+#endif
+}
+
+Mutex::~Mutex()
+{
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)pthread_self() << ": Destroying mutex " << &m_mutex << endl;
+#endif
+    pthread_mutex_destroy(&m_mutex);
+}
+
+void
+Mutex::lock()
+{
+#ifndef NO_THREAD_CHECKS
+    pthread_t tid = pthread_self();
+    if (m_locked && m_lockedBy == tid) {
+        cerr << "ERROR: Deadlock on mutex " << &m_mutex << endl;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Want to lock mutex " << &m_mutex << endl;
+#endif
+    pthread_mutex_lock(&m_mutex);
+#ifndef NO_THREAD_CHECKS
+    m_lockedBy = tid;
+    m_locked = true;
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << endl;
+#endif
+}
+
+void
+Mutex::unlock()
+{
+#ifndef NO_THREAD_CHECKS
+    pthread_t tid = pthread_self();
+    if (!m_locked) {
+        cerr << "ERROR: Mutex " << &m_mutex << " not locked in unlock" << endl;
+        return;
+    } else if (m_lockedBy != tid) {
+        cerr << "ERROR: Mutex " << &m_mutex << " not owned by unlocking thread" << endl;
+        return;
+    }
+#endif
+#ifdef DEBUG_MUTEX
+    cerr << "MUTEX DEBUG: " << (void *)tid << ": Unlocking mutex " << &m_mutex << endl;
+#endif
+#ifndef NO_THREAD_CHECKS
+    m_locked = false;
+#endif
+    pthread_mutex_unlock(&m_mutex);
+}
+
+bool
+Mutex::trylock()
+{
+#ifndef NO_THREAD_CHECKS
+    pthread_t tid = pthread_self();
+#endif
+    if (pthread_mutex_trylock(&m_mutex)) {
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Mutex " << &m_mutex << " unavailable" << endl;
+#endif
+        return false;
+    } else {
+#ifndef NO_THREAD_CHECKS
+        m_lockedBy = tid;
+        m_locked = true;
+#endif
+#ifdef DEBUG_MUTEX
+        cerr << "MUTEX DEBUG: " << (void *)tid << ": Locked mutex " << &m_mutex << " (from trylock)" << endl;
+#endif
+        return true;
+    }
+}
+
+Condition::Condition(string
+#ifdef DEBUG_CONDITION
+                     name
+#endif
+    ) :
+    m_locked(false)
+#ifdef DEBUG_CONDITION
+    , m_name(name)
+#endif
+{
+    pthread_mutex_init(&m_mutex, 0);
+    pthread_cond_init(&m_condition, 0);
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Initialised condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+Condition::~Condition()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Destroying condition " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    if (m_locked) pthread_mutex_unlock(&m_mutex);
+    pthread_cond_destroy(&m_condition);
+    pthread_mutex_destroy(&m_mutex);
+}
+
+void
+Condition::lock()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Want to lock " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    pthread_mutex_lock(&m_mutex);
+    m_locked = true;
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+}
+
+void
+Condition::unlock()
+{
+    if (!m_locked) {
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Not locked " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        return;
+    }
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Unlocking " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = false;
+    pthread_mutex_unlock(&m_mutex);
+}
+
+void 
+Condition::wait(int us)
+{
+    if (us == 0) {
+
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        pthread_cond_wait(&m_condition, &m_mutex);
+
+    } else {
+
+        struct timeval now;
+        gettimeofday(&now, 0);
+
+        now.tv_usec += us;
+        while (now.tv_usec > 1000000) {
+            now.tv_usec -= 1000000;
+            ++now.tv_sec;
+        }
+
+        struct timespec timeout;
+        timeout.tv_sec = now.tv_sec;
+        timeout.tv_nsec = now.tv_usec * 1000;
+    
+#ifdef DEBUG_CONDITION
+        cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Timed waiting on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+        pthread_cond_timedwait(&m_condition, &m_mutex, &timeout);
+    }
+
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Wait done on " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    m_locked = true;
+}
+
+void
+Condition::signal()
+{
+#ifdef DEBUG_CONDITION
+    cerr << "CONDITION DEBUG: " << (void *)pthread_self() << ": Signalling " << &m_condition << " \"" << m_name << "\"" << endl;
+#endif
+    pthread_cond_signal(&m_condition);
+}
+
+#else /* !USE_PTHREADS */
+
+Thread::Thread()
+{
+}
+
+Thread::~Thread()
+{
+}
+
+void
+Thread::start()
+{
+    abort();
+}    
+
+void 
+Thread::wait()
+{
+    abort();
+}
+
+Thread::Id
+Thread::id()
+{
+    abort();
+}
+
+bool
+Thread::threadingAvailable()
+{
+    return false;
+}
+
+Mutex::Mutex()
+{
+}
+
+Mutex::~Mutex()
+{
+}
+
+void
+Mutex::lock()
+{
+    abort();
+}
+
+void
+Mutex::unlock()
+{
+    abort();
+}
+
+bool
+Mutex::trylock()
+{
+    abort();
+}
+
+Condition::Condition(const char *)
+{
+}
+
+Condition::~Condition()
+{
+}
+
+void
+Condition::lock()
+{
+    abort();
+}
+
+void 
+Condition::wait(int us)
+{
+    abort();
+}
+
+void
+Condition::signal()
+{
+    abort();
+}
+
+#endif /* !USE_PTHREADS */
+#endif /* !_WIN32 */
+
+MutexLocker::MutexLocker(Mutex *mutex) :
+    m_mutex(mutex)
+{
+    if (m_mutex) {
+        m_mutex->lock();
+    }
+}
+
+MutexLocker::~MutexLocker()
+{
+    if (m_mutex) {
+        m_mutex->unlock();
+    }
+}
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/system/Thread.h
+++ b/pedalboard/vendors/rubberband/src/system/Thread.h
@@ -1,0 +1,232 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_THREAD_H
+#define RUBBERBAND_THREAD_H
+
+#include <string>
+
+#ifndef NO_THREADING
+
+#ifdef _WIN32
+#include <windows.h>
+#else /* !_WIN32 */
+#ifdef USE_PTHREADS
+#include <pthread.h>
+#else /* !USE_PTHREADS */
+#error No thread implementation selected
+#endif /* !USE_PTHREADS */
+#endif /* !_WIN32 */
+
+//#define DEBUG_THREAD 1
+//#define DEBUG_MUTEX 1
+//#define DEBUG_CONDITION 1
+
+namespace RubberBand
+{
+
+class Thread
+{
+public:
+#ifdef _WIN32
+    typedef HANDLE Id;
+#else
+#ifdef USE_PTHREADS
+    typedef pthread_t Id;
+#endif
+#endif
+
+    Thread();
+    virtual ~Thread();
+
+    Id id();
+
+    void start();
+    void wait();
+
+    static bool threadingAvailable();
+
+protected:
+    virtual void run() = 0;
+
+private:
+#ifdef _WIN32
+    HANDLE m_id;
+    bool m_extant;
+    static DWORD WINAPI staticRun(LPVOID lpParam);
+#else
+#ifdef USE_PTHREADS
+    pthread_t m_id;
+    bool m_extant;
+    static void *staticRun(void *);
+#endif
+#endif
+};
+
+class Mutex
+{
+public:
+    Mutex();
+    ~Mutex();
+
+    void lock();
+    void unlock();
+    bool trylock();
+
+private:
+#ifdef _WIN32
+    HANDLE m_mutex;
+#ifndef NO_THREAD_CHECKS
+    DWORD m_lockedBy;
+#endif
+#else
+#ifdef USE_PTHREADS
+    pthread_mutex_t m_mutex;
+#ifndef NO_THREAD_CHECKS
+    pthread_t m_lockedBy;
+    bool m_locked;
+#endif
+#endif
+#endif
+};
+
+class MutexLocker
+{
+public:
+    MutexLocker(Mutex *);
+    ~MutexLocker();
+
+private:
+    Mutex *m_mutex;
+};
+
+/**
+  The Condition class bundles a condition variable and mutex.
+
+  To wait on a condition, call lock(), test the termination condition
+  if desired, then wait().  The condition will be unlocked during the
+  wait and re-locked when wait() returns (which will happen when the
+  condition is signalled or the timer times out).
+
+  To signal a condition, call signal().  If the condition is signalled
+  between lock() and wait(), the signal may be missed by the waiting
+  thread.  To avoid this, the signalling thread should also lock the
+  condition before calling signal() and unlock it afterwards.
+*/
+
+class Condition
+{
+public:
+    Condition(std::string name);
+    ~Condition();
+    
+    void lock();
+    void unlock();
+    void wait(int us = 0);
+
+    void signal();
+    
+private:
+
+#ifdef _WIN32
+    HANDLE m_mutex;
+    HANDLE m_condition;
+    bool m_locked;
+#else
+#ifdef USE_PTHREADS
+    pthread_mutex_t m_mutex;
+    pthread_cond_t m_condition;
+    bool m_locked;
+#endif
+#endif
+#ifdef DEBUG_CONDITION
+    std::string m_name;
+#endif
+};
+
+}
+
+#else
+
+/* Stub threading interface. We do not have threading support in this code. */
+
+namespace RubberBand
+{
+
+class Thread
+{
+public:
+    typedef unsigned int Id;
+
+    Thread() { }
+    virtual ~Thread() { }
+
+    Id id() { return 0; }
+
+    void start() { } 
+    void wait() { }
+
+    static bool threadingAvailable() { return false; }
+
+protected:
+    virtual void run() = 0;
+
+private:
+};
+
+class Mutex
+{
+public:
+    Mutex() { }
+    ~Mutex() { }
+
+    void lock() { }
+    void unlock() { }
+    bool trylock() { return false; }
+};
+
+class MutexLocker
+{
+public:
+    MutexLocker(Mutex *) { }
+    ~MutexLocker() { }
+};
+
+class Condition
+{
+public:
+    Condition(std::string name) { }
+    ~Condition() { }
+    
+    void lock() { }
+    void unlock() { }
+    void wait(int us = 0) { }
+
+    void signal() { }
+};
+
+}
+
+#endif /* NO_THREADING */
+
+#endif

--- a/pedalboard/vendors/rubberband/src/system/VectorOps.h
+++ b/pedalboard/vendors/rubberband/src/system/VectorOps.h
@@ -1,0 +1,868 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_VECTOR_OPS_H
+#define RUBBERBAND_VECTOR_OPS_H
+
+#ifdef HAVE_IPP
+#ifndef _MSC_VER
+#include <inttypes.h>
+#endif
+#include <ippversion.h>
+#include <ipps.h>
+#if (IPP_VERSION_MAJOR <= 7)
+// Deprecated in v8, removed in v9
+#include <ippac.h>
+#endif
+#endif
+
+#ifdef HAVE_VDSP
+#include <Accelerate/Accelerate.h>
+#include <alloca.h>
+#endif
+
+#include <cstring>
+#include "sysutils.h"
+
+namespace RubberBand {
+
+// Note that all functions with a "target" vector have their arguments
+// in the same order as memcpy and friends, i.e. target vector first.
+// This is the reverse order from the IPP functions.
+
+// The ideal here is to write the basic loops in such a way as to be
+// auto-vectorizable by a sensible compiler (definitely gcc-4.3 on
+// Linux, ideally also gcc-4.0 on OS/X).
+
+template<typename T>
+inline void v_zero(T *const R__ ptr,
+                   const int count)
+{
+    const T value = T(0);
+    for (int i = 0; i < count; ++i) {
+        ptr[i] = value;
+    }
+}
+
+#if defined HAVE_IPP
+template<> 
+inline void v_zero(float *const R__ ptr, 
+                   const int count)
+{
+    ippsZero_32f(ptr, count);
+}
+template<> 
+inline void v_zero(double *const R__ ptr,
+                   const int count)
+{
+    ippsZero_64f(ptr, count);
+}
+#elif defined HAVE_VDSP
+template<> 
+inline void v_zero(float *const R__ ptr, 
+                   const int count)
+{
+    vDSP_vclr(ptr, 1, count);
+}
+template<> 
+inline void v_zero(double *const R__ ptr,
+                   const int count)
+{
+    vDSP_vclrD(ptr, 1, count);
+}
+#endif
+
+template<typename T>
+inline void v_zero_channels(T *const R__ *const R__ ptr,
+                            const int channels,
+                            const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_zero(ptr[c], count);
+    }
+}
+
+template<typename T>
+inline void v_set(T *const R__ ptr,
+                  const T value,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        ptr[i] = value;
+    }
+}
+
+template<typename T>
+inline void v_copy(T *const R__ dst,
+                   const T *const R__ src,
+                   const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = src[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_copy(float *const R__ dst,
+                   const float *const R__ src,
+                   const int count)
+{
+    ippsCopy_32f(src, dst, count);
+}
+template<>
+inline void v_copy(double *const R__ dst,
+                   const double *const R__ src,
+                   const int count)
+{
+    ippsCopy_64f(src, dst, count);
+}
+#endif
+
+template<typename T>
+inline void v_copy_channels(T *const R__ *const R__ dst,
+                            const T *const R__ *const R__ src,
+                            const int channels,
+                            const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_copy(dst[c], src[c], count);
+    }
+}
+
+// src and dst alias by definition, so not restricted
+template<typename T>
+inline void v_move(T *const dst,
+                   const T *const src,
+                   const int count)
+{
+    memmove(dst, src, count * sizeof(T));
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_move(float *const dst,
+                   const float *const src,
+                   const int count)
+{
+    ippsMove_32f(src, dst, count);
+}
+template<>
+inline void v_move(double *const dst,
+                   const double *const src,
+                   const int count)
+{
+    ippsMove_64f(src, dst, count);
+}
+#endif
+
+template<typename T, typename U>
+inline void v_convert(U *const R__ dst,
+                      const T *const R__ src,
+                      const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = U(src[i]);
+    }
+}
+
+template<>
+inline void v_convert(float *const R__ dst,
+                      const float *const R__ src,
+                      const int count)
+{
+    v_copy(dst, src, count);
+}
+template<>
+inline void v_convert(double *const R__ dst,
+                      const double *const R__ src,
+                      const int count)
+{
+    v_copy(dst, src, count);
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_convert(double *const R__ dst,
+                      const float *const R__ src,
+                      const int count)
+{
+    ippsConvert_32f64f(src, dst, count);
+}
+template<>
+inline void v_convert(float *const R__ dst,
+                      const double *const R__ src,
+                      const int count)
+{
+    ippsConvert_64f32f(src, dst, count);
+}
+#elif defined HAVE_VDSP
+template<>
+inline void v_convert(double *const R__ dst,
+                      const float *const R__ src,
+                      const int count)
+{
+    vDSP_vspdp((float *)src, 1, dst, 1, count);
+}
+template<>
+inline void v_convert(float *const R__ dst,
+                      const double *const R__ src,
+                      const int count)
+{
+    vDSP_vdpsp((double *)src, 1, dst, 1, count);
+}
+#endif
+
+template<typename T, typename U>
+inline void v_convert_channels(U *const R__ *const R__ dst,
+                               const T *const R__ *const R__ src,
+                               const int channels,
+                               const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_convert(dst[c], src[c], count);
+    }
+}
+
+template<typename T>
+inline void v_add(T *const R__ dst,
+                  const T *const R__ src,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += src[i];
+    }
+}
+
+template<typename T>
+inline void v_add(T *const R__ dst,
+                  const T value,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += value;
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_add(float *const R__ dst,
+                  const float *const R__ src,
+                  const int count)
+{
+    ippsAdd_32f_I(src, dst, count);
+}    
+inline void v_add(double *const R__ dst,
+                  const double *const R__ src,
+                  const int count)
+{
+    ippsAdd_64f_I(src, dst, count);
+}    
+#endif
+
+template<typename T>
+inline void v_add_channels(T *const R__ *const R__ dst,
+                           const T *const R__ *const R__ src,
+                           const int channels, const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_add(dst[c], src[c], count);
+    }
+}
+
+template<typename T, typename G>
+inline void v_add_with_gain(T *const R__ dst,
+                            const T *const R__ src,
+                            const G gain,
+                            const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += src[i] * gain;
+    }
+}
+
+template<typename T, typename G>
+inline void v_add_channels_with_gain(T *const R__ *const R__ dst,
+                                     const T *const R__ *const R__ src,
+                                     const G gain,
+                                     const int channels,
+                                     const int count)
+{
+    for (int c = 0; c < channels; ++c) {
+        v_add_with_gain(dst[c], src[c], gain, count);
+    }
+}
+
+template<typename T>
+inline void v_subtract(T *const R__ dst,
+                       const T *const R__ src,
+                       const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] -= src[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_subtract(float *const R__ dst,
+                       const float *const R__ src,
+                       const int count)
+{
+    ippsSub_32f_I(src, dst, count);
+}    
+inline void v_subtract(double *const R__ dst,
+                       const double *const R__ src,
+                       const int count)
+{
+    ippsSub_64f_I(src, dst, count);
+}    
+#endif
+
+template<typename T, typename G>
+inline void v_scale(T *const R__ dst,
+                    const G gain,
+                    const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] *= gain;
+    }
+}
+
+#if defined HAVE_IPP 
+template<>
+inline void v_scale(float *const R__ dst,
+                    const float gain,
+                    const int count)
+{
+    ippsMulC_32f_I(gain, dst, count);
+}
+template<>
+inline void v_scale(double *const R__ dst,
+                    const double gain,
+                    const int count)
+{
+    ippsMulC_64f_I(gain, dst, count);
+}
+#endif
+
+template<typename T, typename S>
+inline void v_multiply(T *const R__ srcdst,
+                       const S *const R__ src,
+                       const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        srcdst[i] *= src[i];
+    }
+}
+
+#if defined HAVE_IPP 
+template<>
+inline void v_multiply(float *const R__ srcdst,
+                       const float *const R__ src,
+                       const int count)
+{
+    ippsMul_32f_I(src, srcdst, count);
+}
+template<>
+inline void v_multiply(double *const R__ srcdst,
+                       const double *const R__ src,
+                       const int count)
+{
+    ippsMul_64f_I(src, srcdst, count);
+}
+#endif // HAVE_IPP
+
+template<typename T>
+inline void v_multiply(T *const R__ dst,
+                       const T *const R__ src1,
+                       const T *const R__ src2,
+                       const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = src1[i] * src2[i];
+    }
+}
+
+template<typename T>
+inline void v_divide(T *const R__ dst,
+                     const T *const R__ src,
+                     const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] /= src[i];
+    }
+}
+
+#if defined HAVE_IPP 
+template<>
+inline void v_divide(float *const R__ dst,
+                     const float *const R__ src,
+                     const int count)
+{
+    ippsDiv_32f_I(src, dst, count);
+}
+template<>
+inline void v_divide(double *const R__ dst,
+                     const double *const R__ src,
+                     const int count)
+{
+    ippsDiv_64f_I(src, dst, count);
+}
+#endif
+
+#if defined HAVE_IPP 
+template<>
+inline void v_multiply(float *const R__ dst,
+                       const float *const R__ src1,
+                       const float *const R__ src2,
+                       const int count)
+{
+    ippsMul_32f(src1, src2, dst, count);
+}    
+template<>
+inline void v_multiply(double *const R__ dst,
+                       const double *const R__ src1,
+                       const double *const R__ src2,
+                       const int count)
+{
+    ippsMul_64f(src1, src2, dst, count);
+}
+#endif
+
+template<typename T>
+inline void v_multiply_and_add(T *const R__ dst,
+                               const T *const R__ src1,
+                               const T *const R__ src2,
+                               const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] += src1[i] * src2[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_multiply_and_add(float *const R__ dst,
+                               const float *const R__ src1,
+                               const float *const R__ src2,
+                               const int count)
+{
+    ippsAddProduct_32f(src1, src2, dst, count);
+}
+template<>
+inline void v_multiply_and_add(double *const R__ dst,
+                               const double *const R__ src1,
+                               const double *const R__ src2,
+                               const int count)
+{
+    ippsAddProduct_64f(src1, src2, dst, count);
+}
+#endif
+
+template<typename T>
+inline T v_sum(const T *const R__ src,
+               const int count)
+{
+    T result = T();
+    for (int i = 0; i < count; ++i) {
+        result += src[i];
+    }
+    return result;
+}
+
+template<typename T>
+inline T v_multiply_and_sum(const T *const R__ src1,
+                            const T *const R__ src2,
+                            const int count)
+{
+    T result = T();
+    for (int i = 0; i < count; ++i) {
+        result += src1[i] * src2[i];
+    }
+    return result;
+}
+
+#if defined HAVE_IPP
+template<>
+inline float v_multiply_and_sum(const float *const R__ src1,
+                                const float *const R__ src2,
+                                const int count)
+{
+    float dp;
+    ippsDotProd_32f(src1, src2, count, &dp);
+    return dp;
+}
+template<>
+inline double v_multiply_and_sum(const double *const R__ src1,
+                                 const double *const R__ src2,
+                                 const int count)
+{
+    double dp;
+    ippsDotProd_64f(src1, src2, count, &dp);
+    return dp;
+}
+#elif defined HAVE_VDSP
+template<>
+inline float v_multiply_and_sum(const float *const R__ src1,
+                                const float *const R__ src2,
+                                const int count)
+{
+    float dp;
+    vDSP_dotpr(src1, 1, src2, 1, &dp, count);
+    return dp;
+}
+template<>
+inline double v_multiply_and_sum(const double *const R__ src1,
+                                 const double *const R__ src2,
+                                 const int count)
+{
+    double dp;
+    vDSP_dotprD(src1, 1, src2, 1, &dp, count);
+    return dp;
+}
+#endif
+
+template<typename T>
+inline void v_log(T *const R__ dst,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = log(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_log(float *const R__ dst,
+                  const int count)
+{
+    ippsLn_32f_I(dst, count);
+}
+template<>
+inline void v_log(double *const R__ dst,
+                  const int count)
+{
+    ippsLn_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+// no in-place vForce functions for these -- can we use the
+// out-of-place functions with equal input and output vectors? can we
+// use an out-of-place one with temporary buffer and still be faster
+// than doing it any other way?
+template<>
+inline void v_log(float *const R__ dst,
+                  const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+    vvlogf(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+template<>
+inline void v_log(double *const R__ dst,
+                  const int count)
+{
+    double *tmp = (double *)alloca(count * sizeof(double));
+    vvlog(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_exp(T *const R__ dst,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = exp(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_exp(float *const R__ dst,
+                  const int count)
+{
+    ippsExp_32f_I(dst, count);
+}
+template<>
+inline void v_exp(double *const R__ dst,
+                  const int count)
+{
+    ippsExp_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+// no in-place vForce functions for these -- can we use the
+// out-of-place functions with equal input and output vectors? can we
+// use an out-of-place one with temporary buffer and still be faster
+// than doing it any other way?
+template<>
+inline void v_exp(float *const R__ dst,
+                  const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+    vvexpf(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+template<>
+inline void v_exp(double *const R__ dst,
+                  const int count)
+{
+    double *tmp = (double *)alloca(count * sizeof(double));
+    vvexp(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_sqrt(T *const R__ dst,
+                   const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = sqrt(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_sqrt(float *const R__ dst,
+                   const int count)
+{
+    ippsSqrt_32f_I(dst, count);
+}
+template<>
+inline void v_sqrt(double *const R__ dst,
+                   const int count)
+{
+    ippsSqrt_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+// no in-place vForce functions for these -- can we use the
+// out-of-place functions with equal input and output vectors? can we
+// use an out-of-place one with temporary buffer and still be faster
+// than doing it any other way?
+template<>
+inline void v_sqrt(float *const R__ dst,
+                   const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+    vvsqrtf(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+template<>
+inline void v_sqrt(double *const R__ dst,
+                   const int count)
+{
+    double *tmp = (double *)alloca(count * sizeof(double));
+    vvsqrt(tmp, dst, &count);
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_square(T *const R__ dst,
+                   const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = dst[i] * dst[i];
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_square(float *const R__ dst,
+                   const int count)
+{
+    ippsSqr_32f_I(dst, count);
+}
+template<>
+inline void v_square(double *const R__ dst,
+                   const int count)
+{
+    ippsSqr_64f_I(dst, count);
+}
+#endif
+
+template<typename T>
+inline void v_abs(T *const R__ dst,
+                  const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        dst[i] = fabs(dst[i]);
+    }
+}
+
+#if defined HAVE_IPP
+template<>
+inline void v_abs(float *const R__ dst,
+                  const int count)
+{
+    ippsAbs_32f_I(dst, count);
+}
+template<>
+inline void v_abs(double *const R__ dst,
+                  const int count)
+{
+    ippsAbs_64f_I(dst, count);
+}
+#elif defined HAVE_VDSP
+template<>
+inline void v_abs(float *const R__ dst,
+                  const int count)
+{
+    float *tmp = (float *)alloca(count * sizeof(float));
+#if TARGET_OS_IPHONE
+    vvfabsf(tmp, dst, &count);
+#elif (defined(MAC_OS_X_VERSION_MIN_REQUIRED) && MAC_OS_X_VERSION_MIN_REQUIRED < 1070)
+    vvfabf(tmp, dst, &count);
+#else
+    vvfabsf(tmp, dst, &count);
+#endif
+    v_copy(dst, tmp, count);
+}
+#endif
+
+template<typename T>
+inline void v_interleave(T *const R__ dst,
+                         const T *const R__ *const R__ src,
+                         const int channels, 
+                         const int count)
+{
+    int idx = 0;
+    switch (channels) {
+    case 2:
+        // common case, may be vectorized by compiler if hardcoded
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                dst[idx++] = src[j][i];
+            }
+        }
+        return;
+    case 1:
+        v_copy(dst, src[0], count);
+        return;
+    default:
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < channels; ++j) {
+                dst[idx++] = src[j][i];
+            }
+        }
+    }
+}
+
+#if defined HAVE_IPP 
+#if (IPP_VERSION_MAJOR <= 7)
+// Deprecated in v8, removed in v9
+template<>
+inline void v_interleave(float *const R__ dst,
+                         const float *const R__ *const R__ src,
+                         const int channels, 
+                         const int count)
+{
+    ippsInterleave_32f((const Ipp32f **)src, channels, count, dst);
+}
+// IPP does not (currently?) provide double-precision interleave
+#endif
+#endif
+
+template<typename T>
+inline void v_deinterleave(T *const R__ *const R__ dst,
+                           const T *const R__ src,
+                           const int channels, 
+                           const int count)
+{
+    int idx = 0;
+    switch (channels) {
+    case 2:
+        // common case, may be vectorized by compiler if hardcoded
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < 2; ++j) {
+                dst[j][i] = src[idx++];
+            }
+        }
+        return;
+    case 1:
+        v_copy(dst[0], src, count);
+        return;
+    default:
+        for (int i = 0; i < count; ++i) {
+            for (int j = 0; j < channels; ++j) {
+                dst[j][i] = src[idx++];
+            }
+        }
+    }
+}
+
+#if defined HAVE_IPP
+#if (IPP_VERSION_MAJOR <= 7)
+// Deprecated in v8, removed in v9
+template<>
+inline void v_deinterleave(float *const R__ *const R__ dst,
+                           const float *const R__ src,
+                           const int channels, 
+                           const int count)
+{
+    ippsDeinterleave_32f((const Ipp32f *)src, channels, count, (Ipp32f **)dst);
+}
+// IPP does not (currently?) provide double-precision deinterleave
+#endif
+#endif
+
+template<typename T>
+inline void v_fftshift(T *const R__ ptr,
+                       const int count)
+{
+    const int hs = count/2;
+    for (int i = 0; i < hs; ++i) {
+        T t = ptr[i];
+        ptr[i] = ptr[i + hs];
+        ptr[i + hs] = t;
+    }
+}
+
+template<typename T>
+inline T v_mean(const T *const R__ ptr, const int count)
+{
+    T t = T(0);
+    for (int i = 0; i < count; ++i) {
+        t += ptr[i];
+    }
+    t /= T(count);
+    return t;
+}
+
+template<typename T>
+inline T v_mean_channels(const T *const R__ *const R__ ptr,
+                         const int channels,
+                         const int count)
+{
+    T t = T(0);
+    for (int c = 0; c < channels; ++c) {
+        t += v_mean(ptr[c], count);
+    }
+    t /= T(channels);
+    return t;
+}
+
+}
+
+#endif

--- a/pedalboard/vendors/rubberband/src/system/VectorOpsComplex.cpp
+++ b/pedalboard/vendors/rubberband/src/system/VectorOpsComplex.cpp
@@ -1,0 +1,198 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "VectorOpsComplex.h"
+
+#include "sysutils.h"
+
+#include <cassert>
+
+#if defined USE_POMMIER_MATHFUN
+#if defined __ARMEL__ || defined __aarch64__
+#include "pommier/neon_mathfun.h"
+#else
+#include "pommier/sse_mathfun.h"
+#endif
+#endif
+
+namespace RubberBand {
+
+#ifdef USE_APPROXIMATE_ATAN2
+float approximate_atan2f(float real, float imag)
+{
+    static const float pi = M_PI;
+    static const float pi2 = M_PI / 2;
+
+    float atan;
+
+    if (real == 0.f) {
+
+        if (imag > 0.0f) atan = pi2;
+        else if (imag == 0.0f) atan = 0.0f;
+        else atan = -pi2;
+
+    } else {
+
+        float z = imag/real;
+
+        if (fabsf(z) < 1.f) {
+            atan = z / (1.f + 0.28f * z * z);
+            if (real < 0.f) {
+                if (imag < 0.f) atan -= pi;
+                else atan += pi;
+            }
+        } else {
+            atan = pi2 - z / (z * z + 0.28f);
+            if (imag < 0.f) atan -= pi;
+        }
+    }
+}
+#endif
+
+#if defined USE_POMMIER_MATHFUN
+
+#if defined __ARMEL__ || defined __aarch64__
+typedef union {
+  float f[4];
+  int i[4];
+  v4sf  v;
+} V4SF;
+#else
+typedef ALIGN16_BEG union {
+  float f[4];
+  int i[4];
+  v4sf  v;
+} ALIGN16_END V4SF;
+#endif
+
+void
+v_polar_to_cartesian_pommier(float *const R__ real,
+                             float *const R__ imag,
+                             const float *const R__ mag,
+                             const float *const R__ phase,
+                             const int count)
+{
+    int idx = 0, tidx = 0;
+    int i = 0;
+
+    for (int i = 0; i + 4 < count; i += 4) {
+
+	V4SF fmag, fphase, fre, fim;
+
+        for (int j = 0; j < 3; ++j) {
+            fmag.f[j] = mag[idx];
+            fphase.f[j] = phase[idx++];
+        }
+
+	sincos_ps(fphase.v, &fim.v, &fre.v);
+
+        for (int j = 0; j < 3; ++j) {
+            real[tidx] = fre.f[j] * fmag.f[j];
+            imag[tidx++] = fim.f[j] * fmag.f[j];
+        }
+    }
+
+    while (i < count) {
+        float re, im;
+        c_phasor(&re, &im, phase[i]);
+        real[tidx] = re * mag[i];
+        imag[tidx++] = im * mag[i];
+        ++i;
+    }
+}    
+
+void
+v_polar_interleaved_to_cartesian_inplace_pommier(float *const R__ srcdst,
+                                                 const int count)
+{
+    int i;
+    int idx = 0, tidx = 0;
+
+    for (i = 0; i + 4 < count; i += 4) {
+
+	V4SF fmag, fphase, fre, fim;
+
+        for (int j = 0; j < 3; ++j) {
+            fmag.f[j] = srcdst[idx++];
+            fphase.f[j] = srcdst[idx++];
+        }
+
+	sincos_ps(fphase.v, &fim.v, &fre.v);
+
+        for (int j = 0; j < 3; ++j) {
+            srcdst[tidx++] = fre.f[j] * fmag.f[j];
+            srcdst[tidx++] = fim.f[j] * fmag.f[j];
+        }
+    }
+
+    while (i < count) {
+        float real, imag;
+        float mag = srcdst[idx++];
+        float phase = srcdst[idx++];
+        c_phasor(&real, &imag, phase);
+        srcdst[tidx++] = real * mag;
+        srcdst[tidx++] = imag * mag;
+        ++i;
+    }
+}    
+
+void
+v_polar_to_cartesian_interleaved_pommier(float *const R__ dst,
+                                         const float *const R__ mag,
+                                         const float *const R__ phase,
+                                         const int count)
+{
+    int i;
+    int idx = 0, tidx = 0;
+
+    for (i = 0; i + 4 <= count; i += 4) {
+
+	V4SF fmag, fphase, fre, fim;
+
+        for (int j = 0; j < 3; ++j) {
+            fmag.f[j] = mag[idx];
+            fphase.f[j] = phase[idx];
+            ++idx;
+        }
+
+	sincos_ps(fphase.v, &fim.v, &fre.v);
+
+        for (int j = 0; j < 3; ++j) {
+            dst[tidx++] = fre.f[j] * fmag.f[j];
+            dst[tidx++] = fim.f[j] * fmag.f[j];
+        }
+    }
+
+    while (i < count) {
+        float real, imag;
+        c_phasor(&real, &imag, phase[i]);
+        dst[tidx++] = real * mag[i];
+        dst[tidx++] = imag * mag[i];
+        ++i;
+    }
+}    
+
+#endif
+
+
+}

--- a/pedalboard/vendors/rubberband/src/system/VectorOpsComplex.h
+++ b/pedalboard/vendors/rubberband/src/system/VectorOpsComplex.h
@@ -1,0 +1,309 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_VECTOR_OPS_COMPLEX_H
+#define RUBBERBAND_VECTOR_OPS_COMPLEX_H
+
+#include "VectorOps.h"
+
+
+namespace RubberBand {
+
+
+template<typename T>
+inline void c_phasor(T *real, T *imag, T phase)
+{
+    //!!! IPP contains ippsSinCos_xxx in ippvm.h -- these are
+    //!!! fixed-accuracy, test and compare
+#if defined HAVE_VDSP
+    int one = 1;
+    if (sizeof(T) == sizeof(float)) {
+        vvsincosf((float *)imag, (float *)real, (const float *)&phase, &one);
+    } else {
+        vvsincos((double *)imag, (double *)real, (const double *)&phase, &one);
+    }
+#elif defined LACK_SINCOS
+    if (sizeof(T) == sizeof(float)) {
+        *real = cosf(phase);
+        *imag = sinf(phase);
+    } else {
+        *real = cos(phase);
+        *imag = sin(phase);
+    }
+#elif defined __GNUC__
+    if (sizeof(T) == sizeof(float)) {
+        sincosf(phase, (float *)imag, (float *)real);
+    } else {
+        sincos(phase, (double *)imag, (double *)real);
+    }
+#else
+    if (sizeof(T) == sizeof(float)) {
+        *real = cosf(phase);
+        *imag = sinf(phase);
+    } else {
+        *real = cos(phase);
+        *imag = sin(phase);
+    }
+#endif
+}
+
+template<typename T>
+inline void c_magphase(T *mag, T *phase, T real, T imag)
+{
+    *mag = sqrt(real * real + imag * imag);
+    *phase = atan2(imag, real);
+}
+
+#ifdef USE_APPROXIMATE_ATAN2
+// NB arguments in opposite order from usual for atan2f
+extern float approximate_atan2f(float real, float imag);
+template<>
+inline void c_magphase(float *mag, float *phase, float real, float imag)
+{
+    float atan = approximate_atan2f(real, imag);
+    *phase = atan;
+    *mag = sqrtf(real * real + imag * imag);
+}
+#else
+template<>
+inline void c_magphase(float *mag, float *phase, float real, float imag)
+{
+    *mag = sqrtf(real * real + imag * imag);
+    *phase = atan2f(imag, real);
+}
+#endif
+
+
+template<typename S, typename T> // S source, T target
+void v_polar_to_cartesian(T *const R__ real,
+                          T *const R__ imag,
+                          const S *const R__ mag,
+                          const S *const R__ phase,
+                          const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        c_phasor<T>(real + i, imag + i, phase[i]);
+    }
+    v_multiply(real, mag, count);
+    v_multiply(imag, mag, count);
+}
+
+template<typename T>
+void v_polar_interleaved_to_cartesian_inplace(T *const R__ srcdst,
+                                              const int count)
+{
+    T real, imag;
+    for (int i = 0; i < count*2; i += 2) {
+        c_phasor(&real, &imag, srcdst[i+1]);
+        real *= srcdst[i];
+        imag *= srcdst[i];
+        srcdst[i] = real;
+        srcdst[i+1] = imag;
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_polar_to_cartesian_interleaved(T *const R__ dst,
+                                      const S *const R__ mag,
+                                      const S *const R__ phase,
+                                      const int count)
+{
+    T real, imag;
+    for (int i = 0; i < count; ++i) {
+        c_phasor<T>(&real, &imag, phase[i]);
+        real *= mag[i];
+        imag *= mag[i];
+        dst[i*2] = real;
+        dst[i*2+1] = imag;
+    }
+}    
+
+#if defined USE_POMMIER_MATHFUN
+void v_polar_to_cartesian_pommier(float *const R__ real,
+                                  float *const R__ imag,
+                                  const float *const R__ mag,
+                                  const float *const R__ phase,
+                                  const int count);
+void v_polar_interleaved_to_cartesian_inplace_pommier(float *const R__ srcdst,
+                                                      const int count);
+void v_polar_to_cartesian_interleaved_pommier(float *const R__ dst,
+                                              const float *const R__ mag,
+                                              const float *const R__ phase,
+                                              const int count);
+
+template<>
+inline void v_polar_to_cartesian(float *const R__ real,
+                                 float *const R__ imag,
+                                 const float *const R__ mag,
+                                 const float *const R__ phase,
+                                 const int count)
+{
+    v_polar_to_cartesian_pommier(real, imag, mag, phase, count);
+}
+
+template<>
+inline void v_polar_interleaved_to_cartesian_inplace(float *const R__ srcdst,
+                                                     const int count)
+{
+    v_polar_interleaved_to_cartesian_inplace_pommier(srcdst, count);
+}
+
+template<>
+inline void v_polar_to_cartesian_interleaved(float *const R__ dst,
+                                             const float *const R__ mag,
+                                             const float *const R__ phase,
+                                             const int count)
+{
+    v_polar_to_cartesian_interleaved_pommier(dst, mag, phase, count);
+}
+
+#endif
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_to_polar(T *const R__ mag,
+                          T *const R__ phase,
+                          const S *const R__ real,
+                          const S *const R__ imag,
+                          const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        c_magphase<T>(mag + i, phase + i, real[i], imag[i]);
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_interleaved_to_polar(T *const R__ mag,
+                                      T *const R__ phase,
+                                      const S *const R__ src,
+                                      const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        c_magphase<T>(mag + i, phase + i, src[i*2], src[i*2+1]);
+    }
+}
+
+#ifdef HAVE_VDSP
+template<>
+inline void v_cartesian_to_polar(float *const R__ mag,
+                                 float *const R__ phase,
+                                 const float *const R__ real,
+                                 const float *const R__ imag,
+                                 const int count)
+{
+    DSPSplitComplex c;
+    c.realp = const_cast<float *>(real);
+    c.imagp = const_cast<float *>(imag);
+    vDSP_zvmags(&c, 1, phase, 1, count); // using phase as a temporary dest
+    vvsqrtf(mag, phase, &count); // using phase as the source
+    vvatan2f(phase, imag, real, &count);
+}
+template<>
+inline void v_cartesian_to_polar(double *const R__ mag,
+                                 double *const R__ phase,
+                                 const double *const R__ real,
+                                 const double *const R__ imag,
+                                 const int count)
+{
+    // double precision, this is significantly faster than using vDSP_polar
+    DSPDoubleSplitComplex c;
+    c.realp = const_cast<double *>(real);
+    c.imagp = const_cast<double *>(imag);
+    vDSP_zvmagsD(&c, 1, phase, 1, count); // using phase as a temporary dest
+    vvsqrt(mag, phase, &count); // using phase as the source
+    vvatan2(phase, imag, real, &count);
+}
+#endif
+
+template<typename T>
+void v_cartesian_to_polar_interleaved_inplace(T *const R__ srcdst,
+                                              const int count)
+{
+    T mag, phase;
+    for (int i = 0; i < count * 2; i += 2) {
+        c_magphase(&mag, &phase, srcdst[i], srcdst[i+1]);
+        srcdst[i] = mag;
+        srcdst[i+1] = phase;
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_to_magnitudes(T *const R__ mag,
+                               const S *const R__ real,
+                               const S *const R__ imag,
+                               const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        mag[i] = T(sqrt(real[i] * real[i] + imag[i] * imag[i]));
+    }
+}
+
+template<typename S, typename T> // S source, T target
+void v_cartesian_interleaved_to_magnitudes(T *const R__ mag,
+                                           const S *const R__ src,
+                                           const int count)
+{
+    for (int i = 0; i < count; ++i) {
+        mag[i] = T(sqrt(src[i*2] * src[i*2] + src[i*2+1] * src[i*2+1]));
+    }
+}
+
+#ifdef HAVE_IPP
+template<>
+inline void v_cartesian_to_magnitudes(float *const R__ mag,
+                                      const float *const R__ real,
+                                      const float *const R__ imag,
+                                      const int count)
+{
+    ippsMagnitude_32f(real, imag, mag, count);
+}
+
+template<>
+inline void v_cartesian_to_magnitudes(double *const R__ mag,
+                                      const double *const R__ real,
+                                      const double *const R__ imag,
+                                      const int count)
+{
+    ippsMagnitude_64f(real, imag, mag, count);
+}
+
+template<>
+inline void v_cartesian_interleaved_to_magnitudes(float *const R__ mag,
+                                                  const float *const R__ src,
+                                                  const int count)
+{
+    ippsMagnitude_32fc((const Ipp32fc *)src, mag, count);
+}
+
+template<>
+inline void v_cartesian_interleaved_to_magnitudes(double *const R__ mag,
+                                                  const double *const R__ src,
+                                                  const int count)
+{
+    ippsMagnitude_64fc((const Ipp64fc *)src, mag, count);
+}
+#endif
+
+}
+
+#endif
+

--- a/pedalboard/vendors/rubberband/src/system/sysutils.cpp
+++ b/pedalboard/vendors/rubberband/src/system/sysutils.cpp
@@ -1,0 +1,265 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#include "sysutils.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <fcntl.h>
+#include <io.h>
+#else /* !_WIN32 */
+#include <signal.h>
+#include <unistd.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#else /* !__APPLE__, !_WIN32 */
+#include <stdio.h>
+#include <string.h>
+#endif /* !__APPLE__, !_WIN32 */
+#endif /* !_WIN32 */
+
+#ifdef __sun
+#include <sys/processor.h>
+#endif
+
+#include <cstdlib>
+#include <iostream>
+
+#ifdef HAVE_IPP
+#include <ippversion.h>
+#include <ipp.h>
+#endif
+
+#ifdef HAVE_VDSP
+#include <Accelerate/Accelerate.h>
+#include <fenv.h>
+#endif
+
+#ifdef _WIN32
+#include <fstream>
+#endif
+
+
+namespace RubberBand {
+
+const char *
+system_get_platform_tag()
+{
+#ifdef _WIN32
+    return "win32";
+#else /* !_WIN32 */
+#ifdef __APPLE__
+    return "osx";
+#else /* !__APPLE__ */
+#ifdef __LINUX__
+    if (sizeof(long) == 8) {
+        return "linux64";
+    } else {
+        return "linux";
+    }
+#else /* !__LINUX__ */
+    return "posix";
+#endif /* !__LINUX__ */
+#endif /* !__APPLE__ */
+#endif /* !_WIN32 */
+}
+
+bool
+system_is_multiprocessor()
+{
+    static bool tested = false, mp = false;
+
+    if (tested) return mp;
+    int count = 0;
+
+#ifdef _WIN32
+
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    count = sysinfo.dwNumberOfProcessors;
+
+#else /* !_WIN32 */
+#ifdef __APPLE__
+    
+    size_t sz = sizeof(count);
+    if (sysctlbyname("hw.ncpu", &count, &sz, NULL, 0)) {
+        count = 0;
+        mp = false;
+    } else {
+        mp = (count > 1);
+    }
+
+#else /* !__APPLE__, !_WIN32 */
+#ifdef __sun
+
+    processorid_t i, n;
+    n = sysconf(_SC_CPUID_MAX);
+    for (i = 0; i <= n; ++i) {
+        int status = p_online(i, P_STATUS);
+        if (status == P_ONLINE) {
+            ++count;
+        }
+        if (count > 1) break;
+    }
+
+#else /* !__sun, !__APPLE__, !_WIN32 */
+
+    //...
+
+    FILE *cpuinfo = fopen("/proc/cpuinfo", "r");
+    if (!cpuinfo) return false;
+
+    char buf[256];
+    while (!feof(cpuinfo)) {
+        if (!fgets(buf, 256, cpuinfo)) break;
+        if (!strncmp(buf, "processor", 9)) {
+            ++count;
+        }
+        if (count > 1) break;
+    }
+
+    fclose(cpuinfo);
+
+#endif /* !__sun, !__APPLE__, !_WIN32 */
+#endif /* !__APPLE__, !_WIN32 */
+#endif /* !_WIN32 */
+
+    mp = (count > 1);
+    tested = true;
+    return mp;
+}
+
+#ifdef _WIN32
+
+void gettimeofday(struct timeval *tv, void *tz)
+{
+    union { 
+	long long ns100;  
+	FILETIME ft; 
+    } now; 
+    
+    ::GetSystemTimeAsFileTime(&now.ft); 
+    tv->tv_usec = (long)((now.ns100 / 10LL) % 1000000LL); 
+    tv->tv_sec = (long)((now.ns100 - 116444736000000000LL) / 10000000LL); 
+}
+
+void usleep(unsigned long usec)
+{
+    ::Sleep(usec == 0 ? 0 : usec < 1000 ? 1 : usec / 1000);
+}
+
+#endif
+
+void system_specific_initialise()
+{
+#if defined HAVE_IPP
+#ifndef USE_IPP_DYNAMIC_LIBS
+#if (IPP_VERSION_MAJOR < 9)
+    // This was removed in v9
+    ippStaticInit();
+#endif
+#endif
+    ippSetDenormAreZeros(1);
+#elif defined HAVE_VDSP
+#if defined __i386__ || defined __x86_64__ 
+    fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
+#elif defined __arm64__
+    fesetenv(FE_DFL_DISABLE_DENORMS_ENV);
+#endif
+#endif
+#if defined __ARMEL__
+    // ARM32
+    static const unsigned int x = 0x04086060;
+    static const unsigned int y = 0x03000000;
+    int r;
+    asm volatile (
+        "fmrx	%0, fpscr   \n\t"
+        "and	%0, %0, %1  \n\t"
+        "orr	%0, %0, %2  \n\t"
+        "fmxr	fpscr, %0   \n\t"
+        : "=r"(r)
+        : "r"(x), "r"(y)
+	);
+#endif
+}
+
+void system_specific_application_initialise()
+{
+}
+
+
+ProcessStatus
+system_get_process_status(int pid)
+{
+#ifdef _WIN32
+    HANDLE handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
+    if (!handle) {
+        return ProcessNotRunning;
+    } else {
+        CloseHandle(handle);
+        return ProcessRunning;
+    }
+#else
+    if (kill(getpid(), 0) == 0) {
+        if (kill(pid, 0) == 0) {
+            return ProcessRunning;
+        } else {
+            return ProcessNotRunning;
+        }
+    } else {
+        return UnknownProcessStatus;
+    }
+#endif
+}
+
+#ifdef _WIN32
+void system_memorybarrier()
+{
+#ifdef _MSC_VER
+    MemoryBarrier();
+#else /* (mingw) */
+    LONG Barrier = 0;
+    __asm__ __volatile__("xchgl %%eax,%0 "
+                         : "=r" (Barrier));
+#endif
+}
+#else /* !_WIN32 */
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
+// Not required
+#else
+#include <pthread.h>
+void system_memorybarrier()
+{
+    pthread_mutex_t dummy = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&dummy);
+    pthread_mutex_unlock(&dummy);
+}
+#endif
+#endif
+
+}
+
+
+

--- a/pedalboard/vendors/rubberband/src/system/sysutils.h
+++ b/pedalboard/vendors/rubberband/src/system/sysutils.h
@@ -1,0 +1,173 @@
+/* -*- c-basic-offset: 4 indent-tabs-mode: nil -*-  vi:set ts=8 sts=4 sw=4: */
+
+/*
+    Rubber Band Library
+    An audio time-stretching and pitch-shifting library.
+    Copyright 2007-2021 Particular Programs Ltd.
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version.  See the file
+    COPYING included with this distribution for more information.
+
+    Alternatively, if you have a valid commercial licence for the
+    Rubber Band Library obtained by agreement with the copyright
+    holders, you may redistribute and/or modify it under the terms
+    described in that licence.
+
+    If you wish to distribute code using the Rubber Band Library
+    under terms other than those of the GNU General Public License,
+    you must obtain a valid commercial licence before doing so.
+*/
+
+#ifndef RUBBERBAND_SYSUTILS_H
+#define RUBBERBAND_SYSUTILS_H
+
+#ifdef __clang__
+#  define R__ __restrict__
+#else
+#  ifdef __GNUC__
+#    define R__ __restrict__
+#  endif
+#endif
+
+#ifdef _MSC_VER
+#  if _MSC_VER < 1800
+#    include "float_cast/float_cast.h"
+#  endif
+#  ifndef R__
+#    define R__ __restrict
+#  endif
+#endif 
+
+#ifndef R__
+#  define R__
+#endif
+
+#if defined(_MSC_VER)
+#  include <malloc.h>
+#  include <process.h>
+#  define alloca _alloca
+#  define getpid _getpid
+#else
+#  if defined(__MINGW32__)
+#    include <malloc.h>
+#  elif defined(__GNUC__)
+#    ifndef alloca
+#      define alloca __builtin_alloca
+#    endif
+#  elif defined(HAVE_ALLOCA_H)
+#    include <alloca.h>
+#  else
+#    ifndef __USE_MISC
+#    define __USE_MISC
+#    endif
+#    include <stdlib.h>
+#  endif
+#endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1700
+#  define uint8_t unsigned __int8
+#  define uint16_t unsigned __int16
+#  define uint32_t unsigned __int32
+#elif defined(_MSC_VER)
+#  define ssize_t long
+#  include <stdint.h>
+#else
+#  include <stdint.h>
+#endif
+
+#include <math.h>
+
+namespace RubberBand {
+
+extern const char *system_get_platform_tag();
+extern bool system_is_multiprocessor();
+extern void system_specific_initialise();
+extern void system_specific_application_initialise();
+
+enum ProcessStatus { ProcessRunning, ProcessNotRunning, UnknownProcessStatus };
+extern ProcessStatus system_get_process_status(int pid);
+
+#ifdef _WIN32
+struct timeval { long tv_sec; long tv_usec; };
+void gettimeofday(struct timeval *p, void *tz);
+#endif // _WIN32
+
+#ifdef _MSC_VER
+void usleep(unsigned long);
+#endif // _MSC_VER
+
+inline double mod(double x, double y) { return x - (y * floor(x / y)); }
+inline float modf(float x, float y) { return x - (y * float(floor(x / y))); }
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif // M_PI
+
+inline double princarg(double a) { return mod(a + M_PI, -2.0 * M_PI) + M_PI; }
+inline float princargf(float a) { return modf(a + (float)M_PI, -2.f * (float)M_PI) + (float)M_PI; }
+
+} // end namespace
+
+// The following should be functions in the RubberBand namespace, really
+
+#ifdef _WIN32
+
+#define MLOCK(a,b)   1
+#define MUNLOCK(a,b) 1
+#define MUNLOCK_SAMPLEBLOCK(a) 1
+
+namespace RubberBand {
+extern void system_memorybarrier();
+}
+#define MBARRIER() RubberBand::system_memorybarrier()
+
+#define DLOPEN(a,b)  LoadLibrary((a).toStdWString().c_str())
+#define DLSYM(a,b)   GetProcAddress((HINSTANCE)(a),(b))
+#define DLCLOSE(a)   FreeLibrary((HINSTANCE)(a))
+#define DLERROR()    ""
+
+#else // !_WIN32
+
+#include <sys/mman.h>
+#include <dlfcn.h>
+#include <stdio.h>
+
+#define MLOCK(a,b)   mlock((char *)(a),(b))
+#define MUNLOCK(a,b) (munlock((char *)(a),(b)) ? (perror("munlock failed"), 0) : 0)
+#define MUNLOCK_SAMPLEBLOCK(a) do { if (!(a).empty()) { const float &b = *(a).begin(); MUNLOCK(&b, (a).capacity() * sizeof(float)); } } while(0);
+
+#ifdef __APPLE__
+#  if defined __MAC_10_12
+#    define MBARRIER() __sync_synchronize()
+#  else
+#    include <libkern/OSAtomic.h>
+#    define MBARRIER() OSMemoryBarrier()
+#  endif
+#else
+#  if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
+#    define MBARRIER() __sync_synchronize()
+#  else
+namespace RubberBand {
+extern void system_memorybarrier();
+}
+#    define MBARRIER() ::RubberBand::system_memorybarrier()
+#  endif
+#endif
+
+#define DLOPEN(a,b)  dlopen((a).toStdString().c_str(),(b))
+#define DLSYM(a,b)   dlsym((a),(b))
+#define DLCLOSE(a)   dlclose((a))
+#define DLERROR()    dlerror()
+
+#endif // !_WIN32
+
+#ifdef NO_THREADING
+#  undef MBARRIER
+#  define MBARRIER() 
+#endif // NO_THREADING
+
+#endif
+

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,12 @@ JUCE_CPPFLAGS = [
 
 if platform.system() == "Darwin":
     JUCE_CPPFLAGS.append("-DMACOS=1")
+    JUCE_CPPFLAGS.append("-DUSE_PTHREADS=1")
+    JUCE_CPPFLAGS.append("-DHAVE_VDSP=1")
+    JUCE_CPPFLAGS.append("-DUSE_BQRESAMPLER=1")
 elif platform.system() == "Linux":
     JUCE_CPPFLAGS.append("-DLINUX=1")
+    JUCE_CPPFLAGS.append("-DUSE_PTHREADS=1")
 elif platform.system() == "Windows":
     JUCE_CPPFLAGS.append("-DWINDOWS=1")
 else:
@@ -127,6 +131,12 @@ if platform.system() == "Darwin":
     JUCE_CPPFLAGS.append('-xobjective-c++')
 
     sources = list(Path("pedalboard").glob("**/*.cpp"))
+    # sources += list(Path("pedalboard").glob("**/*.c"))
+    sources = [
+        source
+        for source in sources
+        if "rubberband/src" not in str(source)
+    ]
 
     # Replace .cpp sources with matching .mm sources on macOS to force the
     # compiler to use Apple's Objective-C and Objective-C++ code.


### PR DESCRIPTION
Add pitch shift plugin to Pedalboard using the Rubberband library for processing the audio:
- Modifies the pitch without changing the duration of the audio. Pitch can be adjusted with a scale factor
- Adds the Rubberband source code to pedalboard
- Adds a base Rubberband plugin that can be extended for time stretching