### PR TITLE
Fixes to allow for click-free processing.

### DIFF
--- a/pedalboard/plugins/PitchShift.h
+++ b/pedalboard/plugins/PitchShift.h
@@ -63,9 +63,7 @@ namespace Pedalboard
                 // No need to explicitly call reset if constructing new object
 
                 // Is this appropriate to create a new object every time the spec changes?
-
-                // TODO: Need to add streaming mode!
-                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels);
+                auto rb = new RubberBandStretcher(spec.sampleRate, spec.numChannels, RubberBandStretcher::OptionProcessRealTime | RubberBandStretcher::OptionThreadingNever);
                 rb->setMaxProcessSize(spec.maximumBlockSize);
                 rb->setPitchScale(_pitchScale);
                 // what about deallocating?


### PR DESCRIPTION
Added some commented code here to fix some of the clicks we were hearing; it seems that one of three issues was causing the problem (or perhaps all three):
 - Rubberband was running in offline mode, which meant it was outputting a different number of samples each time `retrieve` was called
 - Rubberband had threading enabled (as is the default) which meant that we had a race condition between the call to `process` and the call to `available`/`retrieve`
 - `retrieve` was being called in a loop without updating the pointers being passed in, which meant that any new data being supplied by Rubberband would overwrite the existing data fetched in the previous iteration of the loop